### PR TITLE
Add internals visible to all data test projects for Metrics.

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>23</Revision>
+    <Revision>24</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/AssemblyInfo.cs
+++ b/src/Diagnostics/AssemblyInfo.cs
@@ -59,6 +59,12 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("System.Fabric.Replicator.Test" + TestKey)]
 [assembly: InternalsVisibleTo("System.Fabric.Store.Test" + PublicKey)]
 [assembly: InternalsVisibleTo("System.Fabric.Store.Test" + TestKey)]
+[assembly: InternalsVisibleTo("System.Fabric.Collections.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("System.Fabric.Collections.Test" + TestKey)]
+[assembly: InternalsVisibleTo("System.Fabric.ReplicatorStack.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("System.Fabric.ReplicatorStack.Test" + TestKey)]
+[assembly: InternalsVisibleTo("System.Fabric.KtlLogicalLogBuffer.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("System.Fabric.KtlLogicalLogBuffer.Test" + TestKey)]
 
 [assembly: InternalsVisibleTo("FabricIS.parallel" + PublicKey)]
 [assembly: InternalsVisibleTo("FabricIS.parallel" + TestKey)]


### PR DESCRIPTION
Need to add System.Fabric.Collections.Test but since metrics are going in almost everywhere and I don't want to have to make another PR when that happens, I've also added the rest of the data test projects.