### PR TITLE
Rename classes implementing IDiagnostic

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/AggregatedDiagnostics.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/AggregatedDiagnostics.cs
@@ -10,11 +10,11 @@ using System.Linq;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class AggregatedDiagnosticEvents : IDiagnostics
+    sealed class AggregatedDiagnostics : IDiagnostics
     {
         readonly IEnumerable<IDiagnostics> diagnosticEvents;
 
-        internal AggregatedDiagnosticEvents(IEnumerable<IDiagnostics> diagnosticEvents)
+        internal AggregatedDiagnostics(IEnumerable<IDiagnostics> diagnosticEvents)
         {
             _ = diagnosticEvents ?? throw new ArgumentNullException(nameof(diagnosticEvents));
             if (diagnosticEvents.Any(d => d == null))

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/DiagnosticsFactory.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/DiagnosticsFactory.cs
@@ -31,11 +31,11 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
         public virtual IDiagnostics CreateDiagnostics(IClock clock)
         {
-            var performanceCounterDiagnosticEvents = new PerformanceCounterDiagnosticEvents(performanceCounterProvider, clock);
-            var eventSourceDiagnosticEvents = new EventSourceDiagnosticEvents(ActorFrameworkEventSource.Writer, clock, serviceContext, friendlyNameBuilder, typeInformation);
-            var registeredDiagnosticsEvents = new List<IDiagnostics> { performanceCounterDiagnosticEvents, eventSourceDiagnosticEvents };
+            var performanceCounterDiagnostics = new PerformanceCounterDiagnostics(performanceCounterProvider, clock);
+            var eventSourceDiagnostics = new EventSourceDiagnostics(ActorFrameworkEventSource.Writer, clock, serviceContext, friendlyNameBuilder, typeInformation);
+            var registeredDiagnostics = new List<IDiagnostics> { performanceCounterDiagnostics, eventSourceDiagnostics };
 
-            return new AggregatedDiagnosticEvents(registeredDiagnosticsEvents);
+            return new AggregatedDiagnostics(registeredDiagnostics);
         }
 
         public virtual void Dispose()

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/EventSourceDiagnostics.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/EventSourceDiagnostics.cs
@@ -12,7 +12,7 @@ using Microsoft.ServiceFabric.Services.Remoting.Description;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class EventSourceDiagnosticEvents : IDiagnostics
+    sealed class EventSourceDiagnostics : IDiagnostics
     {
         readonly ActorFrameworkEventSource eventSource;
         readonly ServiceContext serviceContext;
@@ -20,7 +20,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         readonly string actorType;
         readonly Dictionary<long, ActorMethodInfo> actorMethodInfo;
 
-        internal EventSourceDiagnosticEvents(ActorFrameworkEventSource eventSource, IClock clock, ServiceContext serviceContext, ActorMethodFriendlyNameBuilder nameBuilder, ActorTypeInformation typeInfo)
+        internal EventSourceDiagnostics(ActorFrameworkEventSource eventSource, IClock clock, ServiceContext serviceContext, ActorMethodFriendlyNameBuilder nameBuilder, ActorTypeInformation typeInfo)
         {
             this.eventSource = eventSource ?? throw new ArgumentNullException(nameof(eventSource));
             this.serviceContext = serviceContext ?? throw new ArgumentNullException(nameof(serviceContext));

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/PerformanceCounterDiagnostics.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/PerformanceCounterDiagnostics.cs
@@ -9,12 +9,12 @@ using Microsoft.ServiceFabric.Diagnostics;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class PerformanceCounterDiagnosticEvents : IDiagnostics
+    sealed class PerformanceCounterDiagnostics : IDiagnostics
     {
         readonly PerformanceCounterProviderV2 performanceCounterProvider;
         readonly IClock clock;
 
-        internal PerformanceCounterDiagnosticEvents(PerformanceCounterProviderV2 performanceCounterProvider, IClock clock)
+        internal PerformanceCounterDiagnostics(PerformanceCounterProviderV2 performanceCounterProvider, IClock clock)
         {
             this.performanceCounterProvider = performanceCounterProvider ?? throw new ArgumentNullException(nameof(performanceCounterProvider));
             this.clock = clock ?? throw new ArgumentNullException(nameof(clock));

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/MockActorManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         private readonly ActorEventSource traceSource;
 
         private IActorEventManager eventManager;
-        private IDiagnostics diagnosticEvents;
+        private IDiagnostics diagnostics;
 
         internal MockActorManager(ActorService actorService)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             this.remindersByActorId = new ConcurrentDictionary<ActorId, ConcurrentDictionary<string, ActorReminder>>();
             this.traceSource = ActorEventSource.Instance;
             this.IsClosed = false;
-            this.diagnosticEvents = new AggregatedDiagnosticEvents(Enumerable.Empty<IDiagnostics>());
+            this.diagnostics = new AggregatedDiagnostics(Enumerable.Empty<IDiagnostics>());
         }
 
         public bool IsClosed { get; private set; }
@@ -58,7 +58,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             get { return this.actorService.StateProvider; }
         }
 
-        public IDiagnostics DiagnosticsEvents { get => this.diagnosticEvents; }
+        public IDiagnostics DiagnosticsEvents { get => this.diagnostics; }
 
         public Task OpenAsync(IServicePartition partition, CancellationToken cancellationToken)
         {

--- a/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/AggregatedDiagnosticsTest.cs
+++ b/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/AggregatedDiagnosticsTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    public abstract class AggregatedDiagnosticEventsTest
+    public abstract class AggregatedDiagnosticsTest
     {
         internal interface ITestDiagnosticEvents : IDiagnostics { }
 
@@ -23,8 +23,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
         readonly IDiagnostics sut;
 
-        readonly IDiagnostics diagnosticEvent = Mock.Of<IDiagnostics>();
-        readonly IDiagnostics anotherDiagnosticEvents = Mock.Of<ITestDiagnosticEvents>();
+        readonly IDiagnostics diagnostics = Mock.Of<IDiagnostics>();
+        readonly IDiagnostics anotherDiagnostics = Mock.Of<ITestDiagnosticEvents>();
 
         readonly ActorId actorId = fuzzy.ActorId();
         readonly long interfaceMethodKey = fuzzy.Int64();
@@ -32,28 +32,28 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         readonly PendingActorMethodDiagnosticData pendingActorMethodDiagnosticData = default;
         readonly ActorMethodDiagnosticData actorMethodDiagnosticData = default;
 
-        public AggregatedDiagnosticEventsTest() => sut = new AggregatedDiagnosticEvents(new List<IDiagnostics> { diagnosticEvent, anotherDiagnosticEvents });
+        public AggregatedDiagnosticsTest() => sut = new AggregatedDiagnostics(new List<IDiagnostics> { diagnostics, anotherDiagnostics });
 
-        public sealed class Constructor : AggregatedDiagnosticEventsTest
+        public sealed class Constructor : AggregatedDiagnosticsTest
         {
             [Fact]
             public void ThrowsOnNullEventsList()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new AggregatedDiagnosticEvents(null));
+                var exception = Assert.Throws<ArgumentNullException>(() => new AggregatedDiagnostics(null));
                 Assert.Equal("diagnosticEvents", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnAnyNullEvents()
             {
-                var exception = Assert.Throws<ArgumentException>(() => new AggregatedDiagnosticEvents(new List<IDiagnostics> { diagnosticEvent, null }));
+                var exception = Assert.Throws<ArgumentException>(() => new AggregatedDiagnostics(new List<IDiagnostics> { diagnostics, null }));
                 Assert.Equal("diagnosticEvents", exception.Message);
             }
 
             [Fact]
             public void AssignsEmptyEvent()
             {
-                var newSut = new AggregatedDiagnosticEvents(new List<IDiagnostics>());
+                var newSut = new AggregatedDiagnostics(new List<IDiagnostics>());
 
                 Assert.NotNull(newSut.Field<IEnumerable<IDiagnostics>>());
                 Assert.Empty(newSut.Field<IEnumerable<IDiagnostics>>().Value);
@@ -62,7 +62,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             [Fact]
             public void AssignsSingleEvent()
             {
-                var newSut = new AggregatedDiagnosticEvents(new List<IDiagnostics>() { diagnosticEvent });
+                var newSut = new AggregatedDiagnostics(new List<IDiagnostics>() { diagnostics });
 
                 Assert.NotNull(newSut.Field<IEnumerable<IDiagnostics>>());
                 Assert.Single(newSut.Field<IEnumerable<IDiagnostics>>().Value);
@@ -79,15 +79,15 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             }
         }
 
-        public sealed class ActorRequestProcessing : AggregatedDiagnosticEventsTest
+        public sealed class ActorRequestProcessing : AggregatedDiagnosticsTest
         {
             [Fact]
             public void StartInvokesAllDiagnostics()
             {
                 sut.ActorRequestProcessingStart();
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorRequestProcessingStart(), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorRequestProcessingStart(), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorRequestProcessingStart(), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorRequestProcessingStart(), Times.Once);
             }
 
             [Fact]
@@ -95,20 +95,20 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.ActorRequestProcessingFinish(startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorRequestProcessingFinish(startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorRequestProcessingFinish(startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorRequestProcessingFinish(startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorRequestProcessingFinish(startTime), Times.Once);
             }
         }
 
-        public sealed class ActorOnActivateAsync : AggregatedDiagnosticEventsTest
+        public sealed class ActorOnActivateAsync : AggregatedDiagnosticsTest
         {
             [Fact]
             public void StartInvokesAllDiagnostics()
             {
                 sut.ActorOnActivateAsyncStart();
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorOnActivateAsyncStart(), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorOnActivateAsyncStart(), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorOnActivateAsyncStart(), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorOnActivateAsyncStart(), Times.Once);
             }
 
             [Fact]
@@ -116,20 +116,20 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.ActorOnActivateAsyncFinish(startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorOnActivateAsyncFinish(startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorOnActivateAsyncFinish(startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorOnActivateAsyncFinish(startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorOnActivateAsyncFinish(startTime), Times.Once);
             }
         }
 
-        public sealed class ActorMethod : AggregatedDiagnosticEventsTest
+        public sealed class ActorMethod : AggregatedDiagnosticsTest
         {
             [Fact]
             public void StartInvokesAllDiagnostics()
             {
                 sut.ActorMethodStart(actorId, interfaceMethodKey);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorMethodStart(actorId, interfaceMethodKey), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorMethodStart(actorId, interfaceMethodKey), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorMethodStart(actorId, interfaceMethodKey), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorMethodStart(actorId, interfaceMethodKey), Times.Once);
             }
 
             [Fact]
@@ -139,20 +139,20 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
                 sut.ActorMethodFinish(actorMethodDiagnosticData, startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorMethodFinish(actorMethodDiagnosticData, startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorMethodFinish(actorMethodDiagnosticData, startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorMethodFinish(actorMethodDiagnosticData, startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorMethodFinish(actorMethodDiagnosticData, startTime), Times.Once);
             }
         }
 
-        public sealed class ActorStateLoad : AggregatedDiagnosticEventsTest
+        public sealed class ActorStateLoad : AggregatedDiagnosticsTest
         {
             [Fact]
             public void StartInvokesAllDiagnostics()
             {
                 sut.LoadActorStateStart();
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.LoadActorStateStart(), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.LoadActorStateStart(), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.LoadActorStateStart(), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.LoadActorStateStart(), Times.Once);
             }
 
             [Fact]
@@ -160,8 +160,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.LoadActorStateFinish(startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.LoadActorStateFinish(startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.LoadActorStateFinish(startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.LoadActorStateFinish(startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.LoadActorStateFinish(startTime), Times.Once);
             }
 
             [Fact]
@@ -169,8 +169,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.SaveActorStateStart(actorId);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.SaveActorStateStart(actorId), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.SaveActorStateStart(actorId), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.SaveActorStateStart(actorId), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.SaveActorStateStart(actorId), Times.Once);
             }
 
             [Fact]
@@ -178,20 +178,20 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.SaveActorStateFinish(actorId, startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.SaveActorStateFinish(actorId, startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.SaveActorStateFinish(actorId, startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.SaveActorStateFinish(actorId, startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.SaveActorStateFinish(actorId, startTime), Times.Once);
             }
         }
 
-        public sealed class ActorLock : AggregatedDiagnosticEventsTest
+        public sealed class ActorLock : AggregatedDiagnosticsTest
         {
             [Fact]
             public void AcquireFinishInvokesAllDiagnostics()
             {
                 sut.AcquireActorLockFinish(pendingActorMethodDiagnosticData, startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.AcquireActorLockFinish(pendingActorMethodDiagnosticData, startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.AcquireActorLockFinish(pendingActorMethodDiagnosticData, startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.AcquireActorLockFinish(pendingActorMethodDiagnosticData, startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.AcquireActorLockFinish(pendingActorMethodDiagnosticData, startTime), Times.Once);
             }
 
             [Fact]
@@ -199,12 +199,12 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.ReleaseActorLock(startTime);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ReleaseActorLock(startTime), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ReleaseActorLock(startTime), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ReleaseActorLock(startTime), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ReleaseActorLock(startTime), Times.Once);
             }
         }
 
-        public sealed class ActorLifecycle : AggregatedDiagnosticEventsTest
+        public sealed class ActorLifecycle : AggregatedDiagnosticsTest
         {
             [Fact]
             public void ChangeRoleInvokesAllDiagnostics()
@@ -214,8 +214,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
                 sut.ActorChangeRole(currentRole, newRole);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorChangeRole(currentRole, newRole), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorChangeRole(currentRole, newRole), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorChangeRole(currentRole, newRole), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorChangeRole(currentRole, newRole), Times.Once);
             }
 
             [Fact]
@@ -223,8 +223,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.ActorActivated(actorId);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorActivated(actorId), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorActivated(actorId), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorActivated(actorId), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorActivated(actorId), Times.Once);
             }
 
             [Fact]
@@ -232,8 +232,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.ActorDeactivated(actorId);
 
-                Mock.Get(diagnosticEvent).Verify(ds => ds.ActorDeactivated(actorId), Times.Once);
-                Mock.Get(anotherDiagnosticEvents).Verify(ds => ds.ActorDeactivated(actorId), Times.Once);
+                Mock.Get(diagnostics).Verify(ds => ds.ActorDeactivated(actorId), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorDeactivated(actorId), Times.Once);
             }
         }
     }

--- a/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/DiagnosticsFactoryTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             [Fact]
             public void CreatesAggregatedDiagnostics()
             {
-                Assert.IsAssignableFrom<AggregatedDiagnosticEvents>(diagnostics);
+                Assert.IsAssignableFrom<AggregatedDiagnostics>(diagnostics);
             }
 
             [Fact]
@@ -120,7 +120,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 var perfCounterDiagnotics = diagnostics.Field<IEnumerable<IDiagnostics>>().Value.First();
 
-                Assert.IsAssignableFrom<PerformanceCounterDiagnosticEvents>(perfCounterDiagnotics);
+                Assert.IsAssignableFrom<PerformanceCounterDiagnostics>(perfCounterDiagnotics);
                 Assert.Equal(sut.Field<PerformanceCounterProviderV2>().Value, perfCounterDiagnotics.Field<PerformanceCounterProviderV2>().Value);
                 Assert.Equal(clock, perfCounterDiagnotics.Field<IClock>().Value);
             }
@@ -130,7 +130,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 var eventSourceDiagnostics = diagnostics.Field<IEnumerable<IDiagnostics>>().Value.Last();
 
-                Assert.IsAssignableFrom<EventSourceDiagnosticEvents>(eventSourceDiagnostics);
+                Assert.IsAssignableFrom<EventSourceDiagnostics>(eventSourceDiagnostics);
                 Assert.Equal(ActorFrameworkEventSource.Writer, eventSourceDiagnostics.Field<ActorFrameworkEventSource>().Value);
                 Assert.Equal(serviceContext, eventSourceDiagnostics.Field<ServiceContext>().Value);
                 Assert.Equal(clock, eventSourceDiagnostics.Field<IClock>().Value);

--- a/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/EventSourceDiagnosticsTest.cs
+++ b/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/EventSourceDiagnosticsTest.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
 {
-    public class EventSourceDiagnosticEventsTest : IDisposable
+    public class EventSourceDiagnosticsTest : IDisposable
     {
         static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
 
@@ -32,14 +32,14 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
         readonly ActorMethodFriendlyNameBuilder nameBuilder;
         readonly ServiceContext serviceContext = fuzzy.ServiceContext();
 
-        public EventSourceDiagnosticEventsTest()
+        public EventSourceDiagnosticsTest()
         {
             // Prevent Linux specific code path in ServiceFabricEventSource as it is not a part of tested logic
             typeof(ServiceFabricEventSource).Field<Func<OSPlatform, bool>>().Set((os) => false);
             eventSource = Mock.Of<ActorFrameworkEventSource>();
             nameBuilder = new ActorMethodFriendlyNameBuilder(typeInfo);
 
-            sut = new EventSourceDiagnosticEvents(eventSource, clock, serviceContext, nameBuilder, typeInfo);
+            sut = new EventSourceDiagnostics(eventSource, clock, serviceContext, nameBuilder, typeInfo);
 
             Mock.Get(eventSource).Setup(eventSource => eventSource.IsActorSaveStateStartEventEnabled()).Returns(true);
             Mock.Get(eventSource).Setup(eventSource => eventSource.IsActorSaveStateStopEventEnabled()).Returns(true);
@@ -54,7 +54,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
             typeof(ServiceFabricEventSource).Field<Func<OSPlatform, bool>>().Set(RuntimeInformation.IsOSPlatform);
         }
 
-        public class Constructor : EventSourceDiagnosticEventsTest
+        public class Constructor : EventSourceDiagnosticsTest
         {
             [Fact]
             public void WithParametersSetsValue()
@@ -75,35 +75,35 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
             [Fact]
             public void ThrowsOnNullTypeInfo()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnosticEvents(eventSource, clock, serviceContext, nameBuilder, null));
+                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnostics(eventSource, clock, serviceContext, nameBuilder, null));
                 Assert.Equal("typeInfo", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnNullNameBuilder()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnosticEvents(eventSource, clock, serviceContext, null, typeInfo));
+                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnostics(eventSource, clock, serviceContext, null, typeInfo));
                 Assert.Equal("nameBuilder", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnNullClock()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnosticEvents(eventSource, null, serviceContext, nameBuilder, typeInfo));
+                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnostics(eventSource, null, serviceContext, nameBuilder, typeInfo));
                 Assert.Equal("clock", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnNullEventSource()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnosticEvents(null, clock, serviceContext, nameBuilder, typeInfo));
+                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnostics(null, clock, serviceContext, nameBuilder, typeInfo));
                 Assert.Equal("eventSource", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnNullServiceContext()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnosticEvents(eventSource, clock, null, nameBuilder, typeInfo));
+                var exception = Assert.Throws<ArgumentNullException>(() => new EventSourceDiagnostics(eventSource, clock, null, nameBuilder, typeInfo));
                 Assert.Equal("serviceContext", exception.ParamName);
             }
 
@@ -114,7 +114,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
             }
         }
 
-        public class OnEvents : EventSourceDiagnosticEventsTest
+        public class OnEvents : EventSourceDiagnosticsTest
         {
             readonly long interfaceMethodKey = fuzzy.Int64();
             readonly ActorId actorId = fuzzy.ActorId();

--- a/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/PerformanceCounterDiagnosticsTest.cs
+++ b/test/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/PerformanceCounterDiagnosticsTest.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    public class PerformanceCounterDiagnosticEventsTest
+    public class PerformanceCounterDiagnosticsTest
     {
         readonly static IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
 
@@ -30,9 +30,9 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         readonly static ActorTypeInformation actorTypeInfo = ActorTypeInformation.Get(typeof(TestActor));
         readonly PerformanceCounterProviderV2 performanceCounterProvider = new PerformanceCounterProviderV2(Guid.NewGuid(), actorTypeInfo);
 
-        protected PerformanceCounterDiagnosticEventsTest() => sut = new PerformanceCounterDiagnosticEvents(performanceCounterProvider, clock);
+        protected PerformanceCounterDiagnosticsTest() => sut = new PerformanceCounterDiagnostics(performanceCounterProvider, clock);
 
-        public class Constructor : PerformanceCounterDiagnosticEventsTest
+        public class Constructor : PerformanceCounterDiagnosticsTest
         {
             [Fact]
             public void WithParametersSetsValue()
@@ -47,19 +47,19 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             [Fact]
             public void ThrowsOnNullProvider()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new PerformanceCounterDiagnosticEvents(null, clock));
+                var exception = Assert.Throws<ArgumentNullException>(() => new PerformanceCounterDiagnostics(null, clock));
                 Assert.Equal("performanceCounterProvider", exception.ParamName);
             }
 
             [Fact]
             public void ThrowsOnNullClock()
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new PerformanceCounterDiagnosticEvents(performanceCounterProvider, null));
+                var exception = Assert.Throws<ArgumentNullException>(() => new PerformanceCounterDiagnostics(performanceCounterProvider, null));
                 Assert.Equal("clock", exception.ParamName);
             }
         }
 
-        public class OnEvents : PerformanceCounterDiagnosticEventsTest
+        public class OnEvents : PerformanceCounterDiagnosticsTest
         {
             readonly FabricAverageCount64PerformanceCounterWriter actorRequestProcessingTimeCounterWriter = Mock.Of<FabricAverageCount64PerformanceCounterWriter>();
             readonly FabricAverageCount64PerformanceCounterWriter actorLockAcquireWaitTimeCounterWriter = Mock.Of<FabricAverageCount64PerformanceCounterWriter>();


### PR DESCRIPTION
Recently we renamed `IDiagnosticEvents` interface into `IDiagnostics`

Bring names of classes implementing this interface in line with the new name.