### PR TITLE
Add Diagnostics visibility for FabricTelemetryApp

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>23</Revision>
+    <Revision>24</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/AssemblyInfo.cs
+++ b/src/Diagnostics/AssemblyInfo.cs
@@ -23,6 +23,7 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("NodeAgentSFUtilityTest" + TestKey)]
 [assembly: InternalsVisibleTo("TelemetryLibTest" + TestKey)]
 [assembly: InternalsVisibleTo("EventsValidationTest" + PublicKey)]
+[assembly: InternalsVisibleTo("FabricTelemetryApp" + PublicKey)]
 [assembly: InternalsVisibleTo("AzureFilesVolumePlugin" + PublicKey)]
 [assembly: InternalsVisibleTo("AzureFilesVolumePluginSetup" + PublicKey)]
 [assembly: InternalsVisibleTo("SFVolumeDiskDebugAgentCommon" + PublicKey)]


### PR DESCRIPTION
Allow FabricTelemetryApp to use Diagnostics internal API for metrics.

FabricTelemetryApp is a test app used by Observability team to verify metric emission.