### PR TITLE
Remove ReplicaId from System Dimensions

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>24</Revision>
+    <Revision>25</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -26,7 +26,6 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             {
                 this.systemDimensionNames = new[]
                 {
-                    nameof(ServiceContext.ReplicaOrInstanceId),
                     nameof(ServiceContext.PartitionId),
                     nameof(ServiceContext.ServiceTypeName),
                     nameof(ServiceContext.ServiceName),
@@ -36,7 +35,6 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
                 this.systemDimensionValues = new[]
                 {
-                    serviceContext.ReplicaOrInstanceId.ToString(),
                     serviceContext.PartitionId.ToString(),
                     serviceContext.ServiceTypeName,
                     serviceContext.ServiceName.ToString(),

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -39,19 +39,17 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
                 var actualSystemDimensionNames = (string[])sut.Private().Field<IEnumerable<string>>().Value;
                 var actualSystemDimensionValues = (string[])sut.Protected().Field<IEnumerable<string>>().Value;
 
-                Assert.Equal(serviceContext.ReplicaOrInstanceId.ToString(), actualSystemDimensionValues[0]);
-                Assert.Equal(serviceContext.PartitionId.ToString(), actualSystemDimensionValues[1]);
-                Assert.Equal(serviceContext.ServiceTypeName, actualSystemDimensionValues[2]);
-                Assert.Equal(serviceContext.ServiceName.ToString(), actualSystemDimensionValues[3]);
-                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationName, actualSystemDimensionValues[4]);
-                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationTypeName, actualSystemDimensionValues[5]);
+                Assert.Equal(serviceContext.PartitionId.ToString(), actualSystemDimensionValues[0]);
+                Assert.Equal(serviceContext.ServiceTypeName, actualSystemDimensionValues[1]);
+                Assert.Equal(serviceContext.ServiceName.ToString(), actualSystemDimensionValues[2]);
+                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationName, actualSystemDimensionValues[3]);
+                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationTypeName, actualSystemDimensionValues[4]);
 
-                Assert.Equal(nameof(ServiceContext.ReplicaOrInstanceId), actualSystemDimensionNames[0]);
-                Assert.Equal(nameof(ServiceContext.PartitionId), actualSystemDimensionNames[1]);
-                Assert.Equal(nameof(ServiceContext.ServiceTypeName), actualSystemDimensionNames[2]);
-                Assert.Equal(nameof(ServiceContext.ServiceName), actualSystemDimensionNames[3]);
-                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationName), actualSystemDimensionNames[4]);
-                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationTypeName), actualSystemDimensionNames[5]);
+                Assert.Equal(nameof(ServiceContext.PartitionId), actualSystemDimensionNames[0]);
+                Assert.Equal(nameof(ServiceContext.ServiceTypeName), actualSystemDimensionNames[1]);
+                Assert.Equal(nameof(ServiceContext.ServiceName), actualSystemDimensionNames[2]);
+                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationName), actualSystemDimensionNames[3]);
+                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationTypeName), actualSystemDimensionNames[4]);
             }
 
             [Fact]


### PR DESCRIPTION
Remove ReplicaId from the default system dimensions that are emitted. 
ReplicaId has a high cardinality and could cause cardinality explosion.