### PR TITLE
Bump Microsoft.AspNetCore.Server.Kestrel to version 2.3.9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,7 @@
         <PackageVersion Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" /> <!-- Secure version of Microsoft.AspNetCore.Server.Kestrel dependency -->
+        <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.6" />
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" /> <!-- Double write -->
         <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
         <PackageVersion Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.6" />
+        <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.9" />
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" /> <!-- Double write -->
         <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />


### PR DESCRIPTION
Bump `Microsoft.AspNetCore.Server.Kestrel` from version `2.3.0` to `2.3.9` and remove explicit transitive dependency to `Microsoft.AspNetCore.Server.Kestrel.Core` that is not needed anymore. 