### PR TITLE
Use the correct .editorconfig file, additional cleanup

### DIFF
--- a/code.sln
+++ b/code.sln
@@ -29,7 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnetcore", "dotnetcore", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2E1B4B64-112D-4D58-B156-C7E94B6D9D11}"
 	ProjectSection(SolutionItems) = preProject
-		..\.editorconfig = ..\.editorconfig
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A0BD3F34-AEC0-40FE-9CB0-60A892F5B713}"

--- a/src/FabActUtil/Tool.cs
+++ b/src/FabActUtil/Tool.cs
@@ -11,8 +11,8 @@ namespace FabActUtil
     using System.IO;
     using System.Reflection;
     using Microsoft.ServiceFabric.Actors;
-    using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Actors.Generator;
+    using Microsoft.ServiceFabric.Actors.Runtime;
 
     internal class Tool
     {
@@ -187,23 +187,23 @@ namespace FabActUtil
                             actorTypeInfoTable[actorTypeInterface].ImplementationType))
                         {
                             throw new TypeLoadException(
-                            string.Format(CultureInfo.CurrentCulture,
-                                SR.ErrorNoActorServiceNameMultipleImplDerivation,
-                                actorTypeInterface.FullName,
-                                actorTypeInfoTable[actorTypeInterface].ImplementationType.FullName,
-                                actorTypeInformation.ImplementationType.FullName,
-                                typeof(ActorServiceAttribute).FullName));
+                                string.Format(CultureInfo.CurrentCulture,
+                                    SR.ErrorNoActorServiceNameMultipleImplDerivation,
+                                    actorTypeInterface.FullName,
+                                    actorTypeInfoTable[actorTypeInterface].ImplementationType.FullName,
+                                    actorTypeInformation.ImplementationType.FullName,
+                                    typeof(ActorServiceAttribute).FullName));
                         }
                         else if (actorTypeInfoTable[actorTypeInterface].ImplementationType.IsAssignableFrom(
                             actorTypeInformation.ImplementationType))
                         {
                             throw new TypeLoadException(
-                              string.Format(CultureInfo.CurrentCulture,
-                                  SR.ErrorNoActorServiceNameMultipleImplDerivation,
-                                  actorTypeInterface.FullName,
-                                  actorTypeInformation.ImplementationType.FullName,
-                                  actorTypeInfoTable[actorTypeInterface].ImplementationType.FullName,
-                                  typeof(ActorServiceAttribute).FullName));
+                                string.Format(CultureInfo.CurrentCulture,
+                                    SR.ErrorNoActorServiceNameMultipleImplDerivation,
+                                    actorTypeInterface.FullName,
+                                    actorTypeInformation.ImplementationType.FullName,
+                                    actorTypeInfoTable[actorTypeInterface].ImplementationType.FullName,
+                                    typeof(ActorServiceAttribute).FullName));
                         }
                         else
                         {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Client/ServiceProxyFactory.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Client/ServiceProxyFactory.cs
@@ -131,13 +131,13 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Client
                 targetReplicaSelector,
                 listenerName);
 #else
-            if (proxyFactoryV2==null)
+            if (proxyFactoryV2 == null)
             {
                 var provider = this.GetProviderAttribute(serviceInterfaceType);
                 //We are overriding listenerName since using provider we can have multiple listener configured(Compat Mode).
                 this.overrideListenerName = true;
                 this.proxyFactoryV2 =
-                    new V2.Client.ServiceProxyFactory(provider.CreateServiceRemotingClientFactoryV2,this.retrySettings);
+                    new V2.Client.ServiceProxyFactory(provider.CreateServiceRemotingClientFactoryV2, this.retrySettings);
             }
             if (this.overrideListenerName && listenerName == null)
             {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -119,8 +119,8 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
             }
 
 #else
-             return new[]
-                {
+            return new[]
+               {
                     new ServiceReplicaListener(
                         (t) =>
                         {

--- a/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/WcfRemoteExceptionInformation.cs
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/WcfRemoteExceptionInformation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf
         public static readonly FaultCode FaultCodeThrow = new FaultCode(FaultCodeName,
             new FaultCode(FaultSubCodeThrowName));
 
-        private static readonly DataContractSerializer serializer =
+        private static readonly DataContractSerializer Serializer =
             new DataContractSerializer(typeof(ServiceExceptionData));
 
         public static string ToString(Exception exception)
@@ -108,7 +108,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf
 
                 using (var textStream = XmlWriter.Create(stringWriter))
                 {
-                    serializer.WriteObject(textStream, serviceExceptionData);
+                    Serializer.WriteObject(textStream, serviceExceptionData);
                     textStream.Flush();
 
                     result = stringWriter.ToString();
@@ -137,7 +137,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf
                 };
                 using (var textStream = XmlReader.Create(stringReader, settings))
                 {
-                    result = (ServiceExceptionData)serializer.ReadObject(textStream);
+                    result = (ServiceExceptionData)Serializer.ReadObject(textStream);
                     return true;
                 }
             }


### PR DESCRIPTION
The code.sln should use the .editorconfig file in the same directory. Few minor coding style fixes.