### PR TITLE
Temporarily use NullMeterProvider and better align package versioning with SemVer

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -10,9 +10,9 @@
     <!-- Major Version for Microsoft.ServiceFabric.Diagnostics binary - Bump together with normal MajorVersion -->
     <!-- We migrated Diagnostics package from WindowsFabric repo and we need to keep the versioning consistent -->
     <MajorVersion Condition="'$(MSBuildProjectName)' == 'Microsoft.ServiceFabric.Diagnostics'">12</MajorVersion>
-    <MinorVersion>12</MinorVersion>
+    <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>0</Revision>
+    <Revision>13</Revision>
 
   </PropertyGroup>
 </Project>

--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -50,7 +50,7 @@
   <PropertyGroup>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <PackageVersionSuffix>-beta</PackageVersionSuffix>
-    <Version>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)$(PackageVersionSuffix)</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(BuildVersion)$(PackageVersionSuffix).$(Revision)</Version>
     <AssemblyFileVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)</AssemblyFileVersion>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)</FileVersion>
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Fabric;
 using System.Fabric.Common;
@@ -132,7 +133,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 new ExceptionSerializer(svcExceptionConvertors, remotingSettings),
                 serviceContext.PartitionId,
                 serviceContext.ReplicaOrInstanceId,
-                new TimeSpanMeterProvider(serviceContext));
+                new NullMeterProvider<TimeSpan>());
 
             this.fabricTransportlistener = new FabricTransportListener(
                 remotingSettings.GetInternalSettings(),


### PR DESCRIPTION
- Temporarily switch FabricTransportServiceRemotingListener to NullMeterProvider
This will allow integrating GitHub changes without having to wait for completion of the FabricTelemetry.dll

- Generate package versions in Major.Minor.Build-beta.Revision format
This is better aligned with SemVer than the previous Major.Minor.Build-beta format. It also allows us to increment the Revision number without "burning" the Minor build number for internal releases.

- Switch internal package versioning from Minor version to Revision
Specifically, from 9/12.12.0.0 to 9/12.0.0.13. This will produce package versions 9/12.0.0-beta.13
 


