### PR TITLE
Change C# version from 11.0 to latestMajor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <!--
+      Use latest C# version available with the current .NET SDK.
+      https://learn.microsoft.com/dotnet/csharp/language-reference/configure-language-version
+    -->
+    <LangVersion>latestMajor</LangVersion>
+
     <!-- 
       Place all build outputs in the root of the repository instead of nested project directories to
       - speed up git clean operations,

--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -41,11 +41,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <!-- Use C# 11.0 features -->
-  <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
-  </PropertyGroup>
-
   <!-- Set Version numbers. These are used for generating Assemblies. -->
   <PropertyGroup>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/FabActUtil/CommandLineParser/CommandLineArgumentParser.cs
+++ b/src/FabActUtil/CommandLineParser/CommandLineArgumentParser.cs
@@ -144,9 +144,9 @@ namespace FabActUtil.CommandLineParser
 
                         builder.Append(":{");
                         var first = true;
-                        foreach (var field in valueType.GetFields())
+                        foreach (FieldInfo @field in valueType.GetFields())
                         {
-                            if (field.IsStatic)
+                            if (@field.IsStatic)
                             {
                                 if (first)
                                 {
@@ -157,7 +157,7 @@ namespace FabActUtil.CommandLineParser
                                     builder.Append('|');
                                 }
 
-                                builder.Append(field.Name);
+                                builder.Append(@field.Name);
                             }
                         }
 


### PR DESCRIPTION
This should allow us to use latest compiler features available in the .NET SDK. It is not clear whether new compiler features are always available for older .NET, particularly .NET Framework versions. The docs say it's not supported but some C# 14.0 features, like the field keyword appear to be supported.