### PR TITLE
Fix .NET8 warnings

### DIFF
--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -21,7 +21,7 @@
   <!-- Properties specific to certain TargetFrameworks -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'"> 
     <DefineConstants>$(DefineConstants);DotNetCoreClr</DefineConstants>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);SYSLIB0011;SYSLIB0050;SYSLIB0037;SYSLIB0012</WarningsNotAsErrors >
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);SYSLIB0011;SYSLIB0050</WarningsNotAsErrors >
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <OutputType>Library</OutputType>

--- a/src/FabActUtil/Tool.cs
+++ b/src/FabActUtil/Tool.cs
@@ -307,12 +307,5 @@ namespace FabActUtil
 
             return false;
         }
-
-        private static string GetToolPath()
-        {
-            var codeBase = Assembly.GetEntryAssembly().CodeBase;
-            var uri = new UriBuilder(codeBase);
-            return Uri.UnescapeDataString(uri.Path);
-        }
     }
 }

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
@@ -64,8 +64,8 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
                     Version = currentAssembly.GetName().Version,
 #if !DotNetCoreClr
                     CultureInfo = currentAssembly.GetName().CultureInfo,
-#endif
                     ProcessorArchitecture = currentAssembly.GetName().ProcessorArchitecture,
+#endif
                 };
 
                 actorsMigrationAssembly.SetPublicKeyToken(currentAssembly.GetName().GetPublicKeyToken());


### PR DESCRIPTION
- Recently we moved from `netstandard2.0` -> `net8.0`
- After migration there are several new warnings appearing during the build
- Fixing the warnings except for `BinaryFormater` related ones, which will be fixed in [Remove binary serialization #435](https://github.com/microsoft/service-fabric-services-and-actors-dotnet/pull/435)