### PR TITLE
Deprecate Actor state migration APIs in release_8.0

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>15</BuildVersion>
+    <BuildVersion>16</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/AmbiguousActorIdHandlerBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/AmbiguousActorIdHandlerBase.cs
@@ -11,6 +11,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Runtime;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal abstract class AmbiguousActorIdHandlerBase : IAmbiguousActorIdHandler
     {
         private ActorStateProviderHelper stateProviderHelper;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CatchupPhaseWorkload.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CatchupPhaseWorkload.cs
@@ -5,11 +5,13 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Fabric;
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Services.Communication.Client;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class CatchupPhaseWorkload : MigrationPhaseWorkloadBase
     {
         public CatchupPhaseWorkload(

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/AspNetCoreCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/AspNetCoreCommunicationListener.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// Base class for creating AspNetCore based communication listener for Service Fabric stateless or stateful service.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal abstract class AspNetCoreCommunicationListener : ICommunicationListener
     {
         private readonly ServiceContext serviceContext;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/GenericHostCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/GenericHostCommunicationListener.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.Extensions.Hosting;
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class GenericHostCommunicationListener : ICommunicationListener
     {
         private readonly Func<string, AspNetCoreCommunicationListener, IHost> build;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/HttpSysCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/HttpSysCommunicationListener.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// An AspNetCore HttpSys server based communication listener for Service Fabric stateless or stateful service.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class HttpSysCommunicationListener : AspNetCoreCommunicationListener
     {
         private readonly string endpointName;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/WebHostCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CommunicationListener/WebHostCommunicationListener.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.AspNetCore.Hosting.Server.Features;
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class WebHostCommunicationListener : ICommunicationListener
     {
         private readonly Func<string, AspNetCoreCommunicationListener, IWebHost> build;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/KvsMigrationController.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/KvsMigrationController.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers
     /// Represents the controller class for KVS migration REST API.
     /// </summary>
     [Route("[controller]")]
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class KvsMigrationController : ControllerBase
     {
         private KvsActorStateProvider kvsActorStateProvider;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/MigrationControllerFeatureProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/MigrationControllerFeatureProvider.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers
 {
+    using System;
     using System.Reflection;
     using Microsoft.AspNetCore.Mvc.Controllers;
 
@@ -12,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers
     /// MigrationControllerFeatureProvider class to override IsController to be able
     /// to load internal migration controllers
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class MigrationControllerFeatureProvider : ControllerFeatureProvider
     {
         protected override bool IsController(TypeInfo typeInfo)

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/RcMigrationController.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Controllers/RcMigrationController.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers
     /// Represents the controller class for KVS migration REST API.
     /// </summary>
     [Route("[controller]")]
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class RcMigrationController : ControllerBase
     {
         private IMigrationOrchestrator migrationOrchestrator;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CopyPhaseWorkload.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/CopyPhaseWorkload.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Fabric;
     using System.Threading;
     using System.Threading.Tasks;
@@ -12,9 +13,12 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Services.Communication.Client;
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationUtility;
+#pragma warning restore 618
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class CopyPhaseWorkload : MigrationPhaseWorkloadBase
     {
         private static readonly string TraceType = typeof(CopyPhaseWorkload).Name;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/DowntimeWorkload.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/DowntimeWorkload.cs
@@ -5,11 +5,13 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Fabric;
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Services.Communication.Client;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class DowntimeWorkload : MigrationPhaseWorkloadBase
     {
         public DowntimeWorkload(

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/KvsActorStateProviderExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/KvsActorStateProviderExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Services;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal static class KvsActorStateProviderExtensions
     {
         public static readonly string TombstoneCleanupMessage = "KeyValueStoreReplicaSettings.DisableTombstoneCleanup is either not enabled or set to false";

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/ServiceParitionClientExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/ServiceParitionClientExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Extensions
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Services.Communication.Client;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal static class ServiceParitionClientExtensions
     {
         private static readonly DataContractJsonSerializer ErrorSerializer = new DataContractJsonSerializer(typeof(ErrorResponse));

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/WebHostBuilderServiceFabricExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Extensions/WebHostBuilderServiceFabricExtensions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// Class containing Service Fabric related extension methods for Microsoft.AspNetCore.Hosting.IWebHostBuilder.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal static class WebHostBuilderServiceFabricExtensions
     {
         private static readonly string SettingName = "UseServiceFabricIntegration";

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IAmbiguousActorIdHandler.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IAmbiguousActorIdHandler.cs
@@ -5,12 +5,14 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
     /// ActorId Handler.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public interface IAmbiguousActorIdHandler
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IMigrationPhaseWorkload.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IMigrationPhaseWorkload.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Migration;
@@ -12,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// Interface definition for migration workload by phase.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal interface IMigrationPhaseWorkload
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IWorker.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/IWorker.cs
@@ -7,8 +7,10 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
     using System.Threading;
     using System.Threading.Tasks;
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.PhaseInput;
     using static Microsoft.ServiceFabric.Actors.Migration.PhaseResult;
+#pragma warning restore 618
 
     /// <summary>
     /// Interface definition for workers.

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/KVSAmbiguousActorIdHandler.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/KVSAmbiguousActorIdHandler.cs
@@ -5,10 +5,12 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Runtime;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class KVSAmbiguousActorIdHandler : AmbiguousActorIdHandlerBase
     {
         private const string ActorStorageKeyPrefix = "Actor";

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/KVStoRCMigrationActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/KVStoRCMigrationActorStateProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// Provides an implementation of <see cref="KVStoRCMigrationActorStateProvider"/> which
     /// uses <see cref="ReliableCollectionsActorStateProvider"/> to store and persist the actor state.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class KVStoRCMigrationActorStateProvider :
         IActorStateProvider, VolatileLogicalTimeManager.ISnapshotHandler, IActorStateProviderInternal
     {

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Middleware/DefaultMigrationExceptionMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Middleware/DefaultMigrationExceptionMiddleware.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Middleware
     using Microsoft.AspNetCore.Http;
     using Microsoft.ServiceFabric.Actors.Migration;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class DefaultMigrationExceptionMiddleware
     {
         private static readonly DataContractJsonSerializer Serializer = new DataContractJsonSerializer(typeof(ErrorResponse));

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationOrchestratorBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationOrchestratorBase.cs
@@ -23,6 +23,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// Base class for migration orchestration.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal abstract class MigrationOrchestratorBase : IMigrationOrchestrator
     {
         private static readonly string TraceType = typeof(MigrationOrchestratorBase).Name;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationPhaseWorkloadBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationPhaseWorkloadBase.cs
@@ -16,11 +16,14 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Runtime.Migration;
     using Microsoft.ServiceFabric.Data.Collections;
     using Microsoft.ServiceFabric.Services.Communication.Client;
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationUtility;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.PhaseInput;
     using static Microsoft.ServiceFabric.Actors.Migration.PhaseResult;
+#pragma warning restore 618
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal abstract class MigrationPhaseWorkloadBase : IMigrationPhaseWorkload
     {
         private static readonly string TraceType = typeof(MigrationPhaseWorkloadBase).Name;
@@ -538,6 +541,6 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
                },
                "MigrationPhaseWorkloadBase.AddOrUpdateResultAsync",
                token);
-         }
+        }
     }
 }

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationSettings.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationSettings.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 
     [DataContract]
     [KnownType(typeof(Actors.Runtime.Migration.MigrationSettings))]
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class MigrationSettings : Actors.Runtime.Migration.MigrationSettings
     {
         private static readonly string TraceType = typeof(MigrationSettings).ToString();

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationUtility.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationUtility.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Data.Collections;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal static class MigrationUtility
     {
         private static readonly string TraceType = typeof(MigrationUtility).ToString();

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationWorker.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationWorker.cs
@@ -19,11 +19,14 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Services.Communication.Client;
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationUtility;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.PhaseInput;
     using static Microsoft.ServiceFabric.Actors.Migration.PhaseResult;
+#pragma warning restore 618
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class MigrationWorker : WorkerBase
     {
         private static readonly string TraceType = typeof(MigrationWorker).Name;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/EnumerationRequest.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/EnumerationRequest.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
     using System.Runtime.Serialization;
 
@@ -12,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
     /// EnumerationRequest
     /// </summary>
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class EnumerationRequest
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/EnumerationResponse.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/EnumerationResponse.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
 {
+    using System;
     using System.Collections.Generic;
     using System.Runtime.Serialization;
 
@@ -12,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
     /// Migration state response.
     /// </summary>
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class EnumerationResponse
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/KeyValuePair.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Models/KeyValuePair.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
 {
+    using System;
     using System.IO;
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Json;
@@ -14,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration.Models
     /// KeyValuePair
     /// </summary>
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class KeyValuePair
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/PartitionHealthExceptionFilter.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/PartitionHealthExceptionFilter.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using System.Fabric;
     using System.Fabric.Health;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class PartitionHealthExceptionFilter
     {
         private const int MaxHealthDescriptionLength = (4 * 1024) - 1;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/PhaseInput.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/PhaseInput.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Migration;
 
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class PhaseInput
     {
         private static DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(PhaseInput), new DataContractJsonSerializerSettings

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/RCAmbiguousActorIdHandler.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/RCAmbiguousActorIdHandler.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Actors.Runtime.Migration;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class RCAmbiguousActorIdHandler : AmbiguousActorIdHandlerBase
     {
         private IReliableCollectionsActorStateProviderInternal stateProvider;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/SourceMigrationOrchestrator.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/SourceMigrationOrchestrator.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     /// <summary>
     /// Migration orchestrator for source(KVS based) service.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class SourceMigrationOrchestrator : MigrationOrchestratorBase
     {
         private static readonly string TraceType = typeof(SourceMigrationOrchestrator).Name;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Startup.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Startup.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
 {
+    using System;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.KVSToRCMigration.Controllers;
     using Microsoft.ServiceFabric.Actors.KVSToRCMigration.Middleware;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class Startup
     {
         public Startup(IConfiguration configuration)

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/TargetMigrationOrchestrator.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/TargetMigrationOrchestrator.cs
@@ -20,12 +20,14 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Data.Collections;
     using Microsoft.ServiceFabric.Services.Client;
     using Microsoft.ServiceFabric.Services.Communication.Client;
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationUtility;
-
+#pragma warning restore 618
     /// <summary>
     /// Orchestrator for Target(RC based) service.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class TargetMigrationOrchestrator : MigrationOrchestratorBase
     {
         private static readonly string TraceType = typeof(TargetMigrationOrchestrator).Name;

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/WorkerBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/WorkerBase.cs
@@ -12,11 +12,14 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Data;
     using Microsoft.ServiceFabric.Data.Collections;
+#pragma warning disable 618 //[Obsolete(DeprecationMessage.StateMigration)]
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationConstants;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.MigrationUtility;
     using static Microsoft.ServiceFabric.Actors.KVSToRCMigration.PhaseInput;
     using static Microsoft.ServiceFabric.Actors.Migration.PhaseResult;
+#pragma warning restore 618
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class WorkerBase : IWorker
     {
         private static readonly string TraceType = typeof(WorkerBase).Name;

--- a/src/Microsoft.ServiceFabric.Actors/DeprecationMessage.cs
+++ b/src/Microsoft.ServiceFabric.Actors/DeprecationMessage.cs
@@ -1,0 +1,12 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Actors
+{
+    static class DeprecationMessage
+    {
+        internal const string StateMigration = "Actor state migration APIs are deprecated and will be removed in the next major version of the Microsoft.ServiceFabric.Actor packages.";
+    }
+}

--- a/src/Microsoft.ServiceFabric.Actors/FabricActorExceptionKnownTypes.cs
+++ b/src/Microsoft.ServiceFabric.Actors/FabricActorExceptionKnownTypes.cs
@@ -83,6 +83,7 @@ namespace Microsoft.ServiceFabric.Actors
                         InnerExFunc = ex => GetInnerExceptions(ex),
                     }
                 },
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
                 {
                     "Microsoft.ServiceFabric.Actors.Migration.Exceptions.ActorCallsDisallowedException", new ConvertorFuncs()
                     {
@@ -107,6 +108,7 @@ namespace Microsoft.ServiceFabric.Actors
                         InnerExFunc = ex => GetInnerExceptions(ex),
                     }
                 },
+#pragma warning restore 618
             };
 
         private static ServiceException ToServiceException(FabricException fabricEx)

--- a/src/Microsoft.ServiceFabric.Actors/Migration/ActorEventForwarder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/ActorEventForwarder.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     using Microsoft.ServiceFabric.Services.Remoting.V2;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Client;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class ActorEventForwarder : IServiceRemotingCallbackMessageHandler
     {
         private static readonly string TraceType = typeof(ActorEventForwarder).Name;

--- a/src/Microsoft.ServiceFabric.Actors/Migration/DefaultActorRequestForwarder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/DefaultActorRequestForwarder.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// <summary>
     /// Default implementation for actor request forwarding scenario.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class DefaultActorRequestForwarder : IRequestForwarder
     {
         private static readonly string TraceType = typeof(DefaultActorRequestForwarder).Name;

--- a/src/Microsoft.ServiceFabric.Actors/Migration/ErrorResponse.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/ErrorResponse.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Migration
 {
+    using System;
     using System.Fabric;
     using System.Runtime.Serialization;
 
@@ -13,6 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// </summary>
     [DataContract]
     [KnownType(typeof(FabricErrorCode))]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class ErrorResponse
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/ActorCallsDisallowedException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/ActorCallsDisallowedException.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration.Exceptions
     /// Target Migration service is disallowed to accept calls until all the sequence numbers are migrated successfully.
     /// </summary>
     [Serializable]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class ActorCallsDisallowedException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/AmbiguousActorIdDetectedException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/AmbiguousActorIdDetectedException.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration.Exceptions
     /// Exception to represent unresolved ambiguous actor id detection.
     /// </summary>
     [Serializable]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class AmbiguousActorIdDetectedException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationConfigException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationConfigException.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration.Exceptions
     /// Exception to represent MigrationConfig provided is invalid.
     /// </summary>
     [Serializable]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class InvalidMigrationConfigException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationOperationException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationOperationException.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration.Exceptions
     /// <summary>
     /// Exception to indicate the current migration operation is not allowed.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class InvalidMigrationOperationException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationStateProviderException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/InvalidMigrationStateProviderException.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors
     /// Exception to indicate actor state provider is invalid and cannot partitipate in migration.
     /// </summary>
     [Serializable]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class InvalidMigrationStateProviderException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/MigrationFrameworkNotInitializedException.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/Exceptions/MigrationFrameworkNotInitializedException.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration.Exceptions
     /// This is a transient exception and proxy calls receiving this exception could retry the call.
     /// </summary>
     [Serializable]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class MigrationFrameworkNotInitializedException : FabricException
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/IRequestForwarder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/IRequestForwarder.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Migration
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Services.Remoting.V2;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
@@ -12,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// <summary>
     /// Interface definition for forwardding actor requests if the current service cannot service the request.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public interface IRequestForwarder
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/MigrationPhase.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/MigrationPhase.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Actors.Migration
 {
     /// <summary>
     /// Indicates actor service migration phase.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public enum MigrationPhase
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/MigrationResult.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/MigrationResult.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// Migration result.
     /// </summary>
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class MigrationResult
     {
         private static DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(MigrationResult), new DataContractJsonSerializerSettings

--- a/src/Microsoft.ServiceFabric.Actors/Migration/MigrationState.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/MigrationState.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Actors.Migration
 {
     /// <summary>
     /// Indicates actor service migration state.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public enum MigrationState
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Migration/PhaseResult.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/PhaseResult.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// Migration phase result.
     /// </summary>
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class PhaseResult
     {
         private static DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(PhaseResult), new DataContractJsonSerializerSettings

--- a/src/Microsoft.ServiceFabric.Actors/Migration/RequestForwarderContext.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Migration/RequestForwarderContext.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ServiceFabric.Actors.Migration
     /// <summary>
     /// Context for request forwarder when the current service is unable to service the request.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public class RequestForwarderContext
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/FabricTransport/FabricTransportActorRemotingProviderAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/FabricTransport/FabricTransportActorRemotingProviderAttribute.cs
@@ -147,18 +147,22 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.FabricTransport
                     =>
                 {
                     var listenerSettings = this.InitializeListenerSettings(actorService);
+
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
                     if (actorService.IsConfiguredForMigration())
                     {
                         return new V2.FabricTransport.Runtime.FabricTransportActorServiceRemotingListener(
-                        actorService,
-                        listenerSettings,
-                        requestForwarderFactory: requestForwarderContext => new DefaultActorRequestForwarder(
                             actorService,
-                            requestForwarderContext,
-                            ServiceRemotingProviderAttribute.DefaultV2listenerName,
-                            callbackMessageHandler => this.CreateServiceRemotingClientFactory(callbackMessageHandler),
-                            null));
+                            listenerSettings,
+                            exceptionConvertors: null,
+                            requestForwarderFactory: requestForwarderContext => new DefaultActorRequestForwarder(
+                                actorService,
+                                requestForwarderContext,
+                                ServiceRemotingProviderAttribute.DefaultV2listenerName,
+                                callbackMessageHandler => this.CreateServiceRemotingClientFactory(callbackMessageHandler),
+                                null));
                     }
+#pragma warning restore 618
 
                     return new V2.FabricTransport.Runtime.FabricTransportActorServiceRemotingListener(
                         actorService,
@@ -173,18 +177,22 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.FabricTransport
                 {
                     var listenerSettings = this.InitializeListenerSettings(actorService);
                     listenerSettings.UseWrappedMessage = true;
+
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
                     if (actorService.IsConfiguredForMigration())
                     {
                         return new V2.FabricTransport.Runtime.FabricTransportActorServiceRemotingListener(
-                        actorService,
-                        listenerSettings,
-                        requestForwarderFactory: requestForwarderContext => new DefaultActorRequestForwarder(
                             actorService,
-                            requestForwarderContext,
-                            ServiceRemotingProviderAttribute.DefaultWrappedMessageStackListenerName,
-                            callbackMessageHandler => this.CreateServiceRemotingClientFactory(callbackMessageHandler),
-                            null));
+                            listenerSettings,
+                            exceptionConvertors: null,
+                            requestForwarderFactory: requestForwarderContext => new DefaultActorRequestForwarder(
+                                actorService,
+                                requestForwarderContext,
+                                ServiceRemotingProviderAttribute.DefaultWrappedMessageStackListenerName,
+                                callbackMessageHandler => this.CreateServiceRemotingClientFactory(callbackMessageHandler),
+                                null));
                     }
+#pragma warning restore 618
 
                     return new V2.FabricTransport.Runtime.FabricTransportActorServiceRemotingListener(
                         actorService,

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V2/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V2/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
@@ -39,17 +39,42 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
         /// </param>
         /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
         /// <param name="requestForwarderFactory">Request forwarder incase migration is ongoing and current service cannot service the request.</param>
+        [Obsolete(DeprecationMessage.StateMigration)]
         public FabricTransportActorServiceRemotingListener(
             ActorService actorService,
-            FabricTransportRemotingListenerSettings listenerSettings = null,
-            IEnumerable<IExceptionConvertor> exceptionConvertors = null,
-            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory = null)
+            FabricTransportRemotingListenerSettings listenerSettings,
+            IEnumerable<IExceptionConvertor> exceptionConvertors,
+            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory)
             : this(
                 actorService,
                 CreateActorRemotingDispatcher(actorService, listenerSettings),
                 SetEndPointResourceName(listenerSettings, actorService),
+                serializationProvider: null,
                 exceptionConvertors: exceptionConvertors,
                 requestForwarderFactory: requestForwarderFactory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportActorServiceRemotingListener"/> class.
+        /// This is a Service Fabric TCP transport based service remoting listener for the specified actor service.
+        /// </summary>
+        /// <param name="actorService">
+        ///     The implementation of the actor service.
+        /// </param>
+        /// <param name="listenerSettings">
+        ///     The settings to use for the listener.
+        /// </param>
+        /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
+        public FabricTransportActorServiceRemotingListener(
+            ActorService actorService,
+            FabricTransportRemotingListenerSettings listenerSettings = null,
+            IEnumerable<IExceptionConvertor> exceptionConvertors = null)
+            : this(
+                actorService,
+                CreateActorRemotingDispatcher(actorService, listenerSettings),
+                SetEndPointResourceName(listenerSettings, actorService),
+                exceptionConvertors: exceptionConvertors)
         {
         }
 
@@ -68,12 +93,13 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
         /// </param>
         /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
         /// <param name="requestForwarderFactory">Request forwarder incase migration is ongoing and current service cannot service the request.</param>
+        [Obsolete(DeprecationMessage.StateMigration)]
         public FabricTransportActorServiceRemotingListener(
             ActorService actorService,
             IServiceRemotingMessageSerializationProvider serializationProvider,
-            FabricTransportRemotingListenerSettings listenerSettings = null,
-            IEnumerable<IExceptionConvertor> exceptionConvertors = null,
-            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory = null)
+            FabricTransportRemotingListenerSettings listenerSettings,
+            IEnumerable<IExceptionConvertor> exceptionConvertors,
+            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory)
             : this(
                 actorService,
                 new ActorServiceRemotingDispatcher(actorService, serializationProvider.CreateMessageBodyFactory()),
@@ -81,6 +107,34 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
                 serializationProvider,
                 exceptionConvertors,
                 requestForwarderFactory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportActorServiceRemotingListener"/> class.
+        /// This is a Service Fabric TCP transport based service remoting listener for the specified actor service.
+        /// </summary>
+        /// <param name="actorService">
+        ///     The implementation of the actor service.
+        /// </param>
+        /// <param name="serializationProvider">
+        /// It is used to serialize deserialize request and response body.
+        /// </param>
+        /// <param name="listenerSettings">
+        ///     The settings to use for the listener.
+        /// </param>
+        /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
+        public FabricTransportActorServiceRemotingListener(
+            ActorService actorService,
+            IServiceRemotingMessageSerializationProvider serializationProvider,
+            FabricTransportRemotingListenerSettings listenerSettings = null,
+            IEnumerable<IExceptionConvertor> exceptionConvertors = null)
+            : this(
+                actorService,
+                new ActorServiceRemotingDispatcher(actorService, serializationProvider.CreateMessageBodyFactory()),
+                SetEndPointResourceName(listenerSettings, actorService),
+                serializationProvider,
+                exceptionConvertors)
         {
         }
 
@@ -129,13 +183,14 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
         /// <param name="serializationProvider">Serialization provider for remoting.</param>
         /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
         /// <param name="requestForwarderFactory">Request forwarder incase migration is ongoing and current service cannot service the request.</param>
+        [Obsolete(DeprecationMessage.StateMigration)]
         public FabricTransportActorServiceRemotingListener(
             ActorService actorService,
             IServiceRemotingMessageHandler messageHandler,
-            FabricTransportRemotingListenerSettings listenerSettings = null,
-            IServiceRemotingMessageSerializationProvider serializationProvider = null,
-            IEnumerable<IExceptionConvertor> exceptionConvertors = null,
-            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory = null)
+            FabricTransportRemotingListenerSettings listenerSettings,
+            IServiceRemotingMessageSerializationProvider serializationProvider,
+            IEnumerable<IExceptionConvertor> exceptionConvertors,
+            Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory)
             : base(
                 GetContext(actorService),
                 OverrideMessageHandlerIfRequired(actorService, messageHandler, requestForwarderFactory),
@@ -147,6 +202,38 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportActorServiceRemotingListener"/> class.
+        /// This is a Service Fabric TCP transport based service remoting listener for the specified actor service.
+        /// </summary>
+        /// <param name="actorService">
+        ///     The context of the service for which the remoting listener is being constructed.
+        /// </param>
+        /// <param name="messageHandler">
+        ///     The handler for processing remoting messages. As the messages are received,
+        ///     the listener delivers them to this handler.
+        /// </param>
+        /// <param name="listenerSettings">Listener Settings.</param>
+        /// <param name="serializationProvider">Serialization provider for remoting.</param>
+        /// <param name="exceptionConvertors">Convertors to convert user exception to service exception.</param>
+        public FabricTransportActorServiceRemotingListener(
+            ActorService actorService,
+            IServiceRemotingMessageHandler messageHandler,
+            FabricTransportRemotingListenerSettings listenerSettings = null,
+            IServiceRemotingMessageSerializationProvider serializationProvider = null,
+            IEnumerable<IExceptionConvertor> exceptionConvertors = null)
+            : base(
+                GetContext(actorService),
+                messageHandler,
+                InitializeSerializerManager(
+                   SetEndPointResourceName(listenerSettings, actorService),
+                   serializationProvider),
+                SetEndPointResourceName(listenerSettings, actorService),
+                GetExceptionConvertors(exceptionConvertors))
+        {
+        }
+
+        [Obsolete(DeprecationMessage.StateMigration)]
         private static IServiceRemotingMessageHandler OverrideMessageHandlerIfRequired(ActorService actorService, IServiceRemotingMessageHandler messageHandler, Func<RequestForwarderContext, IRequestForwarder> requestForwarderFactory)
         {
             if (actorService.IsConfiguredForMigration())

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
@@ -198,7 +198,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             CancellationToken cancellationToken)
         {
             this.ThrowIfClosed();
+
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             ExceptionDispatchInfo exceptionInfo = null;
             Exception exception = null;
@@ -322,7 +325,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             cancellationToken.ThrowIfCancellationRequested();
 
             this.ThrowIfClosed();
+
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             var methodDispatcher = this.actorService.MethodDispatcherMapV2.GetDispatcher(interfaceId, methodId);
             var actorMethodName = methodDispatcher.GetMethodName(methodId);
@@ -349,14 +355,18 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public Task SubscribeAsync(ActorId actorId, int eventInterfaceId, IActorEventSubscriberProxy subscriber)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             return this.eventManager.SubscribeAsync(actorId, eventInterfaceId, subscriber);
         }
 
         public Task UnsubscribeAsync(ActorId actorId, int eventInterfaceId, Guid subscriberId)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             return this.eventManager.UnsubscribeAsync(actorId, eventInterfaceId, subscriberId);
         }
@@ -374,7 +384,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             TimeSpan period,
             bool saveState = true)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             var reminder = new ActorReminder(actorId, this, reminderName, state, dueTime, period);
             await this.RegisterOrUpdateReminderAsync(reminder, dueTime, saveState);
@@ -402,7 +414,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         public async Task UnregisterReminderAsync(string reminderName, ActorId actorId, bool removeFromStateProvider)
         {
             this.ThrowIfClosed();
+
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             ActorTrace.Source.WriteInfoWithId(
                 TraceType,
@@ -444,7 +459,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public Task StartLoadingRemindersAsync(CancellationToken cancellationToken)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             this.loadRemindersTask = this.LoadRemindersAsync(cancellationToken);
             return this.loadRemindersTask;
@@ -452,7 +469,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public async Task FireReminderAsync(ActorReminder reminder)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             var rearmTimer = true;
 
@@ -539,7 +558,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public async Task DeleteActorAsync(string callContext, ActorId actorId, CancellationToken cancellationToken)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.ThrowIfMigrationInProgress();
+#pragma warning restore 618
 
             ExceptionDispatchInfo exceptionInfo = null;
 
@@ -1176,6 +1197,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             }
         }
 
+        [Obsolete(Actors.DeprecationMessage.StateMigration)]
         private void ThrowIfMigrationInProgress()
         {
             this.ActorService.ThrowIfActorCallsDisallowed();

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorService.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorService.cs
@@ -45,6 +45,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         private ReplicaRole replicaRole;
         private Remoting.V2.Runtime.ActorMethodDispatcherMap methodDispatcherMapV2;
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         private IMigrationOrchestrator migrationOrchestrator;
 
         /// <summary>
@@ -63,6 +64,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = null,
             IActorStateProvider stateProvider = null,
             ActorServiceSettings settings = null)
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             : this(
                 context,
                 actorTypeInfo,
@@ -71,9 +73,11 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 stateManagerFactory,
                 stateProvider,
                 settings)
+#pragma warning restore 618
         {
         }
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal ActorService(
            StatefulServiceContext context,
            ActorTypeInformation actorTypeInfo,
@@ -97,6 +101,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         {
         }
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal ActorService(
             StatefulServiceContext context,
             ActorTypeInformation actorTypeInfo,
@@ -198,6 +203,8 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         }
 
         #region Migration
+
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal bool AreActorCallsAllowed
         {
             get
@@ -211,6 +218,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             }
         }
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal bool IsActorCallToBeForwarded
         {
             get
@@ -224,7 +232,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             }
         }
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal IMigrationOrchestrator MigrationOrchestrator { get => this.migrationOrchestrator; }
+
         #endregion Migration
 
         #region IActorService Members
@@ -337,11 +347,14 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         }
 
         #region Migration
+
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal bool IsConfiguredForMigration()
         {
             return this.migrationOrchestrator != null;
         }
 
+        [Obsolete(DeprecationMessage.StateMigration)]
         internal void ThrowIfActorCallsDisallowed()
         {
             if (this.migrationOrchestrator != null)
@@ -349,6 +362,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 this.migrationOrchestrator.ThrowIfActorCallsDisallowed();
             }
         }
+
         #endregion Migration
 
         #region StatefulServiceBase Overrides
@@ -387,7 +401,9 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 }
             }
 
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             this.AddMigrationListener(serviceReplicaListeners);
+#pragma warning restore 618
 
             return serviceReplicaListeners;
         }
@@ -397,6 +413,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         /// </summary>
         /// <param name="serviceReplicaListeners">Existing listener list.</param>
         /// <remarks>To be used when CreateServiceReplicaListeners() is overriden by Custom implementation of Actor Service.</remarks>
+        [Obsolete(DeprecationMessage.StateMigration)]
         protected void AddMigrationListener(IList<ServiceReplicaListener> serviceReplicaListeners)
         {
             // Add migration endpoint
@@ -424,10 +441,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         /// </remarks>
         protected override async Task RunAsync(CancellationToken cancellationToken)
         {
+#pragma warning disable 618 // [Obsolete(DeprecationMessage.StateMigration)]
             if (this.migrationOrchestrator != null)
             {
                 await this.migrationOrchestrator.StartMigrationAsync(false, cancellationToken);
             }
+#pragma warning restore 618
             else
             {
                 await this.ActorManager.StartLoadingRemindersAsync(cancellationToken);

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/AmbiguousActorIdResolverAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/AmbiguousActorIdResolverAttribute.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     /// There can be more than one class annotated with this attribute. In that case, all the resolvers will be tried in order.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class AmbiguousActorIdResolverAttribute : Attribute
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/IAmbiguousActorIdResolver.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/IAmbiguousActorIdResolver.cs
@@ -3,12 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
 {
     /// <summary>
     /// Interface to resolve actorId from storage key incase there is any ambiguity.
     /// The implementation should have a default constructor.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public interface IAmbiguousActorIdResolver
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/IMigrationOrchestrator.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/IMigrationOrchestrator.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     /// <summary>
     /// Interface definition for migraiton operations./>.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal interface IMigrationOrchestrator
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationMode.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationMode.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     /// <summary>
     /// Migration Mode.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public enum MigrationMode
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Generator;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal static class MigrationReflectionHelper
     {
         private static readonly string TraceType = typeof(MigrationReflectionHelper).Name;

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationSettings.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationSettings.cs
@@ -11,6 +11,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     using Microsoft.ServiceFabric.Actors.Migration.Exceptions;
 
     [DataContract]
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class MigrationSettings
     {
         private static readonly string TraceType = typeof(MigrationSettings).ToString();

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/RequestForwardableRemotingDispatcher.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/RequestForwardableRemotingDispatcher.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     using Microsoft.ServiceFabric.Services.Remoting.V2;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
 
+    [Obsolete(DeprecationMessage.StateMigration)]
     internal class RequestForwardableRemotingDispatcher : IServiceRemotingMessageHandler, IDisposable
     {
         private static readonly string TraceType = typeof(RequestForwardableRemotingDispatcher).Name;

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/StateMigration.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/StateMigration.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
 {
     /// <summary>
     /// Indicates actor service migration state.
     /// </summary>
+    [Obsolete(DeprecationMessage.StateMigration)]
     public enum StateMigration
     {
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/StateMigrationAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/StateMigrationAttribute.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
     /// Indicates whether the actor service participates in state migration.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [Obsolete(DeprecationMessage.StateMigration)]
     public sealed class StateMigrationAttribute : Attribute
     {
         /// <summary>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>Microsoft.ServiceFabric.Actors.StateMigration.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>net9.0</TargetFramework>
+    <!-- State migration APIs are obsolete and will be removed. -->
+    <NoWarn>618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />


### PR DESCRIPTION
Actor state migration is very complex, requires elaborate implementation and orchestration in user applications and doesn't solve the problem for non-Actor stateful services. Because of this the data migration from KVS to RC will be handled by the Data stack transparently for the customer applications. 

This PR deprecates all migration-related APIs. #491 completes their removal.

Most of the changes are a straightforward removal of the migration APIs and their implementation with the exception of the `FabricTransportActorServiceRemotingListener`, where public constructors with migration-related parameters were removed  These changes need to be reviewed together with #491 to make sure that remaining constructors are correct. 

Bump internal package version to 8.0.16 for integration with WindowsFabric.

This resolves #450