### PR TITLE
Backport to 7.1 Verbose tracing on Linux for ActorFramework and ServiceFrameworkEventSource classes

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -57,7 +57,7 @@ if($MSBuildFullPath -eq "")
 
 if (!(Test-Path $MSBuildFullPath))
 {
-    throw "Unable to find MSBuild installed on this machine. Please install Visual Studio 2022 or if its installed at non-default location, provide the full ppath to msbuild using -MSBuildFullPath parameter."
+    throw "Unable to find MSBuild installed on this machine. Please install Visual Studio 2022 or if its installed at non-default location, provide the full path to msbuild using -MSBuildFullPath parameter."
 }
 
 

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>7</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <BuildVersion>6</BuildVersion>
+    <BuildVersion>7</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             if (isOSPlatform(OSPlatform.Linux))
             {
                 var publisher = new UnstructuredTracePublisher();
-                publisher.EnableEvents(this, EventLevel.Informational);
+                publisher.EnableEvents(this, EventLevel.LogAlways);
             }
         }
 #endif

--- a/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             if (isOSPlatform(OSPlatform.Linux))
             {
                 var publisher = new UnstructuredTracePublisher();
-                publisher.EnableEvents(this, EventLevel.Informational);
+                publisher.EnableEvents(this, EventLevel.LogAlways);
             }
         }
 #endif

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/Runtime/ServiceFrameworkEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/Runtime/ServiceFrameworkEventSourceTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 using var sut = new ServiceFrameworkEventSource();
 
-                Assert.True(sut.IsEnabled(EventLevel.Informational, EventKeywords.None)); // None = no filtering
+                Assert.True(sut.IsEnabled(EventLevel.Verbose, EventKeywords.All));
                 EventListener listener = sut.Field("m_Dispatchers").Value.Field<EventListener>();
                 Assert.IsType<UnstructuredTracePublisher>(listener);
             }


### PR DESCRIPTION
Make the `ActorFrameworkEventSource` and `ServiceFrameworkEventSource` classes enable publishing of all event levels to the unstructured tracing pipeline we use on Linux. Before, we were only publishing events with level up to `Informational` while all the level of events collected for all other event sources is `Verbose`.