### PR TITLE
Integrate platform neutral WindowsFabric packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,9 +24,9 @@
         <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
         <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.474-beta" />
-        <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="9.0.474-beta" />
-        <PackageVersion Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="9.0.474-beta" />
+        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.520-beta" />
+        <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="9.0.520-beta" />
+        <PackageVersion Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="9.0.520-beta" />
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" /> <!-- Transitive dependency -->
         <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />

--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -7,10 +7,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' ">true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
-    <NoWarn></NoWarn>
     <Platforms>AnyCPU</Platforms>
-    <!-- Temporarily disable platform warnings until WindowsFabric assemblies are changed from net8.0-windows to net8.0 -->
-    <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
 
   <!-- Assembly name, title and documentation -->


### PR DESCRIPTION
Reference build 520 of the packages produced from the WindowsFabric repo. In this version, the net8.0 binaries are no longer net8.0-windows, don't produce the CA1416 warnings and don't need their suppressions.