### PR TITLE
Reintroduce .NET 8 tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: dotnet build -bl:"$Logs/build.binLog"
+      - run: dotnet test --no-build --logger trx --framework net8.0 -bl:"$Logs/test.binLog"
+      - run: dotnet test --no-build --logger trx --framework net9.0 -bl:"$Logs/test.binLog"
       - run: dotnet test --no-build --logger trx --framework net10.0 -bl:"$Logs/test.binLog"
       - run: dotnet pack --no-build -bl:"$Logs/pack.binLog"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: dotnet build -bl:"$Logs/build.binLog"
-      - run: dotnet test --no-build --logger trx --framework net8.0 -bl:"$Logs/test.binLog"
-      - run: dotnet test --no-build --logger trx --framework net9.0 -bl:"$Logs/test.binLog"
-      - run: dotnet test --no-build --logger trx --framework net10.0 -bl:"$Logs/test.binLog"
+      - run: dotnet test --no-build --logger trx --framework net8.0 -bl:"$Logs/test-net8.binLog"
+      - run: dotnet test --no-build --logger trx --framework net9.0 -bl:"$Logs/test-net9.binLog"
+      - run: dotnet test --no-build --logger trx --framework net10.0 -bl:"$Logs/test-net10.binLog"
       - run: dotnet pack --no-build -bl:"$Logs/pack.binLog"
       - uses: actions/upload-artifact@v4
         if: always()

--- a/test/Microsoft.ServiceFabric.Actors.IntegrationTests/Microsoft.ServiceFabric.Actors.IntegrationTests.csproj
+++ b/test/Microsoft.ServiceFabric.Actors.IntegrationTests/Microsoft.ServiceFabric.Actors.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>788378DE-D58E-3914-CE90-3498F7365C4F</ProjectGuid>
-    <TargetFrameworks>net10.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{63B58D31-66BB-4879-B4F1-0969FA3F4464}</ProjectGuid>
-    <TargetFrameworks>net10.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.Diagnostics.Tests/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Microsoft.ServiceFabric.Diagnostics.Tests/Metrics/Implementation/MeterProviderTest.cs
@@ -59,8 +59,8 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             {
                 var sut = new TestMeterProvider<int>(null);
 
-                var actualSystemDimensionNames = (string[])sut.Private().Field<IEnumerable<string>>().Value;
-                var actualSystemDimensionValues = (string[])sut.Protected().Field<IEnumerable<string>>().Value;
+                var actualSystemDimensionNames = sut.Private().Field<IEnumerable<string>>().Value;
+                var actualSystemDimensionValues = sut.Protected().Field<IEnumerable<string>>().Value;
 
                 Assert.Empty(actualSystemDimensionValues);
                 Assert.Empty(actualSystemDimensionNames);

--- a/test/Microsoft.ServiceFabric.Diagnostics.Tests/Microsoft.ServiceFabric.Diagnostics.Tests.csproj
+++ b/test/Microsoft.ServiceFabric.Diagnostics.Tests/Microsoft.ServiceFabric.Diagnostics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{1BDC4681-FDBA-4E55-A247-5F779627A4D7}</ProjectGuid>
-    <TargetFrameworks>net10.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
+++ b/test/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <ProjectGuid>{AE4034AC-27BC-43B8-9176-068B4794E25E}</ProjectGuid>
-    <TargetFrameworks>net10.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{ECB3825D-B309-4C76-A20D-76544459F611}</ProjectGuid>
     <RootNamespace>Microsoft.ServiceFabric.Services</RootNamespace>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{ECB3825D-B309-4C76-A20D-76544459F611}</ProjectGuid>
     <RootNamespace>Microsoft.ServiceFabric.Services</RootNamespace>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />

--- a/test/Microsoft.ServiceFabric.TestFramework/Microsoft.ServiceFabric.TestFramework.csproj
+++ b/test/Microsoft.ServiceFabric.TestFramework/Microsoft.ServiceFabric.TestFramework.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{B8F12A3E-4C5D-4F6A-8B7C-9D1E2F3A4B5C}</ProjectGuid>
     <RootNamespace>Microsoft.ServiceFabric</RootNamespace>
-    <TargetFrameworks>net10.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />


### PR DESCRIPTION
### Overview
- .NET 8 is added to target frameworks for the following test projects:
  - Microsoft.ServiceFabric.Actors.IntegrationTests.csproj
  - Microsoft.ServiceFabric.Actors.Tests.csproj
  - Microsoft.ServiceFabric.Diagnostics.Tests.csproj
  - Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
  - Microsoft.ServiceFabric.Services.Tests.csproj
- Build `Microsoft.ServiceFabric.TestFramework` only for .NET 8 and .NET Framework 4.7
- .NET Framework 4.7 is added to target frameworks for Microsoft.ServiceFabric.Services.Tests.csproj (most likely omitted when migrating to SDK-style projects and using the `<TargetFrameworks>` property.
- Add steps to Linux test pipeline for running tests on .NET 8 and .NET 9 alongside .NET 10.

### Changes in testing logic
After adding .NET 8 to target frameworks for `Microsoft.ServiceFabric.Diagnostics.Tests`, the following failure started happening:
```
Message: 
System.InvalidCastException : Unable to cast object of type 'System.Linq.EmptyPartition`1[System.String]' to type 'System.String[]'.
  Stack Trace: 
Constructor.ThrowAnArgumentExceptionWhenServiceContextNull() line 62
RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```
Explicite casting to `string[]` has bee removed since `Assert.Empty()` can work with `IEnumerable<string>`