### PR TITLE
Make Microsoft.ServiceFabric.Actors package final FabActUtil

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
+++ b/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
@@ -30,11 +30,11 @@
     <Content Include="build/**" PackagePath="build" />
   </ItemGroup>
   <Target Name="PackageContent" Outputs="@(TfmSpecificPackageFile)">
-    <MSBuild Projects="..\FabActUtil\FabActUtil.csproj" Targets="_GetBuildOutputFilesWithTfm">
-      <Output TaskParameter="TargetOutputs" ItemName="TfmSpecificPackageFile" />
+    <MSBuild Projects="..\FabActUtil\FabActUtil.csproj" Targets="BuiltProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="FabActUtilIntermediateOutput" />
     </MSBuild>
     <ItemGroup>
-      <TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="@(FabActUtilIntermediateOutput->'%(FinalOutputPath)')">
         <PackagePath>build\$(TargetFramework)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>


### PR DESCRIPTION
The Pack target appears to have additional logic to transform the BuildOutputInPackage
items from their intermediate to the final output paths. However, for the
TfmSepecificPackageFile items, it uses the original item specification.

The previous version of the PackageContent target used final version of
the Microsoft.ServiceFabric.Actors assembly and the intermediate version
of the FabActUtil. Since the the ADO build pipeline will be signing the
final build outputs only, this would leave the FabActUtil.exe/.dll unsigned.

The new version of the PackageContent target uses the publicly-documented
BuiltProjectOutputGroup target instead of the internal _GetBuildOutputFilesWithTfm.
Both targets return the intermediate project outputs, which have to be
transformed to their final output paths explicitly.