### PR TITLE
Remove DocumentationFile from Test projects on Linux

### DIFF
--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <AssemblyTitle>$(AssemblyName)</AssemblyTitle>
-    <DocumentationFile Condition="!$(MSBuildProjectDirectory.Contains('\test\unittests\'))">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile Condition="!$(MSBuildProjectDirectory.Contains('test'))">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Properties specific to certain TargetFrameworks -->


### PR DESCRIPTION
Make service_fabric_managed_common.props detect test projects correctly on Linux, where the path separator is different from Windows. The test projects shouldn't generate documentation files because this makes the C# compiler report warnings for all test classes and test methods that must be public. This is appropriate for product code, but not for tests, where most of the relevant information should be conveyed by the class and method names.