### PR TITLE
Cleanup .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,49 +15,40 @@ indent_size = 4
 insert_final_newline = true
 charset = utf-8
 
-# Xml build files
-[*.builds]
-indent_size = 2
-
 # Xml files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct,xml}]
-indent_size = 2
-
-# Xml project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+[*.{xml,csproj,props,targets,config,resx}]
 indent_size = 2
 
 # Json files
 [*.json]
 indent_size = 2
 
-# C++ Files
-[*.{cpp,h,in}]
-curly_bracket_next_line = true
-indent_brace_style = Allman
-
 # Shell scripts
 [*.sh]
 end_of_line = lf
-[*.{cmd, bat}]
-end_of_line = crlf
 
 ###############################
-# .NET OSS Coding Conventions #
+# C# Coding Conventions       #
 ###############################
-[*.{cs,vb}]
+[*.{cs}]
+
+# Namespaces
+csharp_style_namespace_declarations = file_scoped:warning # Reduce space wasted on the left
+
 # Organize usings
+csharp_using_directive_placement = outside_namespace:warning # Inside, they can be "simplified" by dropping prefixes and become unreadable
+dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 
 # Avoid this., reduce the code size and complexity to make it irrelevant instead
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
 
 # Use language keywords instead of BCL types
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:none
@@ -66,21 +57,23 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_null_propagation = false:error
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:none
-dotnet_style_require_accessibility_modifiers = always:suggestion
+dotnet_style_require_accessibility_modifiers = omit_if_default:warning # Don't re-state the obvious
 dotnet_prefer_inferred_tuple_names = true:suggestion
 dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
 
-[*.cs]
-# Expression-bodied members
-csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = false:none
+# Make fields read-only
+dotnet_style_readonly_field = true:warning
 
-# SF-OSS: changed from true to false
-csharp_style_expression_bodied_properties = false:none
-
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
+# Avoid unnecessary braces
+csharp_prefer_braces = false:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
 
 # Pattern matching
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -94,13 +87,6 @@ csharp_style_conditional_delegate_call = false:none
 # Expression-level preferences
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
 
-[*.vb]
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
-
-###############################
-# .NET Formatting Rules       #
-###############################
-[*.cs]
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -122,13 +108,13 @@ csharp_space_between_method_call_parameter_list_parentheses = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 
-###############################
-# Roslyn-Specific Conventions #
-###############################
-# Always use var
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+# Use explicit variable type with implicit constructor syntax
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+
+# Use var only when the appears explicitly in the initialization statement and it's not a constructor
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_elsewhere = false:suggestion # Allow var with generics, i.e. var e = Assert.Throws<T>()
 
 # Avoid unnecessary braces and try to simplify the code to improve readability instead
 csharp_prefer_braces = multiple_lines:suggestion
@@ -152,60 +138,37 @@ dotnet_naming_style.I_prefix_style.capitalization               = pascal_case
 dotnet_naming_style.T_prefix_style.required_prefix              = T
 dotnet_naming_style.T_prefix_style.capitalization               = pascal_case
 
-# Use PascalCase for constant fields  
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds            = field
-dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
-dotnet_naming_symbols.constant_fields.required_modifiers          = const
+# camelCase private fields
+dotnet_naming_rule.camel_case_private_fields.severity           = warning
+dotnet_naming_rule.camel_case_private_fields.symbols            = private_fields
+dotnet_naming_rule.camel_case_private_fields.style              = camel_case_style
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
-# Use PascalCase for static fields  
-dotnet_naming_rule.static_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_pascal_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_pascal_case.style    = camel_case_style
-dotnet_naming_symbols.static_fields.applicable_kinds            = field
-dotnet_naming_symbols.static_fields.applicable_accessibilities  = *
-dotnet_naming_symbols.static_fields.required_modifiers          = static
+# camelCase parameters and variables
+dotnet_naming_rule.camel_case_locals.severity           = warning
+dotnet_naming_rule.camel_case_locals.symbols            = locals
+dotnet_naming_rule.camel_case_locals.style              = camel_case_style
+dotnet_naming_symbols.locals.applicable_kinds           = local,parameter
+dotnet_naming_symbols.locals.applicable_accessibilities = *
 
-# Use PascalCase for public fields
-dotnet_naming_rule.pascal_case_for_public_fields.severity       = warning
-dotnet_naming_rule.pascal_case_for_public_fields.symbols        = public_fields
-dotnet_naming_rule.pascal_case_for_public_fields.style          = pascal_case_style
-dotnet_naming_symbols.public_fields.applicable_kinds            = field
-dotnet_naming_symbols.public_fields.applicable_accessibilities  = public
+# PascalCase interfaces with an I prefix
+dotnet_naming_rule.interfaces_start_with_I.severity            = warning
+dotnet_naming_rule.interfaces_start_with_I.symbols             = any_interface
+dotnet_naming_rule.interfaces_start_with_I.style               = I_prefix_style
+dotnet_naming_symbols.any_interface.applicable_kinds           = interface
+dotnet_naming_symbols.any_interface.applicable_accessibilities = *
 
-# Use camelCase for all other fields
-dotnet_naming_rule.camel_case_for_other_fields.severity         = warning
-dotnet_naming_rule.camel_case_for_other_fields.symbols          = other_fields
-dotnet_naming_rule.camel_case_for_other_fields.style            = camel_case_style
-dotnet_naming_symbols.other_fields.applicable_kinds             = field
-dotnet_naming_symbols.other_fields.applicable_accessibilities   = *
-
-# Interfaces must be PascalCase and have an I prefix 
-dotnet_naming_rule.interfaces_start_with_I.severity             = warning
-dotnet_naming_rule.interfaces_start_with_I.symbols              = any_interface
-dotnet_naming_rule.interfaces_start_with_I.style                = I_prefix_style
-dotnet_naming_symbols.any_interface.applicable_accessibilities  = *
-dotnet_naming_symbols.any_interface.applicable_kinds            = interface
-
-# Classes, structs, methods, enums, events, properties, namespaces, delegates must be PascalCase
-dotnet_naming_rule.general_naming.severity                  = warning
-dotnet_naming_rule.general_naming.symbols                   = general
-dotnet_naming_rule.general_naming.style                     = pascal_case_style
-dotnet_naming_symbols.general.applicable_kinds              = class,struct,enum,property,method,event,namespace,delegate
-dotnet_naming_symbols.general.applicable_accessibilities    = *
-
-# Type parameters should be PascalCase and start with T
+# PascalCase type parameters with a T prefix
 dotnet_naming_rule.type_parameters_should_be_pascal_case.severity = warning
 dotnet_naming_rule.type_parameters_should_be_pascal_case.symbols  = type_parameters
 dotnet_naming_rule.type_parameters_should_be_pascal_case.style    = T_prefix_style
 dotnet_naming_symbols.type_parameters.applicable_kinds            = type_parameter
 dotnet_naming_symbols.type_parameters.applicable_accessibilities  = *
 
-# Everything else is camelCase
-dotnet_naming_rule.everything_else_naming.severity                  = warning
-dotnet_naming_rule.everything_else_naming.symbols                   = everything_else
-dotnet_naming_rule.everything_else_naming.style                     = camel_case_style
-dotnet_naming_symbols.everything_else.applicable_kinds              = *
-dotnet_naming_symbols.everything_else.applicable_accessibilities    = *
+# PascalCase everything else
+dotnet_naming_rule.general_naming.severity               = warning
+dotnet_naming_rule.general_naming.symbols                = general
+dotnet_naming_rule.general_naming.style                  = pascal_case_style
+dotnet_naming_symbols.general.applicable_kinds           = *
+dotnet_naming_symbols.general.applicable_accessibilities = *

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "accessibilities",
         "DSTS",
         "netframework",
         "netstandard",


### PR DESCRIPTION
To encourage succinct, expressive code and make authors think carefully about it's readability and complexity, change the `.editorconfig` to
- Reduce brace noise with file-scoped namespaces and expression-bodied members.
- Make sure `var` usage doesn't obscure variable types when we read/review code without IDE assistance.
- Reduce noise from redundant accessibility modifiers and `this.` qualifiers.
- Make fields read-only.
- camelCase private fields, parameters, locals and PascalCase everything else.
- Place using directives outside of namespace to avoid IDE suggestions that "simplify" namespaces by dropping prefixes and can make them ambiguous to human readers.

Also:
- Remove redundant settings 
- Remove C++, VB settings not applicable to this repo