### PR TITLE
Added implementation of IDisposable to classes that contains IDisposable members

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     using Microsoft.ServiceFabric.Actors.Query;
     using Microsoft.ServiceFabric.Services.Common;
 
-    internal sealed class MockActorManager : IActorManager
+    internal sealed class MockActorManager : IActorManager, IDisposable
     {
         private readonly ActorService actorService;
         private readonly ConcurrentDictionary<ActorId, ConcurrentDictionary<string, ActorReminder>> remindersByActorId;
@@ -261,6 +261,15 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         }
 
         #endregion
+
+        #endregion
+
+        #region IDisposable Implementation
+
+        public void Dispose()
+        {
+            diagnosticsManager?.Dispose();
+        }
 
         #endregion
     }

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     using Microsoft.ServiceFabric.Actors.Query;
     using Microsoft.ServiceFabric.Services.Common;
 
-    internal sealed class MockActorManager : IActorManager, IDisposable
+    internal sealed class MockActorManager : IActorManager
     {
         private readonly ActorService actorService;
         private readonly ConcurrentDictionary<ActorId, ConcurrentDictionary<string, ActorReminder>> remindersByActorId;
@@ -261,15 +261,6 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         }
 
         #endregion
-
-        #endregion
-
-        #region IDisposable Implementation
-
-        public void Dispose()
-        {
-            diagnosticsManager?.Dispose();
-        }
 
         #endregion
     }

--- a/src/Microsoft.ServiceFabric.Services/Communication/Client/CommunicationClientCache.cs
+++ b/src/Microsoft.ServiceFabric.Services/Communication/Client/CommunicationClientCache.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Client
 
         public CommunicationClientCache(string traceId)
         {
-            ServiceTrace.Source.WriteNoise(TraceType, "{0} ctor", this.traceId);
+            ServiceTrace.Source.WriteNoise(TraceType, "{0} ctor", traceId);
 
             this.clientCache = new ConcurrentDictionary<Guid, PartitionClientCache>();
             this.traceId = traceId;

--- a/src/Microsoft.ServiceFabric.Services/Runtime/RuntimeContext.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/RuntimeContext.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
     using System.Threading;
     using System.Threading.Tasks;
 
-    internal class RuntimeContext
+    internal class RuntimeContext : IDisposable
     {
         private static readonly object SharedContextLock = new object();
         private static RuntimeContext SharedContext;
@@ -90,6 +90,12 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             return SharedContext;
+        }
+
+        public void Dispose()
+        {
+            Runtime?.Dispose();
+            CodePackageContext?.Dispose();
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatefulServiceReplicaFactory.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatefulServiceReplicaFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
     using System;
     using System.Fabric;
 
-    internal class StatefulServiceReplicaFactory : IStatefulServiceFactory
+    internal class StatefulServiceReplicaFactory : IStatefulServiceFactory, IDisposable
     {
         private readonly Func<StatefulServiceContext, StatefulServiceBase> serviceFactory;
         private readonly RuntimeContext runtimeContext;
@@ -38,6 +38,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             var service = this.serviceFactory(serviceContext);
             return new StatefulServiceReplicaAdapter(service.Context, service);
+        }
+
+        public void Dispose()
+        {
+            runtimeContext?.Dispose();
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceFactory.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
     using System;
     using System.Fabric;
 
-    internal class StatelessServiceInstanceFactory : IStatelessServiceFactory
+    internal class StatelessServiceInstanceFactory : IStatelessServiceFactory, IDisposable
     {
         private readonly Func<StatelessServiceContext, StatelessService> serviceFactory;
         private readonly RuntimeContext runtimeContext;
@@ -38,6 +38,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             var service = this.serviceFactory(instanceContext);
             return new StatelessServiceInstanceAdapter(service.Context, service);
+        }
+
+        public void Dispose()
+        {
+            runtimeContext?.Dispose();
         }
     }
 }


### PR DESCRIPTION
The `MockActorManager` and  `RuntimeContext` class containing IDisposable members does not itself implement IDisposable. 

Also the `traceId` field is used before it is initialized in constructor.

Please review. 