### PR TITLE
Restore original namespace for ServiceFrameworkEventSource

### DIFF
--- a/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Tracing;
 using System.Fabric;
 using Microsoft.ServiceFabric.Diagnostics.Tracing;
 
-namespace Microsoft.ServiceFabric.Services
+namespace Microsoft.ServiceFabric.Services.Runtime
 {
     // REMARKS:
     // When you apply EventAttribute attribute to an ETW event method defined on an EventSource-derived class,

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
@@ -3,7 +3,7 @@ using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.ServiceFabric.Services
+namespace Microsoft.ServiceFabric.Services.Test
 {
     public abstract class ServiceEventSourceTest
     {

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
@@ -3,7 +3,7 @@ using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.ServiceFabric.Services.Test
+namespace Microsoft.ServiceFabric.Services.Tests
 {
     public abstract class ServiceEventSourceTest
     {

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceFrameworkEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceFrameworkEventSourceTest.cs
@@ -1,10 +1,11 @@
 using System.Diagnostics.Tracing;
 using System.IO;
 using Microsoft.ServiceFabric.Diagnostics.Tracing;
+using Microsoft.ServiceFabric.Services.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.ServiceFabric.Services.Diagnostics
+namespace Microsoft.ServiceFabric.Services.Tests
 {
     public abstract class ServiceFrameworkEventSourceTest
     {


### PR DESCRIPTION
- This class was moved to root Microsoft.ServiceFabric.Services from Microsoft.ServiceFabric.Services.Runtime
- This was done in [this PR](https://github.com/microsoft/service-fabric-services-and-actors-dotnet/commit/2bb3eca457d9155e03442ef7f3346493533d6a6d#diff-16e5208ed64cef5abb06616296aabc64e4b6635bd03083bdf1f52ff244be1c07)
- Original PR was not meant to change this. Reverting this particular change.