### PR TITLE
Remove Services.Tests.csproj from list of test projects in netframework.targets

### DIFF
--- a/properties/service_fabric_managed_netframework.targets
+++ b/properties/service_fabric_managed_netframework.targets
@@ -13,7 +13,6 @@
 
     <Projects_Test_netframework Include="$(RepoRoot)test\Microsoft.ServiceFabric.Actors.Tests\Microsoft.ServiceFabric.Actors.Tests.csproj;
                                    $(RepoRoot)test\Microsoft.ServiceFabric.Services.Remoting.Tests\Microsoft.ServiceFabric.Services.Remoting.Tests.csproj;
-                                   $(RepoRoot)test\Microsoft.ServiceFabric.Services.Tests\Microsoft.ServiceFabric.Services.Tests.csproj;
                                    $(RepoRoot)test\Microsoft.ServiceFabric.Diagnostics.Tests\Microsoft.ServiceFabric.Diagnostics.Tests.csproj;
                                    $(RepoRoot)test\Microsoft.ServiceFabric.Actors.IntegrationTests\Microsoft.ServiceFabric.Actors.IntegrationTests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This project doesn't target net472 and fails to build in the ADO pipeline due to a missing Main entry point. It is not clear why this error doesn't happen during GitHub builds, however since we're removing the old build infrastructure, it's probably not worth the effort to get to the root cause of this.