### PR TITLE
Bump revision number for a new build version 9/12.0.0-beta.15

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -12,7 +12,7 @@
     <MajorVersion Condition="'$(MSBuildProjectName)' == 'Microsoft.ServiceFabric.Diagnostics'">12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>14</Revision>
+    <Revision>15</Revision>
 
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
-beta.14 symbols didn't get published correctly. A new build is needed to make debugging of ComWrappers easier.