### PR TITLE
Mark the 3 traces as verbose/noise

### DIFF
--- a/src/Actors/Runtime/ActorBase.cs
+++ b/src/Actors/Runtime/ActorBase.cs
@@ -132,12 +132,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
             this.diagnostics.ActorOnActivateAsyncFinish(startTime);
 
-            this.Manager.TraceSource.WriteInfoWithId(TraceType, this.traceId, "Activated");
+            this.Manager.TraceSource.WriteNoiseWithId(TraceType, this.traceId, "Activated");
         }
 
         internal virtual async Task OnDeactivateInternalAsync()
         {
-            this.Manager.TraceSource.WriteInfoWithId(TraceType, this.traceId, "Deactivating ...");
+            this.Manager.TraceSource.WriteNoiseWithId(TraceType, this.traceId, "Deactivating ...");
             if (this.timers != null)
             {
                 var toDispose = this.timers.ToArray();
@@ -150,7 +150,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             }
 
             await this.OnDeactivateAsync();
-            this.Manager.TraceSource.WriteInfoWithId(TraceType, this.traceId, "Deactivated");
+            this.Manager.TraceSource.WriteNoiseWithId(TraceType, this.traceId, "Deactivated");
         }
 
         internal void OnInvokeFailedInternal()


### PR DESCRIPTION
These 3 traces occur most frequently and, in large Service Fabric clusters, can appear thousands of times per second. They do not provide meaningful diagnostic value and ultimately add unnecessary noise to the logs.

```kusto
...
| where ETWTimestamp > ago(3h)
| where (Text == "Activated" or Text == "Deactivated" or Text == "Deactivating ...") and EventType == "ActorBase"
| summarize count() by bin(ETWTimestamp, 1s), RoleInstance, Tenant
| project-away Tenant, RoleInstance
| order by count_ desc 
| take 20
```

Result

```
ETWTimestamp                | count
--------------------------- | -----
2026-02-24 15:48:03.0000000 | 79440
2026-02-24 13:32:30.0000000 | 64049
2026-02-24 12:21:34.0000000 | 46928
2026-02-24 16:18:23.0000000 | 45574
2026-02-24 14:43:18.0000000 | 45478
2026-02-24 17:05:06.0000000 | 43272
2026-02-24 16:35:01.0000000 | 43083
2026-02-24 16:18:00.0000000 | 42898
2026-02-24 17:32:39.0000000 | 42104
2026-02-24 11:15:54.0000000 | 40524
2026-02-24 15:27:03.0000000 | 40194
2026-02-24 16:43:55.0000000 | 40053
2026-02-24 14:23:04.0000000 | 39623
2026-02-24 13:24:29.0000000 | 38744
2026-02-24 15:28:43.0000000 | 36698
2026-02-24 14:22:23.0000000 | 36064
2026-02-24 16:12:04.0000000 | 33820
2026-02-24 18:51:16.0000000 | 33666
2026-02-24 14:39:07.0000000 | 33570
2026-02-24 15:47:17.0000000 | 33289
```