### PR TITLE
Fix flakey ServiceFabricEventSourceTest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - run: .\UninstallSfSdkFromGac.ps1
       - run: dotnet test code.sln --configuration release --nologo --settings test\default.runsettings --results-directory ${{ env.DROP_DIR }} --logger trx
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test-windows
           path: ${{ env.DROP_DIR }}
@@ -49,6 +50,7 @@ jobs:
       - run: dotnet test code.sln --configuration release --nologo --settings test/default.runsettings --results-directory ${{ env.DROP_DIR }} --logger trx
         continue-on-error: true
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test-linux
           path: ${{ env.DROP_DIR }}

--- a/test/Microsoft.ServiceFabric.Diagnostics.Tests/Tracing/ServiceFabricEventSourceTest.cs
+++ b/test/Microsoft.ServiceFabric.Diagnostics.Tests/Tracing/ServiceFabricEventSourceTest.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Tracing;
-using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Inspector;
 using Microsoft.ServiceFabric.Diagnostics.Tracing.Writer;
@@ -26,34 +24,20 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
             }
         }
 
-        public sealed class ConstructorNetCore : ServiceFabricEventSourceTest, IDisposable
+        public partial class Constructor : IDisposable
         {
+            readonly Mock<Func<OSPlatform, bool>> isOsPlatform = new Mock<Func<OSPlatform, bool>>();
 
-            readonly Func<OSPlatform, bool> isOsPlatform = Mock.Of<Func<OSPlatform, bool>>();
+            public Constructor() =>
+                typeof(ServiceFabricEventSource).Field<Func<OSPlatform, bool>>().Set(isOsPlatform.Object);
 
-            public ConstructorNetCore()
-            {
-                // Enable mocking of OSPlatform detection
-                typeof(TestEventSource).Field<Func<OSPlatform, bool>>().Set(isOsPlatform);
-
-                // Dispose Writer singleton to allow event enablement to work on instances created by the tests
-                var writer = typeof(TestEventSource).Property<TestEventSource>();
-                writer.Value.Dispose();
-            }
-
-            public void Dispose()
-            {
-                // Restore OSPlatform detection
-                typeof(TestEventSource).Field<Func<OSPlatform, bool>>().Set(RuntimeInformation.IsOSPlatform);
-
-                // Restore Writer singleton
-                typeof(TestEventSource).Property<TestEventSource>().Set(new TestEventSource());
-            }
+            public void Dispose() =>
+                typeof(ServiceFabricEventSource).Field<Func<OSPlatform, bool>>().Set(RuntimeInformation.IsOSPlatform);
 
             [Fact]
             public void EnablesUnstructuredEventPublishingOnLinux()
             {
-                Mock.Get(isOsPlatform).Setup(_ => _.Invoke(OSPlatform.Linux)).Returns(true);
+                isOsPlatform.Setup(_ => _.Invoke(OSPlatform.Linux)).Returns(true);
 
                 using var sut = new TestEventSource();
 
@@ -65,7 +49,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
             [Fact]
             public void DoesntEnableUnstructuredEventPublishingOnWindows()
             {
-                Mock.Get(isOsPlatform).Setup(_ => _.Invoke(OSPlatform.Linux)).Returns(false);
+                isOsPlatform.Setup(_ => _.Invoke(OSPlatform.Linux)).Returns(false);
 
                 using var sut = new TestEventSource();
 
@@ -75,39 +59,21 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
 
 #endif
 
-        public sealed class Constructor : ServiceFabricEventSourceTest
+        public sealed partial class Constructor : ServiceFabricEventSourceTest
         {
             [Theory]
             [InlineData(1, "EventWithIdAndType", "Event with id and type: {0}, {1}, {2}", EventLevel.Informational)]
             [InlineData(2, "EventWithIdOnly", "Event with id only: {0}, {1}", EventLevel.Warning)]
-            public void DoesGeneratesEventDescriptorsCorrectly(int eventId, string name, string message, EventLevel eventLevel)
-            {
-                var eventSource = new TestEventSource();
-
-                var eventDescriptorsField = typeof(ServiceFabricEventSource).GetField("eventDescriptors", BindingFlags.NonPublic | BindingFlags.Instance);
-                var eventDescriptors = (ReadOnlyDictionary<int, TraceEvent>)eventDescriptorsField.GetValue(eventSource);
-
-                Assert.True(eventDescriptors.ContainsKey(eventId));
-                var traceEvent = eventDescriptors[eventId];
-                Assert.Equal(name, traceEvent.EventName);
-                Assert.Equal(eventLevel, traceEvent.Level);
-                Assert.Equal(message, traceEvent.Message);
-            }
-        }
-
-        public sealed class Manifest : ServiceFabricEventSourceTest
-        {
-            [Fact]
-            public void CanBeSavedForRegistrationWithExternalTools()
+            public void GeneratesEventDescriptorsCorrectly(int eventId, string name, string message, EventLevel eventLevel)
             {
                 using var sut = new TestEventSource();
 
-                string manifest = EventSource.GenerateManifest(sut.GetType(), sut.GetType().Assembly.Location);
+                var eventDescriptors = sut.Field<ReadOnlyDictionary<int, TraceEvent>>().Value;
 
-                string manifestFile = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(sut.GetType().Assembly.Location), sut.Name), "man");
-                File.WriteAllText(manifestFile, manifest);
-                Console.WriteLine("To register generated manifest for ETL tools, run");
-                Console.WriteLine($"sudo wevtutil install-manifest {manifestFile}");
+                TraceEvent traceEvent = eventDescriptors[eventId];
+                Assert.Equal(name, traceEvent.EventName);
+                Assert.Equal(eventLevel, traceEvent.Level);
+                Assert.Equal(message, traceEvent.Message);
             }
         }
     }

--- a/test/Microsoft.ServiceFabric.Diagnostics.Tests/Tracing/TestEventSource.cs
+++ b/test/Microsoft.ServiceFabric.Diagnostics.Tests/Tracing/TestEventSource.cs
@@ -5,8 +5,6 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
     [EventSource(Name = "TestEventSource")]
     internal class TestEventSource : ServiceFabricEventSource
     {
-        internal static TestEventSource Writer { get; private set; } = new TestEventSource();
-
         [Event(1, Message = "Event with id and type: {0}, {1}, {2}", Level = EventLevel.Informational)]
         public void EventWithIdAndType(string id, string type, string message)
         {


### PR DESCRIPTION
- Make sure every TestEventSource created by tests is disposed. Upgrade to xUnit.v3 surfaced test failures caused by a race condition with the test Constructor.GeneratesEventDescriptorsCorrectly which wasn't disposing the TestEventSource instance.
- Make build.yml upload test results artifacts when tests fail as well.
- Clean up minor nits:
  - Use ServiceFabricEventSource type instead of TestEventSource where it more precisely describes the code intent.
  - Remove unnecessary code elements.
  - Use explicit variable type where it helps improve readability.
  - Remove Manifest test because it described the TestEventSource rather rather than the ServiceFabricEventSource class and duplicated the
    EventSourceTest implemented by tests for all concrete descendants.