### PR TITLE
Trace ActorReminder failures to arm Timer as Warnings instead of Errors

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
@@ -136,7 +136,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 }
                 catch (Exception e)
                 {
-                    this.actorManager.TraceSource.WriteErrorWithId(
+                    this.actorManager.TraceSource.WriteWarningWithId(
                         TraceType,
                         this.actorManager.GetActorTraceId(this.OwnerActorId),
                         "Failed to arm timer for reminder {0} exception {1}",


### PR DESCRIPTION
`ActorReminder` allows due time and period values larger than the maximum supported by the `Timer.Change`. When this happens, it traces an error with the exception information. This exception is caught and ignored. In most cases this shouldn't be a problem because the maximum supported by `Timer` is ~49 days and chances are good that the primary replica will move before then. When reminders are loaded from state, the reminders are set for the remaining time rather than the original time period specified at the time of their registration. 

https://msazure.visualstudio.com/One/_workitems/edit/34574898