### PR TITLE
Fix PowerShell.Http module publishing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cSpell.words": [
+        "DSTS",
+        "netframework",
+        "netstandard",
+        "resx"
+    ]
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,11 @@
 <Project>
   <PropertyGroup>
-    <!-- Place all build outputs in the root of the repository instead of nested project directories -->
+    <!-- 
+      Place all build outputs in the root of the repository instead of nested project directories to
+      - speed up git clean operations,
+      - reduce the number of files to be signed by the official builds,
+      - detect transitive dependency conflicts as double-writes in the MSBuild structured .binlog.
+    -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)bin\</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <VSTestResultsDirectory>$(MSBuildThisFileDirectory)out\tests\</VSTestResultsDirectory>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
+  <!-- Set properties that require well-known properties not available in Directory.Build.props -->
 
   <!-- Common NuGet package settings -->
   <PropertyGroup Condition="'$(IsPackable)' == ''">
@@ -11,6 +12,11 @@
     <IncludeSymbols Condition="'$(IncludeSymbols)' == ''">true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Publish dependencies to the build output for signing -->
+    <PublishDir>$(OutputPath)</PublishDir>
   </PropertyGroup>
 
   <Target Name="UpdateTrxLogFileName" BeforeTargets="VSTest" Condition="'$(VSTestLogger)' == 'trx'" >

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>20</Revision>
+    <Revision>21</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Client.Http/Client.Http/Generated/Serialization/NamedRepartitionSchemeDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/NamedRepartitionSchemeDescriptionConverter.cs
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="NamedRepartitionSchemeDescription" />.
+    /// </summary>
+    internal class NamedRepartitionSchemeDescriptionConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static NamedRepartitionSchemeDescription Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static NamedRepartitionSchemeDescription GetFromJsonProperties(JsonReader reader)
+        {
+            var namesToAdd = default(IEnumerable<string>);
+            var namesToRemove = default(IEnumerable<string>);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("NamesToAdd", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    namesToAdd = reader.ReadList(JsonReaderExtensions.ReadValueAsString);
+                }
+                else if (string.Compare("NamesToRemove", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    namesToRemove = reader.ReadList(JsonReaderExtensions.ReadValueAsString);
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new NamedRepartitionSchemeDescription(
+                namesToAdd: namesToAdd,
+                namesToRemove: namesToRemove);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, NamedRepartitionSchemeDescription obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            writer.WriteProperty(obj.Kind, "Kind", RepartitionSchemeConverter.Serialize);
+            if (obj.NamesToAdd != null)
+            {
+                writer.WriteEnumerableProperty(obj.NamesToAdd, "NamesToAdd", (w, v) => writer.WriteStringValue(v));
+            }
+
+            if (obj.NamesToRemove != null)
+            {
+                writer.WriteEnumerableProperty(obj.NamesToRemove, "NamesToRemove", (w, v) => writer.WriteStringValue(v));
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/RepartitionSchemeConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/RepartitionSchemeConverter.cs
@@ -12,27 +12,27 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
     using Newtonsoft.Json.Linq;
 
     /// <summary>
-    /// Converter for <see cref="CompressionStrategy" />.
+    /// Converter for <see cref="RepartitionScheme" />.
     /// </summary>
-    internal class CompressionStrategyConverter
+    internal class RepartitionSchemeConverter
     {
         /// <summary>
         /// Gets the enum value by reading string value from reader.
         /// </summary>
         /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
         /// <returns>The enum Value.</returns>
-        public static CompressionStrategy? Deserialize(JsonReader reader)
+        public static RepartitionScheme? Deserialize(JsonReader reader)
         {
             var value = reader.ReadValueAsString();
-            var obj = default(CompressionStrategy);
+            var obj = default(RepartitionScheme);
 
-            if (string.Compare(value, "ZIP", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Compare(value, "Invalid", StringComparison.OrdinalIgnoreCase) == 0)
             {
-                obj = CompressionStrategy.ZIP;
+                obj = RepartitionScheme.Invalid;
             }
-            else if (string.Compare(value, "ZSTANDARD", StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Compare(value, "Named", StringComparison.OrdinalIgnoreCase) == 0)
             {
-                obj = CompressionStrategy.ZSTANDARD;
+                obj = RepartitionScheme.Named;
             }
 
             return obj;
@@ -43,18 +43,18 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
         /// </summary>
         /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
         /// <param name="value">The object to serialize to JSON.</param>
-        public static void Serialize(JsonWriter writer, CompressionStrategy? value)
+        public static void Serialize(JsonWriter writer, RepartitionScheme? value)
         {
             switch (value)
             {
-                case CompressionStrategy.ZIP:
-                    writer.WriteStringValue("ZIP");
+                case RepartitionScheme.Invalid:
+                    writer.WriteStringValue("Invalid");
                     break;
-                case CompressionStrategy.ZSTANDARD:
-                    writer.WriteStringValue("ZSTANDARD");
+                case RepartitionScheme.Named:
+                    writer.WriteStringValue("Named");
                     break;
                 default:
-                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type CompressionStrategy");
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type RepartitionScheme");
             }
         }
     }

--- a/src/Client.Http/Client.Http/Generated/Serialization/RepartitionSchemeDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/RepartitionSchemeDescriptionConverter.cs
@@ -1,0 +1,74 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="RepartitionSchemeDescription" />.
+    /// </summary>
+    internal class RepartitionSchemeDescriptionConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static RepartitionSchemeDescription Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static RepartitionSchemeDescription GetFromJsonProperties(JsonReader reader)
+        {
+            RepartitionSchemeDescription obj = null;
+            var propName = reader.ReadPropertyName();
+            if (!propName.Equals("Kind", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new JsonReaderException($"Incorrect discriminator property name {propName}, Expected discriminator property name is Kind.");
+            }
+
+            var propValue = reader.ReadValueAsString();
+            if (propValue.Equals("Named", StringComparison.OrdinalIgnoreCase))
+            {
+                obj = NamedRepartitionSchemeDescriptionConverter.GetFromJsonProperties(reader);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown Kind.");
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, RepartitionSchemeDescription obj)
+        {
+            var kind = obj.Kind;
+            if (kind.Equals(RepartitionScheme.Named))
+            {
+                NamedRepartitionSchemeDescriptionConverter.Serialize(writer, (NamedRepartitionSchemeDescription)obj);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown Kind.");
+            }
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/ServiceTagsConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/ServiceTagsConverter.cs
@@ -1,0 +1,84 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="ServiceTags" />.
+    /// </summary>
+    internal class ServiceTagsConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static ServiceTags Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static ServiceTags GetFromJsonProperties(JsonReader reader)
+        {
+            var tagsRequiredToPlace = default(IEnumerable<string>);
+            var tagsRequiredToRun = default(IEnumerable<string>);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("TagsRequiredToPlace", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    tagsRequiredToPlace = reader.ReadList(JsonReaderExtensions.ReadValueAsString);
+                }
+                else if (string.Compare("TagsRequiredToRun", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    tagsRequiredToRun = reader.ReadList(JsonReaderExtensions.ReadValueAsString);
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new ServiceTags(
+                tagsRequiredToPlace: tagsRequiredToPlace,
+                tagsRequiredToRun: tagsRequiredToRun);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, ServiceTags obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            if (obj.TagsRequiredToPlace != null)
+            {
+                writer.WriteEnumerableProperty(obj.TagsRequiredToPlace, "TagsRequiredToPlace", (w, v) => writer.WriteStringValue(v));
+            }
+
+            if (obj.TagsRequiredToRun != null)
+            {
+                writer.WriteEnumerableProperty(obj.TagsRequiredToRun, "TagsRequiredToRun", (w, v) => writer.WriteStringValue(v));
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
@@ -47,8 +47,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
-            var tagsRequiredToPlace = default(NodeTagsDescription);
-            var tagsRequiredToRun = default(NodeTagsDescription);
+            var serviceTags = default(ServiceTags);
             var targetReplicaSetSize = default(int?);
             var minReplicaSetSize = default(int?);
             var hasPersistedState = default(bool?);
@@ -121,13 +120,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     scalingPolicies = reader.ReadList(ScalingPolicyDescriptionConverter.Deserialize);
                 }
-                else if (string.Compare("TagsRequiredToPlace", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ServiceTags", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsRequiredToPlace = NodeTagsDescriptionConverter.Deserialize(reader);
-                }
-                else if (string.Compare("TagsRequiredToRun", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    tagsRequiredToRun = NodeTagsDescriptionConverter.Deserialize(reader);
+                    serviceTags = ServiceTagsConverter.Deserialize(reader);
                 }
                 else if (string.Compare("TargetReplicaSetSize", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -199,8 +194,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
-                tagsRequiredToPlace: tagsRequiredToPlace,
-                tagsRequiredToRun: tagsRequiredToRun,
+                serviceTags: serviceTags,
                 targetReplicaSetSize: targetReplicaSetSize,
                 minReplicaSetSize: minReplicaSetSize,
                 hasPersistedState: hasPersistedState,
@@ -278,14 +272,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteEnumerableProperty(obj.ScalingPolicies, "ScalingPolicies", ScalingPolicyDescriptionConverter.Serialize);
             }
 
-            if (obj.TagsRequiredToPlace != null)
+            if (obj.ServiceTags != null)
             {
-                writer.WriteProperty(obj.TagsRequiredToPlace, "TagsRequiredToPlace", NodeTagsDescriptionConverter.Serialize);
-            }
-
-            if (obj.TagsRequiredToRun != null)
-            {
-                writer.WriteProperty(obj.TagsRequiredToRun, "TagsRequiredToRun", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.ServiceTags, "ServiceTags", ServiceTagsConverter.Serialize);
             }
 
             if (obj.Flags != null)

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
@@ -41,8 +41,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var defaultMoveCost = default(MoveCost?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
-            var tagsForPlacement = default(NodeTagsDescription);
-            var tagsForRunning = default(NodeTagsDescription);
+            var serviceTags = default(ServiceTags);
+            var repartitionDescription = default(RepartitionSchemeDescription);
             var targetReplicaSetSize = default(int?);
             var minReplicaSetSize = default(int?);
             var replicaRestartWaitDurationSeconds = default(string);
@@ -89,13 +89,13 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     serviceDnsName = reader.ReadValueAsString();
                 }
-                else if (string.Compare("TagsForPlacement", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ServiceTags", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsForPlacement = NodeTagsDescriptionConverter.Deserialize(reader);
+                    serviceTags = ServiceTagsConverter.Deserialize(reader);
                 }
-                else if (string.Compare("TagsForRunning", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("RepartitionDescription", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsForRunning = NodeTagsDescriptionConverter.Deserialize(reader);
+                    repartitionDescription = RepartitionSchemeDescriptionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("TargetReplicaSetSize", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -153,8 +153,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 defaultMoveCost: defaultMoveCost,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
-                tagsForPlacement: tagsForPlacement,
-                tagsForRunning: tagsForRunning,
+                serviceTags: serviceTags,
+                repartitionDescription: repartitionDescription,
                 targetReplicaSetSize: targetReplicaSetSize,
                 minReplicaSetSize: minReplicaSetSize,
                 replicaRestartWaitDurationSeconds: replicaRestartWaitDurationSeconds,
@@ -213,14 +213,14 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.ServiceDnsName, "ServiceDnsName", JsonWriterExtensions.WriteStringValue);
             }
 
-            if (obj.TagsForPlacement != null)
+            if (obj.ServiceTags != null)
             {
-                writer.WriteProperty(obj.TagsForPlacement, "TagsForPlacement", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.ServiceTags, "ServiceTags", ServiceTagsConverter.Serialize);
             }
 
-            if (obj.TagsForRunning != null)
+            if (obj.RepartitionDescription != null)
             {
-                writer.WriteProperty(obj.TagsForRunning, "TagsForRunning", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.RepartitionDescription, "RepartitionDescription", RepartitionSchemeDescriptionConverter.Serialize);
             }
 
             if (obj.TargetReplicaSetSize != null)

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
@@ -47,8 +47,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
-            var tagsRequiredToPlace = default(NodeTagsDescription);
-            var tagsRequiredToRun = default(NodeTagsDescription);
+            var serviceTags = default(ServiceTags);
             var instanceCount = default(int?);
             var minInstanceCount = default(int?);
             var minInstancePercentage = default(int?);
@@ -116,13 +115,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     scalingPolicies = reader.ReadList(ScalingPolicyDescriptionConverter.Deserialize);
                 }
-                else if (string.Compare("TagsRequiredToPlace", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ServiceTags", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsRequiredToPlace = NodeTagsDescriptionConverter.Deserialize(reader);
-                }
-                else if (string.Compare("TagsRequiredToRun", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    tagsRequiredToRun = NodeTagsDescriptionConverter.Deserialize(reader);
+                    serviceTags = ServiceTagsConverter.Deserialize(reader);
                 }
                 else if (string.Compare("InstanceCount", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -174,8 +169,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
-                tagsRequiredToPlace: tagsRequiredToPlace,
-                tagsRequiredToRun: tagsRequiredToRun,
+                serviceTags: serviceTags,
                 instanceCount: instanceCount,
                 minInstanceCount: minInstanceCount,
                 minInstancePercentage: minInstancePercentage,
@@ -246,14 +240,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteEnumerableProperty(obj.ScalingPolicies, "ScalingPolicies", ScalingPolicyDescriptionConverter.Serialize);
             }
 
-            if (obj.TagsRequiredToPlace != null)
+            if (obj.ServiceTags != null)
             {
-                writer.WriteProperty(obj.TagsRequiredToPlace, "TagsRequiredToPlace", NodeTagsDescriptionConverter.Serialize);
-            }
-
-            if (obj.TagsRequiredToRun != null)
-            {
-                writer.WriteProperty(obj.TagsRequiredToRun, "TagsRequiredToRun", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.ServiceTags, "ServiceTags", ServiceTagsConverter.Serialize);
             }
 
             if (obj.MinInstanceCount != null)

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
@@ -41,8 +41,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var defaultMoveCost = default(MoveCost?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
-            var tagsForPlacement = default(NodeTagsDescription);
-            var tagsForRunning = default(NodeTagsDescription);
+            var serviceTags = default(ServiceTags);
+            var repartitionDescription = default(RepartitionSchemeDescription);
             var instanceCount = default(int?);
             var minInstanceCount = default(int?);
             var minInstancePercentage = default(int?);
@@ -85,13 +85,13 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     serviceDnsName = reader.ReadValueAsString();
                 }
-                else if (string.Compare("TagsForPlacement", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ServiceTags", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsForPlacement = NodeTagsDescriptionConverter.Deserialize(reader);
+                    serviceTags = ServiceTagsConverter.Deserialize(reader);
                 }
-                else if (string.Compare("TagsForRunning", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("RepartitionDescription", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    tagsForRunning = NodeTagsDescriptionConverter.Deserialize(reader);
+                    repartitionDescription = RepartitionSchemeDescriptionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("InstanceCount", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -133,8 +133,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 defaultMoveCost: defaultMoveCost,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
-                tagsForPlacement: tagsForPlacement,
-                tagsForRunning: tagsForRunning,
+                serviceTags: serviceTags,
+                repartitionDescription: repartitionDescription,
                 instanceCount: instanceCount,
                 minInstanceCount: minInstanceCount,
                 minInstancePercentage: minInstancePercentage,
@@ -189,14 +189,14 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.ServiceDnsName, "ServiceDnsName", JsonWriterExtensions.WriteStringValue);
             }
 
-            if (obj.TagsForPlacement != null)
+            if (obj.ServiceTags != null)
             {
-                writer.WriteProperty(obj.TagsForPlacement, "TagsForPlacement", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.ServiceTags, "ServiceTags", ServiceTagsConverter.Serialize);
             }
 
-            if (obj.TagsForRunning != null)
+            if (obj.RepartitionDescription != null)
             {
-                writer.WriteProperty(obj.TagsForRunning, "TagsForRunning", NodeTagsDescriptionConverter.Serialize);
+                writer.WriteProperty(obj.RepartitionDescription, "RepartitionDescription", RepartitionSchemeDescriptionConverter.Serialize);
             }
 
             if (obj.InstanceCount != null)

--- a/src/Client.Http/Common/Generated/NamedRepartitionSchemeDescription.cs
+++ b/src/Client.Http/Common/Generated/NamedRepartitionSchemeDescription.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes the named partition scheme of the service.
+    /// </summary>
+    public partial class NamedRepartitionSchemeDescription : RepartitionSchemeDescription
+    {
+        /// <summary>
+        /// Initializes a new instance of the NamedRepartitionSchemeDescription class.
+        /// </summary>
+        /// <param name="namesToAdd">Dynamic array for the names of the partitions to add.</param>
+        /// <param name="namesToRemove">Dynamic array for the names of the partitions to remove.</param>
+        public NamedRepartitionSchemeDescription(
+            IEnumerable<string> namesToAdd = default(IEnumerable<string>),
+            IEnumerable<string> namesToRemove = default(IEnumerable<string>))
+            : base(
+                Common.RepartitionScheme.Named)
+        {
+            this.NamesToAdd = namesToAdd;
+            this.NamesToRemove = namesToRemove;
+        }
+
+        /// <summary>
+        /// Gets dynamic array for the names of the partitions to add.
+        /// </summary>
+        public IEnumerable<string> NamesToAdd { get; }
+
+        /// <summary>
+        /// Gets dynamic array for the names of the partitions to remove.
+        /// </summary>
+        public IEnumerable<string> NamesToRemove { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/RepartitionScheme.cs
+++ b/src/Client.Http/Common/Generated/RepartitionScheme.cs
@@ -6,18 +6,19 @@
 namespace Microsoft.ServiceFabric.Common
 {
     /// <summary>
-    /// Defines values for CompressionStrategy.
+    /// Defines values for RepartitionScheme.
     /// </summary>
-    public enum CompressionStrategy
+    public enum RepartitionScheme
     {
         /// <summary>
-        /// Use ZIP compression for backups.
+        /// Indicates the partition kind is invalid. All Service Fabric enumerations have the invalid type. The value is zero.
         /// </summary>
-        ZIP,
+        Invalid,
 
         /// <summary>
-        /// Use Zstandard compression for backups, which provides better compression ratios.
+        /// Indicates that the partition is based on string names, and is a NamedPartitionSchemeDescription object. The value
+        /// is 1.
         /// </summary>
-        ZSTANDARD,
+        Named,
     }
 }

--- a/src/Client.Http/Common/Generated/RepartitionSchemeDescription.cs
+++ b/src/Client.Http/Common/Generated/RepartitionSchemeDescription.cs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes how the service is repartitioned.
+    /// </summary>
+    public abstract partial class RepartitionSchemeDescription
+    {
+        /// <summary>
+        /// Initializes a new instance of the RepartitionSchemeDescription class.
+        /// </summary>
+        /// <param name="kind">Enumerates the ways that a service can be partitioned.</param>
+        protected RepartitionSchemeDescription(
+            RepartitionScheme? kind)
+        {
+            kind.ThrowIfNull(nameof(kind));
+            this.Kind = kind;
+        }
+
+        /// <summary>
+        /// Gets enumerates the ways that a service can be partitioned.
+        /// </summary>
+        public RepartitionScheme? Kind { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/ServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceDescription.cs
@@ -45,8 +45,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="serviceDnsName">The DNS name of the service. It requires the DNS system service to be enabled in
         /// Service Fabric cluster.</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
-        /// <param name="tagsRequiredToPlace">Tags for placement of this service.</param>
-        /// <param name="tagsRequiredToRun">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
         protected ServiceDescription(
             ServiceName serviceName,
             string serviceTypeName,
@@ -63,8 +62,7 @@ namespace Microsoft.ServiceFabric.Common
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
-            NodeTagsDescription tagsRequiredToPlace = default(NodeTagsDescription),
-            NodeTagsDescription tagsRequiredToRun = default(NodeTagsDescription))
+            ServiceTags serviceTags = default(ServiceTags))
         {
             serviceName.ThrowIfNull(nameof(serviceName));
             serviceTypeName.ThrowIfNull(nameof(serviceTypeName));
@@ -85,8 +83,7 @@ namespace Microsoft.ServiceFabric.Common
             this.ServicePackageActivationMode = servicePackageActivationMode;
             this.ServiceDnsName = serviceDnsName;
             this.ScalingPolicies = scalingPolicies;
-            this.TagsRequiredToPlace = tagsRequiredToPlace;
-            this.TagsRequiredToRun = tagsRequiredToRun;
+            this.ServiceTags = serviceTags;
         }
 
         /// <summary>
@@ -169,14 +166,9 @@ namespace Microsoft.ServiceFabric.Common
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; }
 
         /// <summary>
-        /// Gets tags for placement of this service.
+        /// Gets service tags collections for placement and running of the service.
         /// </summary>
-        public NodeTagsDescription TagsRequiredToPlace { get; }
-
-        /// <summary>
-        /// Gets tags for running of this service.
-        /// </summary>
-        public NodeTagsDescription TagsRequiredToRun { get; }
+        public ServiceTags ServiceTags { get; }
 
         /// <summary>
         /// Gets the kind of service (Stateless or Stateful).

--- a/src/Client.Http/Common/Generated/ServiceTags.cs
+++ b/src/Client.Http/Common/Generated/ServiceTags.cs
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Wrapper for service tags - TagsRequiredToPlace and TagsRequiredToRun.
+    /// </summary>
+    public partial class ServiceTags
+    {
+        /// <summary>
+        /// Initializes a new instance of the ServiceTags class.
+        /// </summary>
+        public ServiceTags(
+            IEnumerable<string> tagsRequiredToPlace = default(IEnumerable<string>),
+            IEnumerable<string> tagsRequiredToRun = default(IEnumerable<string>))
+        {
+            this.TagsRequiredToPlace = tagsRequiredToPlace;
+            this.TagsRequiredToRun = tagsRequiredToRun;
+        }
+
+        /// <summary>
+        /// </summary>
+        public IEnumerable<string> TagsRequiredToPlace { get; }
+
+        /// <summary>
+        /// </summary>
+        public IEnumerable<string> TagsRequiredToRun { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
@@ -43,8 +43,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-        /// - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-        /// - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+        /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+        /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -60,8 +60,8 @@ namespace Microsoft.ServiceFabric.Common
         /// </param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
-        /// <param name="tagsForPlacement">Tags for placement of this service.</param>
-        /// <param name="tagsForRunning">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
+        /// <param name="repartitionDescription">The repartition description as an object.</param>
         protected ServiceUpdateDescription(
             ServiceKind? serviceKind,
             string flags = default(string),
@@ -72,8 +72,8 @@ namespace Microsoft.ServiceFabric.Common
             MoveCost? defaultMoveCost = default(MoveCost?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
-            NodeTagsDescription tagsForPlacement = default(NodeTagsDescription),
-            NodeTagsDescription tagsForRunning = default(NodeTagsDescription))
+            ServiceTags serviceTags = default(ServiceTags),
+            RepartitionSchemeDescription repartitionDescription = default(RepartitionSchemeDescription))
         {
             serviceKind.ThrowIfNull(nameof(serviceKind));
             this.ServiceKind = serviceKind;
@@ -85,8 +85,8 @@ namespace Microsoft.ServiceFabric.Common
             this.DefaultMoveCost = defaultMoveCost;
             this.ScalingPolicies = scalingPolicies;
             this.ServiceDnsName = serviceDnsName;
-            this.TagsForPlacement = tagsForPlacement;
-            this.TagsForRunning = tagsForRunning;
+            this.ServiceTags = serviceTags;
+            this.RepartitionDescription = repartitionDescription;
         }
 
         /// <summary>
@@ -116,8 +116,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-        /// - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-        /// - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+        /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+        /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
         /// </summary>
         public string Flags { get; }
 
@@ -161,14 +161,14 @@ namespace Microsoft.ServiceFabric.Common
         public string ServiceDnsName { get; }
 
         /// <summary>
-        /// Gets tags for placement of this service.
+        /// Gets service tags collections for placement and running of the service.
         /// </summary>
-        public NodeTagsDescription TagsForPlacement { get; }
+        public ServiceTags ServiceTags { get; }
 
         /// <summary>
-        /// Gets tags for running of this service.
+        /// Gets the repartition description as an object.
         /// </summary>
-        public NodeTagsDescription TagsForRunning { get; }
+        public RepartitionSchemeDescription RepartitionDescription { get; }
 
         /// <summary>
         /// Gets the kind of service (Stateless or Stateful).

--- a/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
@@ -48,8 +48,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="serviceDnsName">The DNS name of the service. It requires the DNS system service to be enabled in
         /// Service Fabric cluster.</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
-        /// <param name="tagsRequiredToPlace">Tags for placement of this service.</param>
-        /// <param name="tagsRequiredToRun">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
         /// <param name="flags">Flags indicating whether other properties are set. Each of the associated properties
         /// corresponds to a flag, specified below, which, if set, indicate that the property is specified.
         /// This property can be a combination of those flags obtained using bitwise 'OR' operator.
@@ -74,7 +73,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="dropSourceReplicaOnMove">Indicates whether to drop source Secondary replica even if the target replica
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.</param>
-        /// <param name="replicaLifecycleDescription">Defines how replicas of this service will behave during ther
+        /// <param name="replicaLifecycleDescription">Defines how replicas of this service will behave during their
         /// lifecycle.</param>
         /// <param name="auxiliaryReplicaCount">The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.</param>
@@ -97,8 +96,7 @@ namespace Microsoft.ServiceFabric.Common
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
-            NodeTagsDescription tagsRequiredToPlace = default(NodeTagsDescription),
-            NodeTagsDescription tagsRequiredToRun = default(NodeTagsDescription),
+            ServiceTags serviceTags = default(ServiceTags),
             int? flags = default(int?),
             long? replicaRestartWaitDurationSeconds = default(long?),
             long? quorumLossWaitDurationSeconds = default(long?),
@@ -124,8 +122,7 @@ namespace Microsoft.ServiceFabric.Common
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,
-                tagsRequiredToPlace,
-                tagsRequiredToRun)
+                serviceTags)
         {
             targetReplicaSetSize.ThrowIfNull(nameof(targetReplicaSetSize));
             minReplicaSetSize.ThrowIfNull(nameof(minReplicaSetSize));
@@ -210,7 +207,7 @@ namespace Microsoft.ServiceFabric.Common
         public bool? DropSourceReplicaOnMove { get; }
 
         /// <summary>
-        /// Gets defines how replicas of this service will behave during ther lifecycle.
+        /// Gets defines how replicas of this service will behave during their lifecycle.
         /// </summary>
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; }
 

--- a/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
@@ -42,8 +42,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-        /// - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-        /// - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+        /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+        /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -59,8 +59,8 @@ namespace Microsoft.ServiceFabric.Common
         /// </param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
-        /// <param name="tagsForPlacement">Tags for placement of this service.</param>
-        /// <param name="tagsForRunning">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
+        /// <param name="repartitionDescription">The repartition description as an object.</param>
         /// <param name="targetReplicaSetSize">The target replica set size as a number.</param>
         /// <param name="minReplicaSetSize">The minimum replica set size as a number.</param>
         /// <param name="replicaRestartWaitDurationSeconds">The duration, in seconds, between when a replica goes down and when
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="dropSourceReplicaOnMove">Indicates whether to drop source Secondary replica even if the target replica
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.</param>
-        /// <param name="replicaLifecycleDescription">Defines how replicas of this service will behave during ther
+        /// <param name="replicaLifecycleDescription">Defines how replicas of this service will behave during their
         /// lifecycle.</param>
         /// <param name="auxiliaryReplicaCount">The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.</param>
@@ -88,8 +88,8 @@ namespace Microsoft.ServiceFabric.Common
             MoveCost? defaultMoveCost = default(MoveCost?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
-            NodeTagsDescription tagsForPlacement = default(NodeTagsDescription),
-            NodeTagsDescription tagsForRunning = default(NodeTagsDescription),
+            ServiceTags serviceTags = default(ServiceTags),
+            RepartitionSchemeDescription repartitionDescription = default(RepartitionSchemeDescription),
             int? targetReplicaSetSize = default(int?),
             int? minReplicaSetSize = default(int?),
             string replicaRestartWaitDurationSeconds = default(string),
@@ -110,8 +110,8 @@ namespace Microsoft.ServiceFabric.Common
                 defaultMoveCost,
                 scalingPolicies,
                 serviceDnsName,
-                tagsForPlacement,
-                tagsForRunning)
+                serviceTags,
+                repartitionDescription)
         {
             targetReplicaSetSize?.ThrowIfLessThan("targetReplicaSetSize", 1);
             minReplicaSetSize?.ThrowIfLessThan("minReplicaSetSize", 1);
@@ -165,7 +165,7 @@ namespace Microsoft.ServiceFabric.Common
         public bool? DropSourceReplicaOnMove { get; }
 
         /// <summary>
-        /// Gets defines how replicas of this service will behave during ther lifecycle.
+        /// Gets defines how replicas of this service will behave during their lifecycle.
         /// </summary>
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; }
 

--- a/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
@@ -45,8 +45,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="serviceDnsName">The DNS name of the service. It requires the DNS system service to be enabled in
         /// Service Fabric cluster.</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
-        /// <param name="tagsRequiredToPlace">Tags for placement of this service.</param>
-        /// <param name="tagsRequiredToRun">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
         /// <param name="minInstanceCount">MinInstanceCount is the minimum number of instances that must be up to meet the
         /// EnsureAvailability safety check during operations like upgrade or deactivate node.
         /// The actual number that is used is max( MinInstanceCount, ceil( MinInstancePercentage/100.0 * InstanceCount) ).
@@ -109,8 +108,7 @@ namespace Microsoft.ServiceFabric.Common
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
-            NodeTagsDescription tagsRequiredToPlace = default(NodeTagsDescription),
-            NodeTagsDescription tagsRequiredToRun = default(NodeTagsDescription),
+            ServiceTags serviceTags = default(ServiceTags),
             int? minInstanceCount = default(int?),
             int? minInstancePercentage = default(int?),
             int? flags = default(int?),
@@ -133,8 +131,7 @@ namespace Microsoft.ServiceFabric.Common
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,
-                tagsRequiredToPlace,
-                tagsRequiredToRun)
+                serviceTags)
         {
             instanceCount.ThrowIfNull(nameof(instanceCount));
             instanceCount?.ThrowIfLessThan("instanceCount", -1);

--- a/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
@@ -42,8 +42,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-        /// - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-        /// - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+        /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+        /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -59,8 +59,8 @@ namespace Microsoft.ServiceFabric.Common
         /// </param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
-        /// <param name="tagsForPlacement">Tags for placement of this service.</param>
-        /// <param name="tagsForRunning">Tags for running of this service.</param>
+        /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
+        /// <param name="repartitionDescription">The repartition description as an object.</param>
         /// <param name="instanceCount">The instance count.</param>
         /// <param name="minInstanceCount">MinInstanceCount is the minimum number of instances that must be up to meet the
         /// EnsureAvailability safety check during operations like upgrade or deactivate node.
@@ -106,8 +106,8 @@ namespace Microsoft.ServiceFabric.Common
             MoveCost? defaultMoveCost = default(MoveCost?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
-            NodeTagsDescription tagsForPlacement = default(NodeTagsDescription),
-            NodeTagsDescription tagsForRunning = default(NodeTagsDescription),
+            ServiceTags serviceTags = default(ServiceTags),
+            RepartitionSchemeDescription repartitionDescription = default(RepartitionSchemeDescription),
             int? instanceCount = default(int?),
             int? minInstanceCount = default(int?),
             int? minInstancePercentage = default(int?),
@@ -124,8 +124,8 @@ namespace Microsoft.ServiceFabric.Common
                 defaultMoveCost,
                 scalingPolicies,
                 serviceDnsName,
-                tagsForPlacement,
-                tagsForRunning)
+                serviceTags,
+                repartitionDescription)
         {
             instanceCount?.ThrowIfLessThan("instanceCount", -1);
             this.InstanceCount = instanceCount;

--- a/src/Powershell.Http/Generated/NewServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/NewServiceCmdlet.cs
@@ -219,16 +219,14 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
-        /// Gets or sets TagsRequiredToPlace. Tags for placement of this service.
         /// </summary>
         [Parameter(Mandatory = false, Position = 24)]
-        public NodeTagsDescription TagsRequiredToPlace { get; set; }
+        public IEnumerable<string> TagsRequiredToPlace { get; set; }
 
         /// <summary>
-        /// Gets or sets TagsRequiredToRun. Tags for running of this service.
         /// </summary>
         [Parameter(Mandatory = false, Position = 25)]
-        public NodeTagsDescription TagsRequiredToRun { get; set; }
+        public IEnumerable<string> TagsRequiredToRun { get; set; }
 
         /// <summary>
         /// Gets or sets Flags. Flags indicating whether other properties are set. Each of the associated properties
@@ -299,7 +297,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
-        /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during ther lifecycle.
+        /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
         [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Named__Stateful_")]
         [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Singleton__Stateful_")]
@@ -421,6 +419,11 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     highKey: this.HighKey);
             }
 
+            // Hand-coded to avoid compiler errors in generated code
+            var serviceTags = new ServiceTags(
+                tagsRequiredToPlace: this.TagsRequiredToPlace,
+                tagsRequiredToRun: this.TagsRequiredToRun);
+
             ServiceDescription serviceDescription = null;
             if (this.Stateful.IsPresent)
             {
@@ -442,8 +445,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,
-                    tagsRequiredToPlace: this.TagsRequiredToPlace,
-                    tagsRequiredToRun: this.TagsRequiredToRun,
+                    serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
                     flags: this.Flags,
                     replicaRestartWaitDurationSeconds: this.ReplicaRestartWaitDurationSeconds,
                     quorumLossWaitDurationSeconds: this.QuorumLossWaitDurationSeconds,
@@ -472,8 +474,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,
-                    tagsRequiredToPlace: this.TagsRequiredToPlace,
-                    tagsRequiredToRun: this.TagsRequiredToRun,
+                    serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
                     minInstanceCount: this.MinInstanceCount,
                     minInstancePercentage: this.MinInstancePercentage,
                     flags: this.Flags,

--- a/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
@@ -17,15 +17,22 @@ namespace Microsoft.ServiceFabric.Powershell.Http
     public partial class UpdateServiceCmdlet : CommonCmdletBase
     {
         /// <summary>
+        /// Gets or sets Named flag
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "_Named__Stateless_")]
+        public SwitchParameter Named { get; set; }
+
+        /// <summary>
         /// Gets or sets Stateful flag
         /// </summary>
-        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "_Named__Stateful_")]
         public SwitchParameter Stateful { get; set; }
 
         /// <summary>
         /// Gets or sets Stateless flag
         /// </summary>
-        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "_Named__Stateless_")]
         public SwitchParameter Stateless { get; set; }
 
         /// <summary>
@@ -35,7 +42,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// For example, if the service name is "fabric:/myapp/app1/svc1", the service identity would be "myapp~app1~svc1" in
         /// 6.0+ and "myapp/app1/svc1" in previous versions.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 1)]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 2)]
         public string ServiceId { get; set; }
 
         /// <summary>
@@ -65,10 +72,10 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-        /// - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-        /// - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+        /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+        /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 2)]
+        [Parameter(Mandatory = false, Position = 3)]
         public string Flags { get; set; }
 
         /// <summary>
@@ -77,25 +84,25 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// requirements. For example, to place a service on nodes where NodeType is blue specify the following: "NodeColor ==
         /// blue)".
         /// </summary>
-        [Parameter(Mandatory = false, Position = 3)]
+        [Parameter(Mandatory = false, Position = 4)]
         public string PlacementConstraints { get; set; }
 
         /// <summary>
         /// Gets or sets CorrelationScheme. The correlation scheme.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 4)]
+        [Parameter(Mandatory = false, Position = 5)]
         public IEnumerable<ServiceCorrelationDescription> CorrelationScheme { get; set; }
 
         /// <summary>
         /// Gets or sets LoadMetrics. The service load metrics.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 5)]
+        [Parameter(Mandatory = false, Position = 6)]
         public IEnumerable<ServiceLoadMetricDescription> LoadMetrics { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementPolicies. The service placement policies.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 6)]
+        [Parameter(Mandatory = false, Position = 7)]
         public IEnumerable<ServicePlacementPolicyDescription> ServicePlacementPolicies { get; set; }
 
         /// <summary>
@@ -104,71 +111,83 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// 
         /// Specifies the move cost for the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 7)]
+        [Parameter(Mandatory = false, Position = 8)]
         public MoveCost? DefaultMoveCost { get; set; }
 
         /// <summary>
         /// Gets or sets ScalingPolicies. Scaling policies for this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 8)]
+        [Parameter(Mandatory = false, Position = 9)]
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceDnsName. The DNS name of the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 9)]
+        [Parameter(Mandatory = false, Position = 10)]
         public string ServiceDnsName { get; set; }
 
         /// <summary>
-        /// Gets or sets TagsForPlacement. Tags for placement of this service.
-        /// </summary>
-        [Parameter(Mandatory = false, Position = 10)]
-        public NodeTagsDescription TagsForPlacement { get; set; }
-
-        /// <summary>
-        /// Gets or sets TagsForRunning. Tags for running of this service.
         /// </summary>
         [Parameter(Mandatory = false, Position = 11)]
-        public NodeTagsDescription TagsForRunning { get; set; }
+        public IEnumerable<string> TagsRequiredToPlace { get; set; }
+
+        /// <summary>
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 12)]
+        public IEnumerable<string> TagsRequiredToRun { get; set; }
+
+        /// <summary>
+        /// Gets or sets NamesToAdd. Dynamic array for the names of the partitions to add.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateless_")]
+        public IEnumerable<string> NamesToAdd { get; set; }
+
+        /// <summary>
+        /// Gets or sets NamesToRemove. Dynamic array for the names of the partitions to remove.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateless_")]
+        public IEnumerable<string> NamesToRemove { get; set; }
 
         /// <summary>
         /// Gets or sets TargetReplicaSetSize. The target replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 12, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateful_")]
         public int? TargetReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets MinReplicaSetSize. The minimum replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Named__Stateful_")]
         public int? MinReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaRestartWaitDurationSeconds. The duration, in seconds, between when a replica goes down and when
         /// a new replica is created.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Named__Stateful_")]
         public string ReplicaRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets QuorumLossWaitDurationSeconds. The maximum duration, in seconds, for which a partition is allowed to
         /// be in a state of quorum loss.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Named__Stateful_")]
         public string QuorumLossWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets StandByReplicaKeepDurationSeconds. The definition on how long StandBy replicas should be maintained
         /// before being removed.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Named__Stateful_")]
         public string StandByReplicaKeepDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementTimeLimitSeconds. The duration for which replicas can stay InBuild before reporting
         /// that build is stuck.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Named__Stateful_")]
         public string ServicePlacementTimeLimitSeconds { get; set; }
 
         /// <summary>
@@ -176,32 +195,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Named__Stateful_")]
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
-        /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during ther lifecycle.
+        /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Named__Stateful_")]
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; set; }
 
         /// <summary>
         /// Gets or sets AuxiliaryReplicaCount. The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Named__Stateful_")]
         public int? AuxiliaryReplicaCount { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceSensitivityDescription. Defines default levels of replica sensitivity of this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Stateful_")]
+        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Named__Stateful_")]
         public ServiceSensitivityDescription ServiceSensitivityDescription { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceCount. The instance count.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Named__Stateless_")]
         public int? InstanceCount { get; set; }
 
         /// <summary>
@@ -211,7 +230,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of
         /// nodes on which the instances are allowed to be placed according to the placement constraints on the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstanceCount { get; set; }
 
         /// <summary>
@@ -222,7 +241,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// number of nodes on which the instances are allowed to be placed according to the placement constraints on the
         /// service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstancePercentage { get; set; }
 
         /// <summary>
@@ -239,14 +258,14 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - Close existing connections after in-flight requests have completed.
         /// - Connect to a different instance of the service partition for future requests.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateless_")]
         public string InstanceCloseDelayDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceLifecycleDescription. Defines how instances of this service will behave during their
         /// lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateless_")]
         public InstanceLifecycleDescription InstanceLifecycleDescription { get; set; }
 
         /// <summary>
@@ -257,7 +276,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Stateless_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateless_")]
         public string InstanceRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
@@ -265,12 +284,25 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 28)]
+        [Parameter(Mandatory = false, Position = 31)]
         public long? ServerTimeout { get; set; }
 
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
+            RepartitionSchemeDescription repartitionSchemeDescription = null;
+            if (this.Named.IsPresent)
+            {
+                repartitionSchemeDescription = new NamedRepartitionSchemeDescription(
+                    namesToAdd: this.NamesToAdd,
+                    namesToRemove: this.NamesToRemove);
+            }
+
+            // Hand-coded to avoid compiler errors in generated code
+            var serviceTags = new ServiceTags(
+                tagsRequiredToPlace: this.TagsRequiredToPlace,
+                tagsRequiredToRun: this.TagsRequiredToRun);
+
             ServiceUpdateDescription serviceUpdateDescription = null;
             if (this.Stateful.IsPresent)
             {
@@ -283,8 +315,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     defaultMoveCost: this.DefaultMoveCost,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
-                    tagsForPlacement: this.TagsForPlacement,
-                    tagsForRunning: this.TagsForRunning,
+                    serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
+                    repartitionDescription: repartitionSchemeDescription,
                     targetReplicaSetSize: this.TargetReplicaSetSize,
                     minReplicaSetSize: this.MinReplicaSetSize,
                     replicaRestartWaitDurationSeconds: this.ReplicaRestartWaitDurationSeconds,
@@ -307,8 +339,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     defaultMoveCost: this.DefaultMoveCost,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
-                    tagsForPlacement: this.TagsForPlacement,
-                    tagsForRunning: this.TagsForRunning,
+                    serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
+                    repartitionDescription: repartitionSchemeDescription,
                     instanceCount: this.InstanceCount,
                     minInstanceCount: this.MinInstanceCount,
                     minInstancePercentage: this.MinInstancePercentage,

--- a/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -7147,24 +7147,24 @@
                 <maml:name>TagsRequiredToPlace</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Tags for placement of this service.
+                    
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">NodeTagsDescription</command:parameterValue>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
                 <dev:type>
-                    <maml:name>NodeTagsDescription</maml:name>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="23">
                 <maml:name>TagsRequiredToRun</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Tags for running of this service.
+                    
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">NodeTagsDescription</command:parameterValue>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
                 <dev:type>
-                    <maml:name>NodeTagsDescription</maml:name>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="24">
@@ -7253,7 +7253,7 @@
                 <maml:name>ReplicaLifecycleDescription</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Defines how replicas of this service will behave during ther lifecycle.
+                    Defines how replicas of this service will behave during their lifecycle.
                     </maml:para>
                 </maml:Description>
             <command:parameterValue required="false">ReplicaLifecycleDescription</command:parameterValue>
@@ -7564,6 +7564,12 @@
                 <command:syntaxItem>
                     <maml:name>Update-SFService</maml:name>
                 <command:parameter required="false">
+                        <maml:name>NamesToAdd</maml:name>
+                </command:parameter>
+                <command:parameter required="false">
+                        <maml:name>NamesToRemove</maml:name>
+                </command:parameter>
+                <command:parameter required="false">
                         <maml:name>TargetReplicaSetSize</maml:name>
                 </command:parameter>
                 <command:parameter required="false">
@@ -7596,6 +7602,12 @@
                 </command:syntaxItem>
                 <command:syntaxItem>
                     <maml:name>Update-SFService</maml:name>
+                <command:parameter required="false">
+                        <maml:name>NamesToAdd</maml:name>
+                </command:parameter>
+                <command:parameter required="false">
+                        <maml:name>NamesToRemove</maml:name>
+                </command:parameter>
                 <command:parameter required="false">
                         <maml:name>InstanceCount</maml:name>
                 </command:parameter>
@@ -7662,8 +7674,8 @@
                     - InstanceRestartWaitDuration - Indicates the InstanceCloseDelayDuration property is set. The value is 32768.
                     - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 65536.
                     - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
-                    - TagsForPlacement - Indicates the TagsForPlacement property is set. The value is 1048576.
-                    - TagsForRunning - Indicates the TagsForRunning property is set. The value is 2097152.
+                    - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
+                    - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
                     
                     </maml:para>
                 </maml:Description>
@@ -7760,30 +7772,54 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="9">
-                <maml:name>TagsForPlacement</maml:name>
+                <maml:name>TagsRequiredToPlace</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Tags for placement of this service.
+                    
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">NodeTagsDescription</command:parameterValue>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
                 <dev:type>
-                    <maml:name>NodeTagsDescription</maml:name>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="10">
-                <maml:name>TagsForRunning</maml:name>
+                <maml:name>TagsRequiredToRun</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Tags for running of this service.
+                    
                     </maml:para>
                 </maml:Description>
-            <command:parameterValue required="false">NodeTagsDescription</command:parameterValue>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
                 <dev:type>
-                    <maml:name>NodeTagsDescription</maml:name>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="11">
+                <maml:name>NamesToAdd</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Dynamic array for the names of the partitions to add.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
+                <dev:type>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="12">
+                <maml:name>NamesToRemove</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Dynamic array for the names of the partitions to remove.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">IEnumerable&lt;string&gt;</command:parameterValue>
+                <dev:type>
+                    <maml:name>IEnumerable&lt;string&gt;</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="13">
                 <maml:name>TargetReplicaSetSize</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7795,7 +7831,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="12">
+            <command:parameter required="false" position="14">
                 <maml:name>MinReplicaSetSize</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7807,7 +7843,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="13">
+            <command:parameter required="false" position="15">
                 <maml:name>ReplicaRestartWaitDurationSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7819,7 +7855,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="14">
+            <command:parameter required="false" position="16">
                 <maml:name>QuorumLossWaitDurationSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7831,7 +7867,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="15">
+            <command:parameter required="false" position="17">
                 <maml:name>StandByReplicaKeepDurationSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7843,7 +7879,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="16">
+            <command:parameter required="false" position="18">
                 <maml:name>ServicePlacementTimeLimitSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7855,7 +7891,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="17">
+            <command:parameter required="false" position="19">
                 <maml:name>DropSourceReplicaOnMove</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7867,11 +7903,11 @@
                     <maml:name>bool?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="18">
+            <command:parameter required="false" position="20">
                 <maml:name>ReplicaLifecycleDescription</maml:name>
                 <maml:Description>
                     <maml:para>
-                    Defines how replicas of this service will behave during ther lifecycle.
+                    Defines how replicas of this service will behave during their lifecycle.
                     </maml:para>
                 </maml:Description>
             <command:parameterValue required="false">ReplicaLifecycleDescription</command:parameterValue>
@@ -7879,7 +7915,7 @@
                     <maml:name>ReplicaLifecycleDescription</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="19">
+            <command:parameter required="false" position="21">
                 <maml:name>AuxiliaryReplicaCount</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7891,7 +7927,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="20">
+            <command:parameter required="false" position="22">
                 <maml:name>ServiceSensitivityDescription</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7903,7 +7939,7 @@
                     <maml:name>ServiceSensitivityDescription</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="21">
+            <command:parameter required="false" position="23">
                 <maml:name>InstanceCount</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7915,7 +7951,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="22">
+            <command:parameter required="false" position="24">
                 <maml:name>MinInstanceCount</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7930,7 +7966,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="23">
+            <command:parameter required="false" position="25">
                 <maml:name>MinInstancePercentage</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7945,7 +7981,7 @@
                     <maml:name>int?</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="24">
+            <command:parameter required="false" position="26">
                 <maml:name>InstanceCloseDelayDurationSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7964,7 +8000,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="25">
+            <command:parameter required="false" position="27">
                 <maml:name>InstanceLifecycleDescription</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7976,7 +8012,7 @@
                     <maml:name>InstanceLifecycleDescription</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="26">
+            <command:parameter required="false" position="28">
                 <maml:name>InstanceRestartWaitDurationSeconds</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -7991,7 +8027,7 @@
                     <maml:name>string</maml:name>
                 </dev:type>
             </command:parameter>
-            <command:parameter required="false" position="27">
+            <command:parameter required="false" position="29">
                 <maml:name>ServerTimeout</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -11994,69 +12030,69 @@
             </command:parameters>
     </command:command>
     <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
-        <command:details>
-            <command:name>Restore-SFReplica</command:name>
-            <command:verb>Restore</command:verb>
-            <command:noun>Replica</command:noun>
+            <command:details>
+                <command:name>Restore-SFReplica</command:name>
+                <command:verb>Restore</command:verb>
+                <command:noun>Replica</command:noun>
+                <maml:description>
+                    <maml:para>Recovers a ToBeRemoved replica by reopening the stateful service replica.</maml:para>
+                </maml:description>
+            </command:details>
+            <command:syntax>
+            </command:syntax>
             <maml:description>
-                <maml:para>Recovers a ToBeRemoved replica by reopening the stateful service replica.</maml:para>
+                <maml:para>Recovers a ToBeRemoved replica by reopening the stateful service replica. Use this if the partition is stuck in quorum loss in order to prevent data loss. In the event of Quorum Loss, customers should restore all soft deleted (ToBeRemoved) replicas using this API. Service Fabric automatically determines which replicas to retain to restore quorum. This command has no effect on replicas which are not in the ToBeRemoved state.</maml:para>
             </maml:description>
-        </command:details>
-        <command:syntax>
-        </command:syntax>
-        <maml:description>
-            <maml:para>Recovers a ToBeRemoved replica by reopening the stateful service replica. Use this if the partition is stuck in quorum loss in order to prevent data loss. In the event of Quorum Loss, customers should restore all soft deleted (ToBeRemoved) replicas using this API. Service Fabric automatically determines which replicas to retain to restore quorum. This command has no effect on replicas which are not in the ToBeRemoved state.</maml:para>
-        </maml:description>
-        <command:parameters>
-        <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="0">
-            <maml:name>NodeName</maml:name>
-            <maml:Description>
-                <maml:para>
-                The name of the node.
-                </maml:para>
-            </maml:Description>
-        <command:parameterValue required="true">NodeName</command:parameterValue>
-            <dev:type>
+            <command:parameters>
+            <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="0">
                 <maml:name>NodeName</maml:name>
-            </dev:type>
-        </command:parameter>
-        <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="1">
-            <maml:name>PartitionId</maml:name>
-            <maml:Description>
-                <maml:para>
-                The identity of the partition.
-                </maml:para>
-            </maml:Description>
-        <command:parameterValue required="true">PartitionId</command:parameterValue>
-            <dev:type>
+                <maml:Description>
+                    <maml:para>
+                    The name of the node.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="true">NodeName</command:parameterValue>
+                <dev:type>
+                    <maml:name>NodeName</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="1">
                 <maml:name>PartitionId</maml:name>
-            </dev:type>
-        </command:parameter>
-        <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="2">
-            <maml:name>ReplicaId</maml:name>
-            <maml:Description>
-                <maml:para>
-                The identifier of the replica.
-                </maml:para>
-            </maml:Description>
-        <command:parameterValue required="true">ReplicaId</command:parameterValue>
-            <dev:type>
+                <maml:Description>
+                    <maml:para>
+                    The identity of the partition.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="true">PartitionId</command:parameterValue>
+                <dev:type>
+                    <maml:name>PartitionId</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="2">
                 <maml:name>ReplicaId</maml:name>
-            </dev:type>
-        </command:parameter>
-        <command:parameter required="false" position="3">
-            <maml:name>ServerTimeout</maml:name>
-            <maml:Description>
-                <maml:para>
-                The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
-                </maml:para>
-            </maml:Description>
-        <command:parameterValue required="false">long?</command:parameterValue>
-            <dev:type>
-                <maml:name>long?</maml:name>
-            </dev:type>
-        </command:parameter>
-        </command:parameters>
+                <maml:Description>
+                    <maml:para>
+                    The identifier of the replica.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="true">ReplicaId</command:parameterValue>
+                <dev:type>
+                    <maml:name>ReplicaId</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="3">
+                <maml:name>ServerTimeout</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            </command:parameters>
     </command:command>
     <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
             <command:details>

--- a/src/Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
+++ b/src/Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
@@ -15,10 +15,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput> <!-- Don't create standard lib folder in the package -->
     <NoWarn>$(NoWarn);NU5100</NoWarn> <!-- Disable warnings assemblies not inside the lib folder -->
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- Disable warnings about mismatch between target frameworks and folder names -->
-    <!-- 
-      Don't generate a symbols package.
-      ADO feeds don't support them and the internal pipeline publishes symbols directly from bin.
-    -->
+    <!-- Don't generate a symbols package. ADO feeds don't support them and the internal pipeline publishes symbols directly from bin. -->
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
@@ -49,10 +46,8 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <Content>
-      <!-- Content files should be copied to output directory for signing -->
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <!-- Unsigned content files should not be included in the module/package -->
-      <Pack>false</Pack>
+      <Pack>false</Pack> <!-- Don't pack unsigned content files -->
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory> <!-- for signing -->
     </Content>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -60,43 +55,33 @@
     <Content Link="Microsoft.ServiceFabric.Powershell.Http.Format.ps1xml" Include="Generated\psxml\Microsoft.ServiceFabric.Powershell.Http.Format.ps1xml" />
     <Content Link="Microsoft.ServiceFabric.Powershell.Http-Help.xml" Include="Generated\psxml\Microsoft.ServiceFabric.Powershell.Http-Help.xml" />
   </ItemGroup>
-  <Target Name="DonNotBuildProjectReferencesWhenGettingReferenceCopyLocalPaths"
-    BeforeTargets="ResolveProjectReferences" Condition="'$(_IsPacking)' == 'true'">
+
+  <Target Name="PublishAllDependenciesAfterBuildForSigning" AfterTargets="Build" DependsOnTargets="Publish" Condition="'$(TargetFramework)' != ''" />
+
+  <Target Name="DonNotBuildReferencesWhenPackingSignedFiles" BeforeTargets="ResolveProjectReferences" Condition="'$(_IsPacking)' == 'true'">
     <PropertyGroup>
       <BuildProjectReferences>false</BuildProjectReferences>
     </PropertyGroup>
   </Target>
-  <Target Name="DeterminePowerShellFramework">
+
+  <Target Name="GetFrameworkSpecificPowerShellModuleFiles" Outputs="@(TfmSpecificPackageFile)" DependsOnTargets="PublishItemsOutputGroup">
     <PropertyGroup>
       <PowerShellFramework Condition="'$(TargetFramework)' == 'netstandard2.0'">netstandard</PowerShellFramework>
       <PowerShellFramework Condition="'$(TargetFramework)' == 'net462'">netframework</PowerShellFramework>
     </PropertyGroup>
-  </Target>
-  <Target Name="GetFrameworkSpecificPowerShellModuleFiles" Outputs="@(TfmSpecificPackageFile)"
-    DependsOnTargets="BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup;DeterminePowerShellFramework">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.ServiceFabric.Powershell.Http.Format.ps1xml" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.ServiceFabric.Powershell.Http-Help.xml" />
-      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPathsOutputGroupOutput)" />
-      <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" />
-      <TfmSpecificPackageFile PackagePath="$(PowerShellFramework)" />
-      <!-- Don't include symbols and doc comments files in the module. -->
-      <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)"
-        Condition="'%(TfmSpecificPackageFile.OriginalItemSpec)' != '' and '%(Identity)' != $([MSBuild]::NormalizePath('%(TfmSpecificPackageFile.OriginalItemSpec)'))" />
+      <TfmSpecificPackageFile Include="@(PublishItemsOutputGroupOutputs->'%(OutputPath)')" PackagePath="$(PowerShellFramework)"
+        Condition="'%(PublishItemsOutputGroupOutputs.ExcludeFromSingleFile)' != 'true' and '%(PublishItemsOutputGroupOutputs.Extension)' != '.psd1'" />
     </ItemGroup>
   </Target>
+
   <Target Name="CopyPowerShellModuleToOutputPath" BeforeTargets="GenerateNuSpec" DependsOnTargets="$(GenerateNuspecDependsOn)">
     <PropertyGroup>
       <ModuleOutputPath>$(PackageOutputPath)$(PackageId).$(PackageVersion)</ModuleOutputPath>
     </PropertyGroup>
     <ItemGroup>
-      <!--
-        We only need one of the two identical signed .psd1 files.
-        Other files are provided by the GetFrameworkSpecificPowerShellModuleFiles target that $(GenerateNuspecDependsOn).
-      -->
       <_PackageFiles Include="$(OutputPath)net462\Microsoft.ServiceFabric.Powershell.Http.psd1" PackagePath="/" />
     </ItemGroup>
-    <Copy SourceFiles="@(_PackageFiles)"
-      DestinationFiles="@(_PackageFiles->'$(ModuleOutputPath)\%(PackagePath)\%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_PackageFiles)" DestinationFiles="@(_PackageFiles->'$(ModuleOutputPath)\%(PackagePath)\%(Filename)%(Extension)')" />
   </Target>
 </Project>


### PR DESCRIPTION
- Regenerate Client/Powershell.Http code from latest SF-Swagger definitions.
- Ensure that all Powershell.Http dependencies are published for the netstandard version of the module
- Bump package version number to 12.0.0-beta.21