### PR TITLE
Small fix in UsesPassedRemotingListenerSettings

### DIFF
--- a/test/Microsoft.ServiceFabric.Services.Remoting.Tests/ExceptionSerializerTest.cs
+++ b/test/Microsoft.ServiceFabric.Services.Remoting.Tests/ExceptionSerializerTest.cs
@@ -82,7 +82,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
             [Fact]
             public void UsesPassedRemotingListenerSettings()
             {
-                var expectedSettings = new FabricTransportRemotingListenerSettings();
+                var expectedSettings = new FabricTransportRemotingListenerSettings()
+                {
+                    RemotingExceptionDepth = 17
+                };
 
                 var serializer = ExceptionSerializer.CreateDefault(null, expectedSettings);
 


### PR DESCRIPTION
Set a particular value for `RemotingExceptionDepth` instead of
passing the default value to the factory method.