### PR TITLE
Cleanup ActorService

### DIFF
--- a/src/Actors/Runtime/ActorService.cs
+++ b/src/Actors/Runtime/ActorService.cs
@@ -12,10 +12,12 @@ using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Actors.Diagnostics;
 using Microsoft.ServiceFabric.Actors.Query;
 using Microsoft.ServiceFabric.Actors.Remoting;
+using Microsoft.ServiceFabric.Actors.Remoting.V2.Runtime;
 using Microsoft.ServiceFabric.Diagnostics;
 using Microsoft.ServiceFabric.Diagnostics.Tracing;
 using Microsoft.ServiceFabric.Services;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
+using Microsoft.ServiceFabric.Services.Remoting.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
@@ -29,36 +31,19 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     /// </remarks>
     public class ActorService : StatefulServiceBase, IActorService
     {
-        private const string TraceType = "ActorService";
+        const string TraceType = "ActorService";
 
-        readonly ActorTypeInformation actorTypeInformation;
-        readonly IActorStateProvider stateProvider;
-        readonly ActorServiceSettings settings;
-        readonly IActorActivator actorActivator;
         readonly ActorManagerAdapter actorManagerAdapter;
         readonly Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory;
-        ActorMethodFriendlyNameBuilder methodFriendlyNameBuilder;
         ReplicaRole replicaRole;
-        Remoting.V2.Runtime.ActorMethodDispatcherMap methodDispatcherMapV2;
-
-        readonly IClock clock = new SystemClock();
-        readonly IDiagnostics diagnostics;
         readonly DiagnosticsFactory diagnosticsFactory;
 
-        static Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticFactory = (serviceContext, actorTypeInformation, methodNameBuilder) =>
-        {
-            return new DiagnosticsFactory(serviceContext, actorTypeInformation, methodNameBuilder);
-        };
+        static Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticFactory = 
+            (serviceContext, actorTypeInformation, methodNameBuilder) => new DiagnosticsFactory(serviceContext, actorTypeInformation, methodNameBuilder);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorService"/> class.
         /// </summary>
-        /// <param name="context">Service context the actor service is operating under.</param>
-        /// <param name="actorTypeInfo">The type information of the Actor.</param>
-        /// <param name="actorFactory">The factory method to create Actor objects.</param>
-        /// <param name="stateManagerFactory">The factory method to create <see cref="IActorStateManager"/></param>
-        /// <param name="stateProvider">The state provider to store and access the state of the Actor objects.</param>
-        /// <param name="settings">The settings used to configure the behavior of the Actor service.</param>
         public ActorService(
             StatefulServiceContext context,
             ActorTypeInformation actorTypeInfo,
@@ -66,218 +51,86 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = null,
             IActorStateProvider stateProvider = null,
             ActorServiceSettings settings = null)
-            : base(
-                context,
-                stateProvider ?? ActorStateProviderHelper.CreateDefaultStateProvider(actorTypeInfo))
+            : base(context, stateProvider ?? ActorStateProviderHelper.CreateDefaultStateProvider(actorTypeInfo))
         {
-            this.actorTypeInformation = actorTypeInfo;
-            this.stateProvider = (IActorStateProvider)this.StateProviderReplica;
-            this.settings = ActorServiceSettings.DeepCopyFromOrDefaultOnNull(settings);
+            ActorTypeInformation = actorTypeInfo;
+            StateProvider = (IActorStateProvider)StateProviderReplica;
+            Settings = ActorServiceSettings.DeepCopyFromOrDefaultOnNull(settings);
 
             // Set internal components
-            this.actorActivator = new ActorActivator(actorFactory ?? this.DefaultActorFactory);
+            ActorActivator = new ActorActivator(actorFactory ?? DefaultActorFactory);
             this.stateManagerFactory = stateManagerFactory ?? DefaultActorStateManagerFactory;
-            this.actorManagerAdapter = new ActorManagerAdapter { ActorManager = new MockActorManager(this) };
-            this.replicaRole = ReplicaRole.Unknown;
-            this.methodFriendlyNameBuilder = new ActorMethodFriendlyNameBuilder(actorTypeInformation);
+            actorManagerAdapter = new ActorManagerAdapter { ActorManager = new MockActorManager(this) };
 
-            this.diagnosticsFactory = createDiagnosticFactory(context, actorTypeInfo, methodFriendlyNameBuilder);
-            this.diagnostics = this.diagnosticsFactory.CreateDiagnostics(clock);
+            var methodFriendlyNameBuilder = new ActorMethodFriendlyNameBuilder(ActorTypeInformation);
+            diagnosticsFactory = createDiagnosticFactory(context, actorTypeInfo, methodFriendlyNameBuilder);
+            Diagnostics = diagnosticsFactory.CreateDiagnostics(Clock);
 
-            ActorTelemetry.ActorServiceInitializeEvent(
-                this.ActorManager.ActorService.Context,
-                this.StateProviderReplica.GetType().ToString());
+            ActorTelemetry.ActorServiceInitializeEvent(ActorManager.ActorService.Context, StateProviderReplica.GetType().ToString());
         }
 
         /// <summary>
-        /// Gets the ActorTypeInformation for actor service.
+        /// Gets the <see cref="ActorTypeInformation"/> for the actor service.
         /// </summary>
-        /// <value>
-        /// <see cref="Runtime.ActorTypeInformation"/>
-        /// for the actor hosted by the service replica.
-        /// </value>
-        public ActorTypeInformation ActorTypeInformation
-        {
-            get { return this.actorTypeInformation; }
-        }
+        public ActorTypeInformation ActorTypeInformation { get; }
 
         /// <summary>
-        /// Gets a <see cref="IActorStateProvider"/> that represents the state provider for the actor service.
+        /// Gets a <see cref="IActorStateProvider"/> for the actor service.
         /// </summary>
-        /// <value>
-        /// <see cref="IActorStateProvider"/>
-        /// representing the state provider for the actor service.
-        /// </value>
-        public IActorStateProvider StateProvider
-        {
-            get { return this.stateProvider; }
-        }
+        public IActorStateProvider StateProvider { get; }
 
         /// <summary>
         /// Gets the settings for the actor service.
         /// </summary>
-        /// <value>
-        /// Settings for the actor service.
-        /// </value>
-        public ActorServiceSettings Settings
-        {
-            get { return this.settings; }
-        }
+        public ActorServiceSettings Settings { get; }
 
-        internal IActorActivator ActorActivator
-        {
-            get { return this.actorActivator; }
-        }
-
-        internal Remoting.V2.Runtime.ActorMethodDispatcherMap MethodDispatcherMapV2
-        {
-            get { return this.methodDispatcherMapV2; }
-            set { this.methodDispatcherMapV2 = value; }
-        }
-
-        internal ActorMethodFriendlyNameBuilder MethodFriendlyNameBuilder
-        {
-            get { return this.methodFriendlyNameBuilder; }
-        }
-
-        internal IActorManager ActorManager
-        {
-            get { return this.actorManagerAdapter.ActorManager; }
-        }
-
-        internal IClock Clock
-        {
-            get { return this.clock; }
-        }
-
-        internal IDiagnostics Diagnostics
-        {
-            get { return this.diagnostics; }
-        }
+        internal IActorActivator ActorActivator { get; }
+        internal ActorMethodDispatcherMap MethodDispatcherMapV2 { get; private set; }
+        internal IActorManager ActorManager => actorManagerAdapter.ActorManager;
+        internal IClock Clock { get; } = new SystemClock();
+        internal IDiagnostics Diagnostics { get; }
 
         #region IActorService Members
 
-        /// <summary>
-        /// Deletes an Actor from the Actor service.
-        /// </summary>
-        /// <param name="actorId">The <see cref="ActorId"/> of the actor to be deleted.</param>
-        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        /// <returns>A task that represents the asynchronous operation of call to server.</returns>
-        /// <remarks>
-        /// <para>An active actor, will be deactivated and its state will also be deleted from state provider.</para>
-        /// <para>An in-active actor's state will be deleted from state provider.</para>
-        /// <para>If this method is called for a non-existent actor id in the system, it will be a no-op.</para>
-        /// </remarks>
-        Task IActorService.DeleteActorAsync(ActorId actorId, CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        Task IActorService.DeleteActorAsync(ActorId actorId, CancellationToken cancellation)
         {
-            var requestId = LogContext.GetRequestIdOrDefault();
-            return this.ActorManager.DeleteActorAsync(
-                requestId == default(Guid) ? Guid.NewGuid().ToString() : requestId.ToString(),
-                actorId,
-                cancellationToken);
-        }
-
-        /// <summary>
-        /// Gets the list of Actors by querying the actor service.
-        /// </summary>
-        /// <param name="continuationToken">A continuation token to start querying the results from.
-        /// A null value of continuation token means start returning values form the beginning.</param>
-        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        /// <returns>A task that represents the asynchronous operation of call to server.</returns>
-        Task<PagedResult<ActorInformation>> IActorService.GetActorsAsync(
-            ContinuationToken continuationToken,
-            CancellationToken cancellationToken)
-        {
-            return this.ActorManager.GetActorsFromStateProvider(
-                continuationToken,
-                cancellationToken);
+            Guid requestId = LogContext.GetRequestIdOrDefault();
+            string callContext = requestId == default ? Guid.NewGuid().ToString() : requestId.ToString();
+            return ActorManager.DeleteActorAsync(callContext, actorId, cancellation);
         }
 
         /// <inheritdoc/>
-        Task<ReminderPagedResult<KeyValuePair<ActorId, List<ActorReminderState>>>> IActorService.GetRemindersAsync(
-           ActorId actorId,
-           ContinuationToken continuationToken,
-           CancellationToken cancellationToken)
-        {
-            return this.ActorManager.GetRemindersFromStateProviderAsync(
-                actorId,
-                continuationToken,
-                cancellationToken);
-        }
+        Task<PagedResult<ActorInformation>> IActorService.GetActorsAsync(ContinuationToken continuation, CancellationToken cancellation) =>
+            ActorManager.GetActorsFromStateProvider(continuation, cancellation);
+
+        /// <inheritdoc/>
+        Task<ReminderPagedResult<KeyValuePair<ActorId, List<ActorReminderState>>>> IActorService.GetRemindersAsync(ActorId actorId, ContinuationToken continuation, CancellationToken cancellation) =>
+           ActorManager.GetRemindersFromStateProviderAsync(actorId, continuation, cancellation);
 
         #endregion
 
-        internal async Task StartRemindersIfNeededAsync(bool actorCallsAllowed, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (actorCallsAllowed)
-            {
-                ActorTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.Context.TraceId,
-                    "ActorCallsAllowed : TRUE - Starting reminders.");
-                try
-                {
-                    await this.ActorManager.StartLoadingRemindersAsync(cancellationToken);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    var healthInfo = new HealthInformation("ActorService", "LoadReminders", HealthState.Error)
-                    {
-                        TimeToLive = TimeSpan.MaxValue,
-                        RemoveWhenExpired = false,
-                        Description = ex.Message,
-                    };
-
-                    this.Partition.ReportPartitionHealth(healthInfo, new HealthReportSendOptions { Immediate = true });
-
-                    throw;
-                }
-            }
-            else
-            {
-                ActorTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.Context.TraceId,
-                    "ActorCallsAllowed : FALSE");
-
-                //// TODO: Stop reminders from firing
-            }
-        }
-
-        internal IActorStateManager CreateStateManager(ActorBase actor)
-        {
-            return this.stateManagerFactory.Invoke(actor, this.StateProvider);
-        }
+        internal IActorStateManager CreateStateManager(ActorBase actor) => 
+            stateManagerFactory.Invoke(actor, StateProvider);
 
         internal void InitializeInternal(ActorMethodFriendlyNameBuilder methodNameBuilder)
         {
-            this.methodFriendlyNameBuilder = methodNameBuilder;
-            this.MethodDispatcherMapV2 =
-                new Actors.Remoting.V2.Runtime.ActorMethodDispatcherMap(this.ActorTypeInformation);
+            MethodDispatcherMapV2 = new ActorMethodDispatcherMap(ActorTypeInformation);
         }
 
         #region StatefulServiceBase Overrides
 
-        /// <summary>
-        /// Overrides <see cref="Microsoft.ServiceFabric.Services.Runtime.StatefulServiceBase.CreateServiceReplicaListeners()"/>.
-        /// </summary>
-        /// <returns>Endpoint string pairs like
-        /// {"Endpoints":{"Listener1":"Endpoint1","Listener2":"Endpoint2" ...}}</returns>
+        /// <inheritdoc/>
         protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
         {
-            var types = new List<Type> { this.ActorTypeInformation.ImplementationType };
-            types.AddRange(this.ActorTypeInformation.InterfaceTypes);
+            var types = new List<Type> { ActorTypeInformation.ImplementationType };
+            types.AddRange(ActorTypeInformation.InterfaceTypes);
 
             var provider = ActorRemotingProviderAttribute.GetProvider(types);
             var serviceReplicaListeners = new List<ServiceReplicaListener>();
-
-            var listeners = provider.CreateServiceRemotingListeners();
-            foreach (var kvp in listeners)
-            {
+            Dictionary<string, Func<ActorService, IServiceRemotingListener>> listeners = provider.CreateServiceRemotingListeners();
+            foreach (KeyValuePair<string, Func<ActorService, IServiceRemotingListener>> kvp in listeners)
                 serviceReplicaListeners.Add(new ServiceReplicaListener(t => kvp.Value(this), kvp.Key));
-            }
 
             return serviceReplicaListeners;
         }
@@ -285,98 +138,63 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         /// <summary>
         /// Overrides <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>
-        /// A task that represents the asynchronous operation of loading reminders when the replica becomes primary.
-        /// </returns>
         /// <remarks>
         /// If you need to override this method, please make sure to call this method from your overridden method.
         /// Also make sure your implementation of overridden method conforms to the guideline specified for
         /// <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
-        /// <para>
         /// Failing to do so can cause failover, reconfiguration or upgrade of your actor service to get stuck and
-        /// can impact availibility of your service.
-        /// </para>
+        /// can impact availability of your service.
         /// </remarks>
-        protected override Task RunAsync(CancellationToken cancellationToken) =>
-            ActorManager.StartLoadingRemindersAsync(cancellationToken);
+        protected override Task RunAsync(CancellationToken cancellation) =>
+            ActorManager.StartLoadingRemindersAsync(cancellation);
 
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnChangeRoleAsync(ReplicaRole, CancellationToken)"/>.
-        /// </summary>
-        /// <param name="newRole">The new role for the replica.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous operation performed when the replica becomes primary.</returns>
-        protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellation)
         {
-            ActorTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.Context.TraceId,
-                "Begin change role. New role: {0}.",
-                newRole);
+            ActorTrace.Source.WriteInfoWithId(TraceType, Context.TraceId, "Begin change role. New role: {0}.", newRole);
 
             if (newRole == ReplicaRole.Primary)
             {
-                this.actorManagerAdapter.ActorManager = new ActorManager(this, clock, diagnostics);
-                await this.actorManagerAdapter.OpenAsync(this.Partition, cancellationToken);
-                this.diagnostics.ActorChangeRole(this.replicaRole, newRole);
+                actorManagerAdapter.ActorManager = new ActorManager(this, Clock, Diagnostics);
+                await actorManagerAdapter.OpenAsync(Partition, cancellation);
+                Diagnostics.ActorChangeRole(replicaRole, newRole);
             }
             else
             {
-                this.diagnostics.ActorChangeRole(this.replicaRole, newRole);
-                await this.actorManagerAdapter.CloseAsync(cancellationToken);
+                Diagnostics.ActorChangeRole(replicaRole, newRole);
+                await actorManagerAdapter.CloseAsync(cancellation);
             }
 
-            this.replicaRole = newRole;
+            replicaRole = newRole;
 
-            ActorTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.Context.TraceId,
-                "End change role. New role: {0}.",
-                newRole);
+            ActorTrace.Source.WriteInfoWithId(TraceType, Context.TraceId, "End change role. New role: {0}.", newRole);
         }
 
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnCloseAsync(CancellationToken)"/>.
-        /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous operation performed when the replica is closed.</returns>
-        protected override async Task OnCloseAsync(CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        protected override async Task OnCloseAsync(CancellationToken cancellation)
         {
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "Begin close.");
+            ActorTrace.Source.WriteInfoWithId(TraceType, Context.TraceId, "Begin close.");
+            ActorTelemetry.ActorServiceReplicaCloseEvent(ActorManager.ActorService.Context);
 
-            ActorTelemetry.ActorServiceReplicaCloseEvent(this.ActorManager.ActorService.Context);
+            await actorManagerAdapter.CloseAsync(cancellation);
+            diagnosticsFactory.Dispose();
 
-            await this.actorManagerAdapter.CloseAsync(cancellationToken);
-            this.diagnosticsFactory.Dispose();
-
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "End close.");
+            ActorTrace.Source.WriteInfoWithId(TraceType, Context.TraceId, "End close.");
         }
 
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnAbort()"/>.
-        /// </summary>
+        /// <inheritdoc/>
         protected override void OnAbort()
         {
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "Abort.");
-
-            this.actorManagerAdapter.Abort();
+            ActorTrace.Source.WriteInfoWithId(TraceType, Context.TraceId, "Abort.");
+            actorManagerAdapter.Abort();
         }
 
         #endregion
-        private static IActorStateManager DefaultActorStateManagerFactory(
-            ActorBase actorBase,
-            IActorStateProvider actorStateProvider)
-        {
-            return new ActorStateManager(actorBase, actorStateProvider, actorBase.ActorService.Diagnostics, actorBase.ActorService.Clock);
-        }
 
-        private ActorBase DefaultActorFactory(ActorService actorService, ActorId actorId)
-        {
-            return (ActorBase)Activator.CreateInstance(
-                this.ActorTypeInformation.ImplementationType,
-                actorService,
-                actorId);
-        }
+        static IActorStateManager DefaultActorStateManagerFactory(ActorBase actor, IActorStateProvider stateProvider) =>
+            new ActorStateManager(actor, stateProvider, actor.ActorService.Diagnostics, actor.ActorService.Clock);
+
+        ActorBase DefaultActorFactory(ActorService service, ActorId id) => 
+            (ActorBase)Activator.CreateInstance(ActorTypeInformation.ImplementationType, service, id);
     }
 }


### PR DESCRIPTION
Remove
- Redundant comments
- Unnecessary `this.`
- Unnecessary fields
- Unreferenced methods left over from removed actor state migration

Also,
- Convert single-line methods to expression style.
- Convert properties to auto style