### PR TITLE
Fix bug in ServicePartitionClient when cancellation token is canceled…

### DIFF
--- a/src/Microsoft.ServiceFabric.Services/Communication/Client/ServicePartitionClient.cs
+++ b/src/Microsoft.ServiceFabric.Services/Communication/Client/ServicePartitionClient.cs
@@ -171,12 +171,8 @@ namespace Microsoft.ServiceFabric.Services.Communication.Client
                 // This code will execute when user has specified client retry timeout
                 if (this.retrySettings.ClientRetryTimeout != Timeout.InfiniteTimeSpan)
                 {
-                    cancellationTokenSource = new CancellationTokenSource(this.retrySettings.ClientRetryTimeout);
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        cancellationToken.Register(() => cancellationTokenSource.Cancel());
-                    }
-
+                    cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    cancellationTokenSource.CancelAfter(this.retrySettings.ClientRetryTimeout);
                     cancellationToken = cancellationTokenSource.Token;
                 }
 


### PR DESCRIPTION
… after InvokeWithRetryAsync has been called.