### PR TITLE
Make ActorFrameworkEventSourceTest explain FabricCommon dependency

### DIFF
--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/ActorFrameworkEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/ActorFrameworkEventSourceTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             // Allow event enablement to work on instances created by the tests
             ActorFrameworkEventSource.Writer.Dispose();
 
-            // Disable Linux detection in sut to allow tests to run without libFabricCommon.so
+            // Disable Linux detection in sut to allow tests to run without UnstructuredTracePublisher which fails without FabricCommon
             typeof(ServiceFabricEventSource).Field<Func<OSPlatform, bool>>().Set(_ => false);
 
             sut = new ActorFrameworkEventSource();


### PR DESCRIPTION
Change the comment for disablement of Linux detection to explain that it is needed for tests to run without the UnstructuredTracePublisher which requires the FabricCommon library and always fails in unit tests without it.