### PR TITLE
Fix SF.ActorsServices.Internal package reference errors

### DIFF
--- a/nuprojs/SF.ActorsServices.Internal/SF.ActorsServices.Internal.nuproj
+++ b/nuprojs/SF.ActorsServices.Internal/SF.ActorsServices.Internal.nuproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
       <File Include="$(DropFolderNetFramework)*.*">
-        <TargetPath>lib\netframework</TargetPath>
+        <TargetPath>lib\net462</TargetPath>
       </File>
       <File Include="$(DropFolderNetCore)*.*">
         <TargetPath>lib\net8.0</TargetPath>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -23,7 +23,7 @@
     <!-- We migrated Diagnostics package from WindowsFabric repo and we need to keep the versioning consistent -->
     <MajorVersion Condition="'$(MSBuildProjectName)' == 'Microsoft.ServiceFabric.Diagnostics'">12</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <BuildVersion>3</BuildVersion>
+    <BuildVersion>4</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/FabActUtil/FabActUtil.csproj
+++ b/src/FabActUtil/FabActUtil.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.ServiceFabric.Actors_netframework.targets" 
-    Link="Microsoft.ServiceFabric.Actors.targets">
+    <None Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.ServiceFabric.Actors_netframework.targets">
+      <Link>Microsoft.ServiceFabric.Actors.targets</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.ServiceFabric.Actors_netcore.targets" 
-    Link="Microsoft.ServiceFabric.Actors.targets">
+    <None Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.ServiceFabric.Actors_netcore.targets">
+      <Link>Microsoft.ServiceFabric.Actors.targets</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/FabActUtil/FabActUtil.csproj
+++ b/src/FabActUtil/FabActUtil.csproj
@@ -3,9 +3,15 @@
   <PropertyGroup>
     <ProjectGuid>{F6E091C3-9136-4058-91CF-57CDF383DF74}</ProjectGuid>
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
+  <PropertyGroup>
+    <!-- 
+      The netframework.targets expects FabActUtil to be an EXE. The netcore.targets expects FabActUtil to be a DLL.
+      The netcore binary cannot be an EXE because the SF.ActorsServices.Internal package reference fails to resolve the DLL with the same name.
+    -->
+    <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.ServiceFabric.Actors_netframework.targets" 


### PR DESCRIPTION
When the FabActUtil project was migrated from netstandard2.0 to net8.0, two problems were accidentally introduced:
- For net462, the binary type changed from an EXE to a DLL. 
- For net8.0, in addition to the DLL, the build also produced an EXE with the same name.

These problems became apparent only during integration of the new package version with the WindowsFabric code. 

These changes have been verified by building the WindowsFabric code with a package downloaded from this PR validation build.