### PR TITLE
Add System.Fabric.Common.Test to assemblyinfo

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -12,7 +12,7 @@
     <MajorVersion Condition="'$(MSBuildProjectName)' == 'Microsoft.ServiceFabric.Diagnostics'">12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>16</Revision>
+    <Revision>17</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Diagnostics/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Diagnostics/AssemblyInfo.cs
@@ -43,6 +43,8 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("BackupCopier" + TestKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + TestKey)]
+[assembly: InternalsVisibleTo("System.Fabric.Common.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("System.Fabric.Common.Test" + TestKey)]
 
 [assembly: InternalsVisibleTo("FabricIS.parallel" + PublicKey)]
 [assembly: InternalsVisibleTo("FabricIS.parallel" + TestKey)]


### PR DESCRIPTION
This PR adds InternalsVisibleTo attributes to allow the `System.Fabric.Common.Test` assembly to access internal members of the `Microsoft.ServiceFabric.Diagnostics` assembly used in tests.