### PR TITLE
Enable deterministic dispose for IMeter and IMeterProvider 

### DIFF
--- a/src/Actors/Diagnostics/AggregatedDiagnostics.cs
+++ b/src/Actors/Diagnostics/AggregatedDiagnostics.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class AggregatedDiagnostics : IDiagnostics, IDisposable
+    sealed class AggregatedDiagnostics : IDiagnostics
     {
         readonly IEnumerable<IDiagnostics> diagnosticEvents;
 
@@ -146,10 +146,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         {
             foreach (IDiagnostics d in diagnosticEvents)
             {
-                if (d is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
+                d.Dispose();
             }
         }
     }

--- a/src/Actors/Diagnostics/AggregatedDiagnostics.cs
+++ b/src/Actors/Diagnostics/AggregatedDiagnostics.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class AggregatedDiagnostics : IDiagnostics
+    sealed class AggregatedDiagnostics : IDiagnostics, IDisposable
     {
         readonly IEnumerable<IDiagnostics> diagnosticEvents;
 
@@ -139,6 +139,17 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             foreach (IDiagnostics d in diagnosticEvents)
             {
                 d.AcquireActorLockFinish(diagnosticData, startTime);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (IDiagnostics d in diagnosticEvents)
+            {
+                if (d is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
             }
         }
     }

--- a/src/Actors/Diagnostics/DiagnosticsFactory.cs
+++ b/src/Actors/Diagnostics/DiagnosticsFactory.cs
@@ -22,8 +22,6 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         readonly IMeterProvider<TimeSpan> timeSpanMeterProvider;
         readonly IMeterProvider<long> longMeterProvider;
 
-        AggregatedDiagnostics createdDiagnostics;
-
         public DiagnosticsFactory(ServiceContext serviceContext, ActorTypeInformation typeInformation, ActorMethodFriendlyNameBuilder friendlyNameBuilder)
         {
             this.serviceContext = serviceContext ?? throw new ArgumentNullException(nameof(serviceContext));
@@ -44,13 +42,11 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             var metricDiagnostics = new MetricDiagnostics(longMeterProvider, timeSpanMeterProvider, clock, friendlyNameBuilder, typeInformation);
             var registeredDiagnostics = new IDiagnostics[] { performanceCounterDiagnostics, eventSourceDiagnostics, metricDiagnostics };
 
-            createdDiagnostics = new AggregatedDiagnostics(registeredDiagnostics);
-            return createdDiagnostics;
+            return new AggregatedDiagnostics(registeredDiagnostics);
         }
 
         public virtual void Dispose()
         {
-            createdDiagnostics?.Dispose();
             performanceCounterProvider.Dispose();
             timeSpanMeterProvider.Dispose();
             longMeterProvider.Dispose();

--- a/src/Actors/Diagnostics/DiagnosticsFactory.cs
+++ b/src/Actors/Diagnostics/DiagnosticsFactory.cs
@@ -22,6 +22,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         readonly IMeterProvider<TimeSpan> timeSpanMeterProvider;
         readonly IMeterProvider<long> longMeterProvider;
 
+        AggregatedDiagnostics createdDiagnostics;
+
         public DiagnosticsFactory(ServiceContext serviceContext, ActorTypeInformation typeInformation, ActorMethodFriendlyNameBuilder friendlyNameBuilder)
         {
             this.serviceContext = serviceContext ?? throw new ArgumentNullException(nameof(serviceContext));
@@ -42,12 +44,16 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             var metricDiagnostics = new MetricDiagnostics(longMeterProvider, timeSpanMeterProvider, clock, friendlyNameBuilder, typeInformation);
             var registeredDiagnostics = new IDiagnostics[] { performanceCounterDiagnostics, eventSourceDiagnostics, metricDiagnostics };
 
-            return new AggregatedDiagnostics(registeredDiagnostics);
+            createdDiagnostics = new AggregatedDiagnostics(registeredDiagnostics);
+            return createdDiagnostics;
         }
 
         public virtual void Dispose()
         {
+            createdDiagnostics?.Dispose();
             performanceCounterProvider.Dispose();
+            timeSpanMeterProvider.Dispose();
+            longMeterProvider.Dispose();
         }
     }
 }

--- a/src/Actors/Diagnostics/EventSourceDiagnostics.cs
+++ b/src/Actors/Diagnostics/EventSourceDiagnostics.cs
@@ -149,6 +149,11 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
                 eventSource.ActorSaveStateStart(actorType, actorId, serviceContext);
             }
         }
+        public void Dispose()
+        {
+            // No resources to release
+        }
+
         private long TicksSinceStart(DateTime startTime)
         {
             return TimeSpan.FromMilliseconds((long)(clock.UtcNow - startTime).TotalMilliseconds).Ticks;

--- a/src/Actors/Diagnostics/IDiagnostics.cs
+++ b/src/Actors/Diagnostics/IDiagnostics.cs
@@ -8,7 +8,7 @@ using System.Fabric;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    internal interface IDiagnostics
+    internal interface IDiagnostics : IDisposable
     {
         void ActorRequestProcessingStart();
 

--- a/src/Actors/Diagnostics/MetricDiagnostics.cs
+++ b/src/Actors/Diagnostics/MetricDiagnostics.cs
@@ -12,7 +12,7 @@ using Microsoft.ServiceFabric.Diagnostics.Metrics;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class MetricDiagnostics : IDiagnostics
+    sealed class MetricDiagnostics : IDiagnostics, IDisposable
     {
         private const string ActorMetricsNamespace = "Actor";
         private const string NoneException = "None";
@@ -125,6 +125,18 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         public void SaveActorStateStart(ActorId actorId)
         {
             // Intentionally left blank, since we don't track
+        }
+
+        public void Dispose()
+        {
+            pendingMethodCalls.Dispose();
+            acquireLockDuration.Dispose();
+            releaseLockDuration.Dispose();
+            methodExecutionDuration.Dispose();
+            onActivateAsyncDuration.Dispose();
+            requestProcessingDuration.Dispose();
+            loadStateDuration.Dispose();
+            saveStateDuration.Dispose();
         }
     }
 }

--- a/src/Actors/Diagnostics/MetricDiagnostics.cs
+++ b/src/Actors/Diagnostics/MetricDiagnostics.cs
@@ -38,16 +38,16 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             _ = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
-            this.pendingMethodCalls = longMeterProvider.CreateMeter(ActorMetricsNamespace, "PendingMethodCalls");
-            this.acquireLockDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "AcquireLockDuration");
-            this.releaseLockDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "ReleaseLockDuration");
-            this.methodExecutionDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "MethodExecutionDuration", "MethodName", "MethodSigniture", "Exception");
-            this.onActivateAsyncDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "OnActivateAsyncDuration");
-            this.requestProcessingDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "RequestProcessingDuration");
-            this.loadStateDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "LoadStateDuration");
-            this.saveStateDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "SaveStateDuration");
+            pendingMethodCalls = longMeterProvider.CreateMeter(ActorMetricsNamespace, "PendingMethodCalls");
+            acquireLockDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "AcquireLockDuration");
+            releaseLockDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "ReleaseLockDuration");
+            methodExecutionDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "MethodExecutionDuration", "MethodName", "MethodSigniture", "Exception");
+            onActivateAsyncDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "OnActivateAsyncDuration");
+            requestProcessingDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "RequestProcessingDuration");
+            loadStateDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "LoadStateDuration");
+            saveStateDuration = timeSpanProvider.CreateMeter(ActorMetricsNamespace, "SaveStateDuration");
 
-            this.actorMethodInfo = ActorMethodInfoUtil.BuildActorMethodInfo(nameBuilder, typeInfo);
+            actorMethodInfo = ActorMethodInfoUtil.BuildActorMethodInfo(nameBuilder, typeInfo);
         }
 
         public void AcquireActorLockFinish(PendingActorMethodDiagnosticData diagnosticData, DateTime startTime)
@@ -82,45 +82,30 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             // Intentionally left blank, since we don't track
         }
 
-        public void ActorOnActivateAsyncFinish(DateTime startTime)
-        {
-            onActivateAsyncDuration.Record(clock.UtcNow - startTime);
-        }
+        public void ActorOnActivateAsyncFinish(DateTime startTime) => onActivateAsyncDuration.Record(clock.UtcNow - startTime);
 
         public void ActorOnActivateAsyncStart()
         {
             // Intentionally left blank, since we don't track
         }
 
-        public void ActorRequestProcessingFinish(DateTime startTime)
-        {
-            requestProcessingDuration.Record(clock.UtcNow - startTime);
-        }
+        public void ActorRequestProcessingFinish(DateTime startTime) => requestProcessingDuration.Record(clock.UtcNow - startTime);
 
         public void ActorRequestProcessingStart()
         {
             // Intentionally left blank, since we don't track
         }
 
-        public void LoadActorStateFinish(DateTime startTime)
-        {
-            loadStateDuration.Record(clock.UtcNow - startTime);
-        }
+        public void LoadActorStateFinish(DateTime startTime) => loadStateDuration.Record(clock.UtcNow - startTime);
 
         public void LoadActorStateStart()
         {
             // Intentionally left blank, since we don't track
         }
 
-        public void ReleaseActorLock(DateTime startTime)
-        {
-            releaseLockDuration.Record(clock.UtcNow - startTime);
-        }
+        public void ReleaseActorLock(DateTime startTime) => releaseLockDuration.Record(clock.UtcNow - startTime);
 
-        public void SaveActorStateFinish(ActorId actorId, DateTime startTime)
-        {
-            saveStateDuration.Record(clock.UtcNow - startTime);
-        }
+        public void SaveActorStateFinish(ActorId actorId, DateTime startTime) => saveStateDuration.Record(clock.UtcNow - startTime);
 
         public void SaveActorStateStart(ActorId actorId)
         {

--- a/src/Actors/Diagnostics/MetricDiagnostics.cs
+++ b/src/Actors/Diagnostics/MetricDiagnostics.cs
@@ -12,7 +12,7 @@ using Microsoft.ServiceFabric.Diagnostics.Metrics;
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    sealed class MetricDiagnostics : IDiagnostics, IDisposable
+    sealed class MetricDiagnostics : IDiagnostics
     {
         private const string ActorMetricsNamespace = "Actor";
         private const string NoneException = "None";

--- a/src/Actors/Diagnostics/PerformanceCounterDiagnostics.cs
+++ b/src/Actors/Diagnostics/PerformanceCounterDiagnostics.cs
@@ -141,6 +141,11 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             // Intentionally left blank, since we don't track
         }
 
+        public void Dispose()
+        {
+            // No resources to release
+        }
+
         private long LongMillisecondsSinceStart(DateTime startTime)
         {
             return (long)(clock.UtcNow - startTime).TotalMilliseconds;

--- a/src/Actors/Runtime/ActorService.cs
+++ b/src/Actors/Runtime/ActorService.cs
@@ -348,6 +348,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             ActorTelemetry.ActorServiceReplicaCloseEvent(this.ActorManager.ActorService.Context);
 
             await this.actorManagerAdapter.CloseAsync(cancellationToken);
+            this.diagnostics.Dispose();
             this.diagnosticsFactory.Dispose();
 
             ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "End close.");

--- a/src/Diagnostics/Metrics/IMeter.cs
+++ b/src/Diagnostics/Metrics/IMeter.cs
@@ -3,13 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics
 {
     /// <summary>
     /// Defines a meter for recording telemetry values.
     /// </summary>
     /// <typeparam name="TValueType">The type of the value to be recorded.</typeparam>
-    interface IMeter<TValueType>
+    interface IMeter<TValueType> : IDisposable
     {
         /// <summary>
         /// Records a telemetry value.

--- a/src/Diagnostics/Metrics/IMeter1D.cs
+++ b/src/Diagnostics/Metrics/IMeter1D.cs
@@ -3,13 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics
 {
     /// <summary>
     /// Defines a one-dimensional meter for recording telemetry values with a single dimension.
     /// </summary>
     /// <typeparam name="TValueType">The type of the value to be recorded.</typeparam>
-    interface IMeter1D<TValueType>
+    interface IMeter1D<TValueType> : IDisposable
     {
         /// <summary>
         /// Records a telemetry value with one dimension.

--- a/src/Diagnostics/Metrics/IMeter2D.cs
+++ b/src/Diagnostics/Metrics/IMeter2D.cs
@@ -3,13 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics
 {
     /// <summary>
     /// Defines a two-dimensional meter for recording telemetry values with two dimensions.
     /// </summary>
     /// <typeparam name="TValueType">The type of the value to be recorded.</typeparam>
-    interface IMeter2D<TValueType>
+    interface IMeter2D<TValueType> : IDisposable
     {
         /// <summary>
         /// Records a telemetry value with two dimensions.

--- a/src/Diagnostics/Metrics/IMeter3D.cs
+++ b/src/Diagnostics/Metrics/IMeter3D.cs
@@ -3,13 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics
 {
     /// <summary>
     /// Defines a three-dimensional meter for recording telemetry values with three dimensions.
     /// </summary>
     /// <typeparam name="TValueType">The type of the value to be recorded.</typeparam>
-    interface IMeter3D<TValueType>
+    interface IMeter3D<TValueType> : IDisposable
     {
         /// <summary>
         /// Records a telemetry value with three dimensions.

--- a/src/Diagnostics/Metrics/IMeterProvider.cs
+++ b/src/Diagnostics/Metrics/IMeterProvider.cs
@@ -3,13 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics
 {
     /// <summary>
     /// Provides factory methods for creating telemetry meters with different number of dimensions.
     /// </summary>
     /// <typeparam name="TValueType">The type of the value to be recorded. Currently intended to support integer and timespan meters.</typeparam>
-    interface IMeterProvider<TValueType>
+    interface IMeterProvider<TValueType> : IDisposable
     {
         /// <summary>
         /// Creates a meter for recording telemetry values without dimensions.

--- a/src/Diagnostics/Metrics/Implementation/IFabricMeter.cs
+++ b/src/Diagnostics/Metrics/Implementation/IFabricMeter.cs
@@ -5,10 +5,9 @@
 
 using System;
 using System.Runtime.InteropServices;
-
-#if NET
 using System.Runtime.InteropServices.Marshalling;
-#else
+
+#if !NET
 using GeneratedComInterfaceAttribute = System.Runtime.InteropServices.ComImportAttribute;
 #endif
 

--- a/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
@@ -5,10 +5,9 @@
 
 using System;
 using System.Runtime.InteropServices;
-
-#if NET
 using System.Runtime.InteropServices.Marshalling;
-#else
+
+#if !NET
 using GeneratedComInterfaceAttribute = System.Runtime.InteropServices.ComImportAttribute;
 #endif
 
@@ -19,6 +18,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     partial interface IFabricMeterProvider
     {
+        [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
         IFabricMeter CreateMeter([MarshalAs(UnmanagedType.LPWStr)] string metricNamespace, [MarshalAs(UnmanagedType.LPWStr)] string name, uint count, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] dimensionNames);
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/Int64Meter1D.cs
+++ b/src/Diagnostics/Metrics/Implementation/Int64Meter1D.cs
@@ -11,9 +11,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         internal Int64Meter1D(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues) : base(fabricMeter, systemDimensionValues) { }
 
-        void IMeter1D<long>.Record(long value, string dimension1)
+        void IMeter1D<long>.Record(long value, string dimension1Value)
         {
-            base.Record(value, dimension1);
+            base.Record(value, dimension1Value);
         }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/Int64Meter2D.cs
+++ b/src/Diagnostics/Metrics/Implementation/Int64Meter2D.cs
@@ -11,9 +11,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         internal Int64Meter2D(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues) : base(fabricMeter, systemDimensionValues) { }
 
-        void IMeter2D<long>.Record(long value, string dimension1, string dimension2)
+        void IMeter2D<long>.Record(long value, string dimension1Value, string dimension2Value)
         {
-            base.Record(value, dimension1, dimension2);
+            base.Record(value, dimension1Value, dimension2Value);
         }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/Int64Meter3D.cs
+++ b/src/Diagnostics/Metrics/Implementation/Int64Meter3D.cs
@@ -11,9 +11,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         internal Int64Meter3D(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues) : base(fabricMeter, systemDimensionValues) { }
 
-        void IMeter3D<long>.Record(long value, string dimension1, string dimension2, string dimension3)
+        void IMeter3D<long>.Record(long value, string dimension1Value, string dimension2Value, string dimension3Value)
         {
-            base.Record(value, dimension1, dimension2, dimension3);
+            base.Record(value, dimension1Value, dimension2Value, dimension3Value);
         }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         protected long ConvertTimeSpanToLong(TimeSpan value) => (long)Math.Round(value.TotalMilliseconds);
 
-        unsafe protected void RecordViaNative(long value, int customDimensionCount, string dimension1Value, string dimension2Value, string dimension3Value)
+        protected unsafe void RecordViaNative(long value, int customDimensionCount, string dimension1Value, string dimension2Value, string dimension3Value)
         {
             if (disposed)
                 throw new ObjectDisposedException(nameof(Meter));

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -19,7 +19,6 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
         static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
         bool disposed = false;
 
-
         internal Meter(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues)
         {
             this.systemDimensionValues = systemDimensionValues ?? throw new ArgumentNullException(nameof(systemDimensionValues));
@@ -42,7 +41,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
         unsafe protected void RecordViaNative(long value, int customDimensionCount, string dimension1Value, string dimension2Value, string dimension3Value)
         {
             if (disposed)
-                throw new ObjectDisposedException(nameof(this.GetType));
+                throw new ObjectDisposedException(nameof(Meter));
             if (customDimensionCount < 0 || customDimensionCount > 3)
                 throw new ArgumentOutOfRangeException(nameof(customDimensionCount));
 

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public void Dispose()
         {
-            if (fabricMeter != null)
+            if (!disposed)
             {
                 finalReleaseComObject(fabricMeter);
                 disposed = true;

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -5,15 +5,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Fabric.Interop;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     abstract class Meter : IDisposable
     {
-        protected readonly IFabricMeter fabricMeter;
-
         protected readonly IReadOnlyCollection<string> systemDimensionValues;
+
+        readonly IFabricMeter fabricMeter;
+
+        static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
+        bool disposed = false;
+
 
         internal Meter(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues)
         {
@@ -21,30 +26,25 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             this.fabricMeter = fabricMeter ?? throw new ArgumentNullException(nameof(fabricMeter));
         }
 
-        /// <summary>
-        /// Releases the native COM resources held by this meter.
-        /// </summary>
         public void Dispose()
         {
-            // TODO: Release the fabricMeter COM object
+            if (fabricMeter != null)
+            {
+                finalReleaseComObject(fabricMeter);
+                disposed = true;
+            }
         }
 
-        protected void Record(long value)
-        {
-            RecordViaNative(value, 0, null, null, null);
-        }
+        protected void Record(long value) => RecordViaNative(value, 0, null, null, null);
 
-        protected long ConvertTimeSpanToLong(TimeSpan value)
-        {
-            return (long)Math.Round(value.TotalMilliseconds);
-        }
+        protected long ConvertTimeSpanToLong(TimeSpan value) => (long)Math.Round(value.TotalMilliseconds);
 
         unsafe protected void RecordViaNative(long value, int customDimensionCount, string dimension1Value, string dimension2Value, string dimension3Value)
         {
+            if (disposed)
+                throw new ObjectDisposedException(nameof(this.GetType));
             if (customDimensionCount < 0 || customDimensionCount > 3)
-            {
                 throw new ArgumentOutOfRangeException(nameof(customDimensionCount));
-            }
 
             int dimensionCount = systemDimensionValues.Count + customDimensionCount;
 

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
-    abstract class Meter
+    abstract class Meter : IDisposable
     {
         protected readonly IFabricMeter fabricMeter;
 
@@ -19,6 +19,14 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
         {
             this.systemDimensionValues = systemDimensionValues ?? throw new ArgumentNullException(nameof(systemDimensionValues));
             this.fabricMeter = fabricMeter ?? throw new ArgumentNullException(nameof(fabricMeter));
+        }
+
+        /// <summary>
+        /// Releases the native COM resources held by this meter.
+        /// </summary>
+        public void Dispose()
+        {
+            // TODO: Release the fabricMeter COM object
         }
 
         protected void Record(long value)

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -14,10 +14,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         protected readonly IReadOnlyCollection<string> systemDimensionValues;
 
-        readonly IFabricMeter fabricMeter;
+        IFabricMeter fabricMeter;
 
         static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
-        bool disposed = false;
 
         internal Meter(IFabricMeter fabricMeter, IReadOnlyCollection<string> systemDimensionValues)
         {
@@ -27,10 +26,10 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public void Dispose()
         {
-            if (!disposed)
+            if (!IsDisposed())
             {
                 finalReleaseComObject(fabricMeter);
-                disposed = true;
+                fabricMeter = null;
             }
         }
 
@@ -38,9 +37,11 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         protected long ConvertTimeSpanToLong(TimeSpan value) => (long)Math.Round(value.TotalMilliseconds);
 
+        bool IsDisposed() => fabricMeter == null;
+
         protected unsafe void RecordViaNative(long value, int customDimensionCount, string dimension1Value, string dimension2Value, string dimension3Value)
         {
-            if (disposed)
+            if (IsDisposed())
                 throw new ObjectDisposedException(nameof(Meter));
             if (customDimensionCount < 0 || customDimensionCount > 3)
                 throw new ArgumentOutOfRangeException(nameof(customDimensionCount));

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -60,6 +60,14 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             return fabricMeterProvider.CreateMeter(metricNamespace, metricName, (uint)allDimensions.Length, allDimensions);
         }
 
+        /// <summary>
+        /// Releases the native COM resources held by this meter provider.
+        /// </summary>
+        public void Dispose()
+        {
+            // TODO: Release the fabricMeterProvider COM object
+        }
+
         public abstract IMeter<TValueType> CreateMeter(string metricNamespace, string name);
         public abstract IMeter1D<TValueType> CreateMeter(string metricNamespace, string name, string dimension1Name);
         public abstract IMeter2D<TValueType> CreateMeter(string metricNamespace, string name, string dimension1Name, string dimension2Name);

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public void Dispose()
         {
-            if (fabricMeterProvider != null)
+            if (!disposed)
             {
                 finalReleaseComObject(fabricMeterProvider);
                 disposed = true;

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
+using System.Fabric.Interop;
 using System.Linq;
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
@@ -14,9 +15,12 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         readonly IReadOnlyCollection<string> systemDimensionNames;
         protected readonly IReadOnlyCollection<string> systemDimensionValues;
-        protected readonly IFabricMeterProvider fabricMeterProvider;
+        readonly IFabricMeterProvider fabricMeterProvider;
+
+        bool disposed = false;
 
         static Func<IFabricMeterProvider> createFabricMeterProvider = NativeTelemetry.FabricCreateMeterProvider;
+        static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
 
         protected MeterProvider(ServiceContext serviceContext = null)
         {
@@ -51,6 +55,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         protected IFabricMeter CreateNativeMeter(string metricNamespace, string metricName, IEnumerable<string> additionalDimensions)
         {
+            if (disposed)
+                throw new ObjectDisposedException(nameof(this.GetType));
+
             var allDimensionsList = new List<string>(systemDimensionNames.Count + additionalDimensions.Count());
 
             allDimensionsList.AddRange(systemDimensionNames);
@@ -60,12 +67,13 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             return fabricMeterProvider.CreateMeter(metricNamespace, metricName, (uint)allDimensions.Length, allDimensions);
         }
 
-        /// <summary>
-        /// Releases the native COM resources held by this meter provider.
-        /// </summary>
         public void Dispose()
         {
-            // TODO: Release the fabricMeterProvider COM object
+            if (fabricMeterProvider != null)
+            {
+                finalReleaseComObject(fabricMeterProvider);
+                disposed = true;
+            }
         }
 
         public abstract IMeter<TValueType> CreateMeter(string metricNamespace, string name);

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
         protected IFabricMeter CreateNativeMeter(string metricNamespace, string metricName, IEnumerable<string> additionalDimensions)
         {
             if (disposed)
-                throw new ObjectDisposedException(nameof(this.GetType));
+                throw new ObjectDisposedException(nameof(MeterProvider<TValueType>));
 
             var allDimensionsList = new List<string>(systemDimensionNames.Count + additionalDimensions.Count());
 

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -15,9 +15,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         readonly IReadOnlyCollection<string> systemDimensionNames;
         protected readonly IReadOnlyCollection<string> systemDimensionValues;
-        readonly IFabricMeterProvider fabricMeterProvider;
-
-        bool disposed = false;
+        IFabricMeterProvider fabricMeterProvider;
 
         static Func<IFabricMeterProvider> createFabricMeterProvider = NativeTelemetry.FabricCreateMeterProvider;
         static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
@@ -53,9 +51,11 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             }
         }
 
+        bool IsDisposed() => fabricMeterProvider == null;
+
         protected IFabricMeter CreateNativeMeter(string metricNamespace, string metricName, IEnumerable<string> additionalDimensions)
         {
-            if (disposed)
+            if (IsDisposed())
                 throw new ObjectDisposedException(nameof(MeterProvider<TValueType>));
 
             var allDimensionsList = new List<string>(systemDimensionNames.Count + additionalDimensions.Count());
@@ -69,10 +69,10 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public void Dispose()
         {
-            if (!disposed)
+            if (!IsDisposed())
             {
                 finalReleaseComObject(fabricMeterProvider);
-                disposed = true;
+                fabricMeterProvider = null;
             }
         }
 

--- a/src/Diagnostics/Metrics/Implementation/NativeTelemetry.cs
+++ b/src/Diagnostics/Metrics/Implementation/NativeTelemetry.cs
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------
 
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using HRESULT = System.Int32;
+
 #if !NET
 using LibraryImportAttribute = System.Runtime.InteropServices.DllImportAttribute;
 #endif
@@ -26,7 +28,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 #else
         extern
 #endif
-        HRESULT FabricCreateMeterProvider(out IFabricMeterProvider meterProvider);
+        HRESULT FabricCreateMeterProvider([MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeterProvider>))] out IFabricMeterProvider meterProvider);
 
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/NullMeter.cs
+++ b/src/Diagnostics/Metrics/Implementation/NullMeter.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     sealed class NullMeter<TValueType> : IMeter<TValueType>
     {
         public void Record(TValueType value) { }
+
+        public void Dispose() { }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/NullMeter1D.cs
+++ b/src/Diagnostics/Metrics/Implementation/NullMeter1D.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     sealed class NullMeter1D<TValueType> : IMeter1D<TValueType>
     {
         public void Record(TValueType value, string dimension1) { }
+
+        public void Dispose() { }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/NullMeter2D.cs
+++ b/src/Diagnostics/Metrics/Implementation/NullMeter2D.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     sealed class NullMeter2D<TValueType> : IMeter2D<TValueType>
     {
         public void Record(TValueType value, string dimension1, string dimension2) { }
+
+        public void Dispose() { }
     }
 }

--- a/src/Diagnostics/Metrics/Implementation/NullMeter3D.cs
+++ b/src/Diagnostics/Metrics/Implementation/NullMeter3D.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     sealed class NullMeter3D<TValueType> : IMeter3D<TValueType>
     {
         public void Record(TValueType value, string dimension1, string dimension2, string dimension3) { }
+
+        public void Dispose() { }
     }
 }

--- a/src/Diagnostics/Metrics/NullMeterProvider.cs
+++ b/src/Diagnostics/Metrics/NullMeterProvider.cs
@@ -28,5 +28,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
         {
             return new NullMeter3D<TValueType>();
         }
+
+        public void Dispose() { }
     }
 }

--- a/src/FabricTransport/AssemblyInfo.cs
+++ b/src/FabricTransport/AssemblyInfo.cs
@@ -9,3 +9,4 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.FabricTransport.Tests" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Services.Remoting.Tests" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Services.Remoting" + PublicKey)]
+[assembly: InternalsVisibleTo(DynamicProxyGenAssembly2)]

--- a/src/FabricTransport/Runtime/FabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListener.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Fabric;
 using System.Fabric.Interop;
 using System.Globalization;
@@ -13,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
-    internal class FabricTransportListener : IDisposable
+    internal class FabricTransportListener : IFabricTransportListener
     {
         private NativeFabricTransport.IFabricTransportListener nativeListner;
 

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.ServiceFabric.FabricTransport.Runtime
+{
+    interface IFabricTransportListener : IDisposable
+    {
+        Task<string> OpenAsync(CancellationToken cancellationToken);
+
+        Task CloseAsync(CancellationToken cancellationToken);
+
+        void Abort();
+    }
+}

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
@@ -11,7 +12,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
     /// Defines the interface that must be implemented by the ServiceRemotingListener to receive messages from the
     /// remoting transport.
     /// </summary>
-    internal interface IFabricTransportMessageHandler
+    interface IFabricTransportMessageHandler : IDisposable
     {
         Task<FabricTransportMessage> RequestResponseAsync(FabricTransportRequestContext requestContext,
             FabricTransportMessage fabricTransportMessage);

--- a/src/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEvents.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    internal class AggregatedDiagnosticEvents : IDiagnosticEvents, IDisposable
+    internal class AggregatedDiagnosticEvents : IDiagnosticEvents
     {
         readonly IEnumerable<IDiagnosticEvents> diagnosticEvents;
 
@@ -73,10 +73,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
         {
             foreach (IDiagnosticEvents diagnosticEvent in diagnosticEvents)
             {
-                if (diagnosticEvent is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
+                diagnosticEvent.Dispose();
             }
         }
     }

--- a/src/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEvents.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    internal class AggregatedDiagnosticEvents : IDiagnosticEvents
+    internal class AggregatedDiagnosticEvents : IDiagnosticEvents, IDisposable
     {
         readonly IEnumerable<IDiagnosticEvents> diagnosticEvents;
 
@@ -66,6 +66,17 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             foreach (IDiagnosticEvents diagnosticEvent in diagnosticEvents)
             {
                 diagnosticEvent.OnCreateTransportMessageEnd(startTime);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (IDiagnosticEvents diagnosticEvent in diagnosticEvents)
+            {
+                if (diagnosticEvent is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
             }
         }
     }

--- a/src/Services.Remoting/V2/Diagnostic/IDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/IDiagnosticEvents.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    interface IDiagnosticEvents
+    interface IDiagnosticEvents : IDisposable
     {
         void OnRequestResponseBegin();
         void OnRequestResponseEnd(DateTime startTime);

--- a/src/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEvents.cs
@@ -68,10 +68,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             }
         }
 
+        public void Dispose()
+        {
+            // No resources to release
+        }
+
         private long CalculateMillisecondsSince(DateTime startTime)
         {
             return (long)Math.Round((clock.UtcNow - startTime).TotalMilliseconds);
         }
-
     }
 }

--- a/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
@@ -9,7 +9,7 @@ using Microsoft.ServiceFabric.Diagnostics.Metrics;
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    internal class TelemetryDiagnosticEvents : IDiagnosticEvents, IDisposable
+    internal class TelemetryDiagnosticEvents : IDiagnosticEvents
     {
         readonly IClock clock;
 

--- a/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
@@ -22,9 +22,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             _ = meterProvider ?? throw new ArgumentNullException(nameof(meterProvider));
             this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
-            this.requestProcessingTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.RequestProcessingTime");
-            this.requestDeserializationTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.RequestDeserializationTime");
-            this.responseSerializationTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.ResponseSerializationTime");
+            requestProcessingTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.RequestProcessingTime");
+            requestDeserializationTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.RequestDeserializationTime");
+            responseSerializationTime = meterProvider.CreateMeter("Services.Remoting", "MessageHandler.ResponseSerializationTime");
         }
 
         public void OnCreateTransportMessageBegin()
@@ -32,30 +32,21 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             // Intentionally left blank, since we don't observe this
         }
 
-        public void OnCreateTransportMessageEnd(DateTime startTime)
-        {
-            responseSerializationTime.Record(clock.UtcNow - startTime);
-        }
+        public void OnCreateTransportMessageEnd(DateTime startTime) => responseSerializationTime.Record(clock.UtcNow - startTime);
 
         public void OnRemotingRequestBegin()
         {
             // Intentionally left blank, since we don't observe this
         }
 
-        public void OnRemotingRequestEnd(DateTime startTime)
-        {
-            requestDeserializationTime.Record(clock.UtcNow - startTime);
-        }
+        public void OnRemotingRequestEnd(DateTime startTime) => requestDeserializationTime.Record(clock.UtcNow - startTime);
 
         public void OnRequestResponseBegin()
         {
             // Intentionally left blank, since we don't observe this
         }
 
-        public void OnRequestResponseEnd(DateTime startTime)
-        {
-            requestProcessingTime.Record(clock.UtcNow - startTime);
-        }
+        public void OnRequestResponseEnd(DateTime startTime) => requestProcessingTime.Record(clock.UtcNow - startTime);
 
         public void Dispose()
         {

--- a/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
+++ b/src/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEvents.cs
@@ -9,7 +9,7 @@ using Microsoft.ServiceFabric.Diagnostics.Metrics;
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    internal class TelemetryDiagnosticEvents : IDiagnosticEvents
+    internal class TelemetryDiagnosticEvents : IDiagnosticEvents, IDisposable
     {
         readonly IClock clock;
 
@@ -55,6 +55,13 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
         public void OnRequestResponseEnd(DateTime startTime)
         {
             requestProcessingTime.Record(clock.UtcNow - startTime);
+        }
+
+        public void Dispose()
+        {
+            requestProcessingTime.Dispose();
+            requestDeserializationTime.Dispose();
+            responseSerializationTime.Dispose();
         }
     }
 }

--- a/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
+++ b/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
@@ -29,6 +29,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         private IDiagnosticEvents diagnosticEvents;
         readonly IClock clock;
         readonly ServiceRemotingPerformanceCounterProvider serviceRemotingPerformanceCounterProvider;
+        readonly IMeterProvider<TimeSpan> meterProvider;
 
         public FabricTransportMessageHandler(
             IServiceRemotingMessageHandler remotingMessageHandler,
@@ -47,6 +48,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 
             this.clock = new SystemClock();
 
+            this.meterProvider = meterProvider;
             this.serviceRemotingPerformanceCounterProvider = new ServiceRemotingPerformanceCounterProvider(this.partitionId, this.replicaOrInstanceId);
             var performanceCounterDiagnosticEvents = new PerformanceCounterDiagnosticEvents(serviceRemotingPerformanceCounterProvider, this.clock);
             var telemetryDiagnosticEvents = new TelemetryDiagnosticEvents(meterProvider, this.clock);
@@ -115,6 +117,11 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             {
                 serviceRemotingPerformanceCounterProvider.Dispose();
             }
+            if (this.diagnosticEvents is IDisposable disposableDiagnostics)
+            {
+                disposableDiagnostics.Dispose();
+            }
+            meterProvider.Dispose();
         }
 
         private FabricTransportMessage CreateFabricTransportExceptionMessage(Exception ex)

--- a/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
+++ b/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
@@ -19,14 +19,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 {
     sealed class FabricTransportMessageHandler : IFabricTransportMessageHandler
     {
-        private static readonly string TraceType = typeof(FabricTransportMessageHandler).Name;
-        private readonly IServiceRemotingMessageHandler remotingMessageHandler;
-        private readonly IServiceRemotingMessageSerializersManager serializersManager;
-        private readonly Guid partitionId;
-        private readonly long replicaOrInstanceId;
-        private IServiceRemotingMessageHeaderSerializer headerSerializer;
-        private ExceptionSerializer exceptionSerializer;
-        private IDiagnosticEvents diagnosticEvents;
+        static readonly string traceType = typeof(FabricTransportMessageHandler).Name;
+
+        readonly IServiceRemotingMessageHandler remotingMessageHandler;
+        readonly IServiceRemotingMessageSerializersManager serializersManager;
+        readonly Guid partitionId;
+        readonly long replicaOrInstanceId;
+        readonly IServiceRemotingMessageHeaderSerializer headerSerializer;
+        readonly ExceptionSerializer exceptionSerializer;
+        readonly IDiagnosticEvents diagnosticEvents;
         readonly IClock clock;
         readonly ServiceRemotingPerformanceCounterProvider serviceRemotingPerformanceCounterProvider;
 
@@ -42,17 +43,19 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             this.serializersManager = serializersManager;
             this.partitionId = partitionId;
             this.replicaOrInstanceId = replicaOrInstanceId;
-            this.headerSerializer = this.serializersManager.GetHeaderSerializer();
-            this.exceptionSerializer = exceptionConvertorHandler;
 
-            this.clock = new SystemClock();
+            headerSerializer = this.serializersManager.GetHeaderSerializer();
+            exceptionSerializer = exceptionConvertorHandler;
 
-            this.serviceRemotingPerformanceCounterProvider = new ServiceRemotingPerformanceCounterProvider(this.partitionId, this.replicaOrInstanceId);
-            var performanceCounterDiagnosticEvents = new PerformanceCounterDiagnosticEvents(serviceRemotingPerformanceCounterProvider, this.clock);
-            var telemetryDiagnosticEvents = new TelemetryDiagnosticEvents(meterProvider, this.clock);
+            clock = new SystemClock();
+
+            serviceRemotingPerformanceCounterProvider = new ServiceRemotingPerformanceCounterProvider(this.partitionId, this.replicaOrInstanceId);
+
+            var performanceCounterDiagnosticEvents = new PerformanceCounterDiagnosticEvents(serviceRemotingPerformanceCounterProvider, clock);
+            var telemetryDiagnosticEvents = new TelemetryDiagnosticEvents(meterProvider, clock);
 
             var registeredDiagnosticsEvents = new List<IDiagnosticEvents> { performanceCounterDiagnosticEvents, telemetryDiagnosticEvents };
-            this.diagnosticEvents = new AggregatedDiagnosticEvents(registeredDiagnosticsEvents);
+            diagnosticEvents = new AggregatedDiagnosticEvents(registeredDiagnosticsEvents);
         }
 
         public async Task<FabricTransportMessage> RequestResponseAsync(
@@ -65,7 +68,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             IServiceRemotingRequestMessage remotingRequestMessage = null;
             try
             {
-                remotingRequestMessage = this.CreateRemotingRequestMessage(fabricTransportMessage);
+                remotingRequestMessage = CreateRemotingRequestMessage(fabricTransportMessage);
 
                 LogContext.Set(new LogContext
                 {
@@ -73,23 +76,23 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 });
 
                 var retval = await
-                    this.remotingMessageHandler.HandleRequestResponseAsync(
+                    remotingMessageHandler.HandleRequestResponseAsync(
                         new FabricTransportServiceRemotingRequestContext(requestContext, this.serializersManager),
                         remotingRequestMessage);
-                return this.CreateFabricTransportMessage(retval, remotingRequestMessage.GetHeader().InterfaceId);
+                return CreateFabricTransportMessage(retval, remotingRequestMessage.GetHeader().InterfaceId);
             }
             catch (Exception ex)
             {
                 if (remotingRequestMessage != null)
                 {
-                    ServiceTrace.Source.WriteWarning(TraceType, "[{0}] Remote Exception occured {1}", remotingRequestMessage.GetHeader().RequestId, ex);
+                    ServiceTrace.Source.WriteWarning(traceType, "[{0}] Remote Exception occured {1}", remotingRequestMessage.GetHeader().RequestId, ex);
                 }
                 else
                 {
-                    ServiceTrace.Source.WriteWarning(TraceType, "Remote Exception occured {0}", ex);
+                    ServiceTrace.Source.WriteWarning(traceType, "Remote Exception occured {0}", ex);
                 }
 
-                return this.CreateFabricTransportExceptionMessage(ex);
+                return CreateFabricTransportExceptionMessage(ex);
             }
             finally
             {
@@ -98,20 +101,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             }
         }
 
-        public void HandleOneWay(
-            FabricTransportRequestContext requestContext,
-            FabricTransportMessage requesTransportMessage)
-        {
-            throw new NotImplementedException();
-        }
+        public void HandleOneWay(FabricTransportRequestContext requestContext, FabricTransportMessage requestTransportMessage) => throw new NotImplementedException();
 
         public void Dispose()
         {
-            if (this.remotingMessageHandler is IDisposable disposableItem)
+            if (remotingMessageHandler is IDisposable disposableItem)
             {
                 disposableItem.Dispose();
             }
-            if (this.serviceRemotingPerformanceCounterProvider != null)
+            if (serviceRemotingPerformanceCounterProvider != null)
             {
                 serviceRemotingPerformanceCounterProvider.Dispose();
             }
@@ -122,9 +120,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         {
             var header = new ServiceRemotingResponseMessageHeader();
             header.AddHeader("HasRemoteException", new byte[0]);
-            var serializedHeader = this.serializersManager.GetHeaderSerializer().SerializeResponseHeader(header);
+            var serializedHeader = serializersManager.GetHeaderSerializer().SerializeResponseHeader(header);
 
-            var serializedMsg = this.exceptionSerializer.SerializeRemoteException(ex);
+            var serializedMsg = exceptionSerializer.SerializeRemoteException(ex);
             var msg = new FabricTransportMessage(
                 new FabricTransportRequestHeader(serializedHeader.GetSendBuffer(), serializedHeader.Dispose),
                 new FabricTransportRequestBody(serializedMsg, null));
@@ -138,14 +136,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 return new FabricTransportMessage(null, null);
             }
 
-            var responseHeader = this.headerSerializer.SerializeResponseHeader(retval.GetHeader());
+            var responseHeader = headerSerializer.SerializeResponseHeader(retval.GetHeader());
             var fabricTransportRequestHeader = responseHeader != null
                 ? new FabricTransportRequestHeader(
                     responseHeader.GetSendBuffer(),
                     responseHeader.Dispose)
                 : new FabricTransportRequestHeader(default(ArraySegment<byte>), null);
             var responseSerializer =
-                this.serializersManager.GetResponseBodySerializer(interfaceId);
+                serializersManager.GetResponseBodySerializer(interfaceId);
 
             DateTime operationStartTime = clock.UtcNow;
             diagnosticEvents.OnCreateTransportMessageBegin();
@@ -167,10 +165,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 
         private IServiceRemotingRequestMessage CreateRemotingRequestMessage(FabricTransportMessage fabricTransportMessage)
         {
-            var deSerializedHeader = this.headerSerializer.DeserializeRequestHeaders(
+            var deSerializedHeader = headerSerializer.DeserializeRequestHeaders(
                 new IncomingMessageHeader(fabricTransportMessage.GetHeader().GetRecievedStream()));
             var msgBodySerializer =
-                 this.serializersManager.GetRequestBodySerializer(deSerializedHeader.InterfaceId);
+                 serializersManager.GetRequestBodySerializer(deSerializedHeader.InterfaceId);
 
             DateTime operationStartTime = clock.UtcNow;
             diagnosticEvents.OnRemotingRequestBegin();

--- a/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
+++ b/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandler.cs
@@ -29,7 +29,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         private IDiagnosticEvents diagnosticEvents;
         readonly IClock clock;
         readonly ServiceRemotingPerformanceCounterProvider serviceRemotingPerformanceCounterProvider;
-        readonly IMeterProvider<TimeSpan> meterProvider;
 
         public FabricTransportMessageHandler(
             IServiceRemotingMessageHandler remotingMessageHandler,
@@ -48,7 +47,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 
             this.clock = new SystemClock();
 
-            this.meterProvider = meterProvider;
             this.serviceRemotingPerformanceCounterProvider = new ServiceRemotingPerformanceCounterProvider(this.partitionId, this.replicaOrInstanceId);
             var performanceCounterDiagnosticEvents = new PerformanceCounterDiagnosticEvents(serviceRemotingPerformanceCounterProvider, this.clock);
             var telemetryDiagnosticEvents = new TelemetryDiagnosticEvents(meterProvider, this.clock);
@@ -117,11 +115,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             {
                 serviceRemotingPerformanceCounterProvider.Dispose();
             }
-            if (this.diagnosticEvents is IDisposable disposableDiagnostics)
-            {
-                disposableDiagnostics.Dispose();
-            }
-            meterProvider.Dispose();
+            diagnosticEvents.Dispose();
         }
 
         private FabricTransportMessage CreateFabricTransportExceptionMessage(Exception ex)

--- a/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
+++ b/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
@@ -27,10 +27,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
     {
         private static readonly string DefaultV2ListenerEndpointResourceName = "ServiceEndpointV2";
         private static readonly string DefaultWrappedMessageListenerEndpointResourceName = "ServiceEndpointV2_1";
-        private readonly FabricTransportMessageHandler transportMessageHandler;
+        private readonly IFabricTransportMessageHandler transportMessageHandler;
         private readonly string listenAddress;
         private readonly string publishAddress;
-        readonly FabricTransportListener fabricTransportlistener;
+        readonly IFabricTransportListener fabricTransportlistener;
         readonly IMeterProvider<TimeSpan> meterProvider;
 
         /// <summary>

--- a/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
+++ b/src/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Fabric;
 using System.Fabric.Common;
@@ -30,6 +31,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         private readonly string listenAddress;
         private readonly string publishAddress;
         readonly FabricTransportListener fabricTransportlistener;
+        readonly IMeterProvider<TimeSpan> meterProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportServiceRemotingListener"/> class.
@@ -126,13 +128,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 new DefaultExceptionConvertor()
             };
 
+            this.meterProvider = new TimeSpanMeterProvider(serviceContext);
+
             this.transportMessageHandler = new FabricTransportMessageHandler(
                 serviceRemotingMessageHandler,
                 serializersManager,
                 new ExceptionSerializer(svcExceptionConvertors, remotingSettings),
                 serviceContext.PartitionId,
                 serviceContext.ReplicaOrInstanceId,
-                new TimeSpanMeterProvider(serviceContext));
+                this.meterProvider);
 
             this.fabricTransportlistener = new FabricTransportListener(
                 remotingSettings.GetInternalSettings(),
@@ -233,6 +237,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         {
             this.fabricTransportlistener.Dispose();
             this.transportMessageHandler.Dispose();
+            this.meterProvider.Dispose();
         }
     }
 }

--- a/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
@@ -236,5 +236,31 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
                 Mock.Get(anotherDiagnostics).Verify(ds => ds.ActorDeactivated(actorId), Times.Once);
             }
         }
+
+        public sealed class Dispose : AggregatedDiagnosticsTest
+        {
+            internal interface IDisposableDiagnostics : IDiagnostics, IDisposable { }
+
+            [Fact]
+            public void DisposesDisposableChildren()
+            {
+                var disposableChild = Mock.Of<IDisposableDiagnostics>();
+                var nonDisposableChild = Mock.Of<IDiagnostics>();
+
+                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { disposableChild, nonDisposableChild });
+                aggregated.Dispose();
+
+                Mock.Get(disposableChild).Verify(d => d.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenNoDisposableChildren()
+            {
+                var nonDisposableChild = Mock.Of<IDiagnostics>();
+
+                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { nonDisposableChild });
+                aggregated.Dispose();
+            }
+        }
     }
 }

--- a/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
@@ -239,26 +239,23 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
         public sealed class Dispose : AggregatedDiagnosticsTest
         {
-            internal interface IDisposableDiagnostics : IDiagnostics, IDisposable { }
-
             [Fact]
-            public void DisposesDisposableChildren()
+            public void DisposesAllChildren()
             {
-                var disposableChild = Mock.Of<IDisposableDiagnostics>();
-                var nonDisposableChild = Mock.Of<IDiagnostics>();
+                var child1 = Mock.Of<IDiagnostics>();
+                var child2 = Mock.Of<IDiagnostics>();
 
-                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { disposableChild, nonDisposableChild });
+                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { child1, child2 });
                 aggregated.Dispose();
 
-                Mock.Get(disposableChild).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(child1).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(child2).Verify(d => d.Dispose(), Times.Once);
             }
 
             [Fact]
-            public void DoesNotThrowWhenNoDisposableChildren()
+            public void DoesNotThrowWhenEmpty()
             {
-                var nonDisposableChild = Mock.Of<IDiagnostics>();
-
-                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { nonDisposableChild });
+                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics>());
                 aggregated.Dispose();
             }
         }

--- a/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/AggregatedDiagnosticsTest.cs
@@ -240,23 +240,12 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         public sealed class Dispose : AggregatedDiagnosticsTest
         {
             [Fact]
-            public void DisposesAllChildren()
+            public void DisposesAllChildrenDiagnostics()
             {
-                var child1 = Mock.Of<IDiagnostics>();
-                var child2 = Mock.Of<IDiagnostics>();
+                sut.Dispose();
 
-                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics> { child1, child2 });
-                aggregated.Dispose();
-
-                Mock.Get(child1).Verify(d => d.Dispose(), Times.Once);
-                Mock.Get(child2).Verify(d => d.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DoesNotThrowWhenEmpty()
-            {
-                var aggregated = new AggregatedDiagnostics(new List<IDiagnostics>());
-                aggregated.Dispose();
+                Mock.Get(diagnostics).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(anotherDiagnostics).Verify(d => d.Dispose(), Times.Once);
             }
         }
     }

--- a/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
@@ -101,6 +101,45 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
 
                 mockPerformanceCounterProviderV2.Verify(p => p.Dispose(), Times.Once);
             }
+
+            [Fact]
+            public void DisposesMeterProviders()
+            {
+                var mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
+                var mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
+                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
+                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
+
+                sut.Dispose();
+
+                mockTimeSpanProvider.Verify(p => p.Dispose(), Times.Once);
+                mockLongProvider.Verify(p => p.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DisposesCreatedDiagnostics()
+            {
+                var mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
+                var mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
+                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
+                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
+
+                sut.CreateDiagnostics(Mock.Of<IClock>());
+
+                var createdDiagnostics = sut.Field<AggregatedDiagnostics>().Value;
+                Assert.NotNull(createdDiagnostics);
+
+                sut.Dispose();
+
+                // After disposal, the MetricDiagnostics inside AggregatedDiagnostics should have been disposed.
+                // We verify that the meters created by the mock providers had Dispose called.
+                var metricDiagnostics = createdDiagnostics.Field<IEnumerable<IDiagnostics>>().Value
+                    .OfType<MetricDiagnostics>().Single();
+
+                // MetricDiagnostics disposes its meters; verify via the mock meter objects
+                Mock.Get(metricDiagnostics.Field<IMeter<long>>().Value).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(metricDiagnostics.Field<IMeter<TimeSpan>>("acquireLockDuration").Value).Verify(m => m.Dispose(), Times.Once);
+            }
         }
 
         public class CreateDiagnostics : DiagnosticsFactoryTest

--- a/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
@@ -12,7 +12,6 @@ using Inspector;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using Microsoft.ServiceFabric.Diagnostics;
 using Microsoft.ServiceFabric.Diagnostics.Metrics;
-using Microsoft.ServiceFabric.TestFramework;
 using Moq;
 using Xunit;
 
@@ -87,11 +86,18 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         {
             readonly Guid guid = Guid.NewGuid();
             readonly Mock<PerformanceCounterProviderV2> mockPerformanceCounterProviderV2;
+            readonly Mock<IMeterProvider<TimeSpan>> mockTimeSpanProvider;
+            readonly Mock<IMeterProvider<long>> mockLongProvider;
 
             public DisposeTest()
             {
                 mockPerformanceCounterProviderV2 = new Mock<PerformanceCounterProviderV2>(guid, typeInformation);
+                mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
+                mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
+
                 sut.Field<PerformanceCounterProviderV2>().Set(mockPerformanceCounterProviderV2.Object);
+                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
+                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
             }
 
             [Fact]
@@ -105,11 +111,6 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             [Fact]
             public void DisposesMeterProviders()
             {
-                var mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
-                var mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
-                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
-                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
-
                 sut.Dispose();
 
                 mockTimeSpanProvider.Verify(p => p.Dispose(), Times.Once);

--- a/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
@@ -115,31 +115,6 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
                 mockTimeSpanProvider.Verify(p => p.Dispose(), Times.Once);
                 mockLongProvider.Verify(p => p.Dispose(), Times.Once);
             }
-
-            [Fact]
-            public void DisposesCreatedDiagnostics()
-            {
-                var mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
-                var mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
-                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
-                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
-
-                sut.CreateDiagnostics(Mock.Of<IClock>());
-
-                var createdDiagnostics = sut.Field<AggregatedDiagnostics>().Value;
-                Assert.NotNull(createdDiagnostics);
-
-                sut.Dispose();
-
-                // After disposal, the MetricDiagnostics inside AggregatedDiagnostics should have been disposed.
-                // We verify that the meters created by the mock providers had Dispose called.
-                var metricDiagnostics = createdDiagnostics.Field<IEnumerable<IDiagnostics>>().Value
-                    .OfType<MetricDiagnostics>().Single();
-
-                // MetricDiagnostics disposes its meters; verify via the mock meter objects
-                Mock.Get(metricDiagnostics.Field<IMeter<long>>().Value).Verify(m => m.Dispose(), Times.Once);
-                Mock.Get(metricDiagnostics.Field<IMeter<TimeSpan>>("acquireLockDuration").Value).Verify(m => m.Dispose(), Times.Once);
-            }
         }
 
         public class CreateDiagnostics : DiagnosticsFactoryTest

--- a/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
@@ -85,19 +85,19 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
         public class DisposeTest : DiagnosticsFactoryTest
         {
             readonly Guid guid = Guid.NewGuid();
-            readonly Mock<PerformanceCounterProviderV2> mockPerformanceCounterProviderV2;
-            readonly Mock<IMeterProvider<TimeSpan>> mockTimeSpanProvider;
-            readonly Mock<IMeterProvider<long>> mockLongProvider;
+            readonly Mock<PerformanceCounterProviderV2> performanceCounterProviderV2;
+            readonly Mock<IMeterProvider<TimeSpan>> timeSpanProvider;
+            readonly Mock<IMeterProvider<long>> longProvider;
 
             public DisposeTest()
             {
-                mockPerformanceCounterProviderV2 = new Mock<PerformanceCounterProviderV2>(guid, typeInformation);
-                mockTimeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
-                mockLongProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
+                performanceCounterProviderV2 = new Mock<PerformanceCounterProviderV2>(guid, typeInformation);
+                timeSpanProvider = new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock };
+                longProvider = new Mock<IMeterProvider<long>>() { DefaultValue = DefaultValue.Mock };
 
-                sut.Field<PerformanceCounterProviderV2>().Set(mockPerformanceCounterProviderV2.Object);
-                sut.Field<IMeterProvider<TimeSpan>>().Set(mockTimeSpanProvider.Object);
-                sut.Field<IMeterProvider<long>>().Set(mockLongProvider.Object);
+                sut.Field<PerformanceCounterProviderV2>().Set(performanceCounterProviderV2.Object);
+                sut.Field<IMeterProvider<TimeSpan>>().Set(timeSpanProvider.Object);
+                sut.Field<IMeterProvider<long>>().Set(longProvider.Object);
             }
 
             [Fact]
@@ -105,7 +105,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.Dispose();
 
-                mockPerformanceCounterProviderV2.Verify(p => p.Dispose(), Times.Once);
+                performanceCounterProviderV2.Verify(p => p.Dispose(), Times.Once);
             }
 
             [Fact]
@@ -113,8 +113,8 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             {
                 sut.Dispose();
 
-                mockTimeSpanProvider.Verify(p => p.Dispose(), Times.Once);
-                mockLongProvider.Verify(p => p.Dispose(), Times.Once);
+                timeSpanProvider.Verify(p => p.Dispose(), Times.Once);
+                longProvider.Verify(p => p.Dispose(), Times.Once);
             }
         }
 

--- a/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
+++ b/test/Actors/Diagnostics/DiagnosticsFactoryTest.cs
@@ -101,18 +101,11 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             }
 
             [Fact]
-            public void DisposesPerformanceCounterProvider()
+            public void DisposesAllDependencies()
             {
                 sut.Dispose();
 
                 performanceCounterProviderV2.Verify(p => p.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DisposesMeterProviders()
-            {
-                sut.Dispose();
-
                 timeSpanProvider.Verify(p => p.Dispose(), Times.Once);
                 longProvider.Verify(p => p.Dispose(), Times.Once);
             }

--- a/test/Actors/Diagnostics/EventSourceDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/EventSourceDiagnosticsTest.cs
@@ -311,5 +311,14 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
                 }
             }
         }
+
+        public class DisposeMethod : EventSourceDiagnosticsTest
+        {
+            [Fact]
+            public void DoesNotThrow()
+            {
+                sut.Dispose();
+            }
+        }
     }
 }

--- a/test/Actors/Diagnostics/EventSourceDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/EventSourceDiagnosticsTest.cs
@@ -311,14 +311,5 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
                 }
             }
         }
-
-        public class DisposeMethod : EventSourceDiagnosticsTest
-        {
-            [Fact]
-            public void DoesNotThrow()
-            {
-                sut.Dispose();
-            }
-        }
     }
 }

--- a/test/Actors/Diagnostics/MetricDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/MetricDiagnosticsTest.cs
@@ -231,5 +231,23 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Diagnostics
             }
         }
 
+        public class Dispose : MetricDiagnosticsTest
+        {
+            [Fact]
+            public void DisposesAllMeters()
+            {
+                sut.Dispose();
+
+                Mock.Get(pendingMethodCalls).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(acquireLockDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(releaseLockDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(methodExecutionDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(onActivateAsyncDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(requestProcessingDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(loadStateDuration).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(saveStateDuration).Verify(m => m.Dispose(), Times.Once);
+            }
+        }
+
     }
 }

--- a/test/Actors/Diagnostics/PerformanceCounterDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/PerformanceCounterDiagnosticsTest.cs
@@ -355,14 +355,5 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
                 }
             }
         }
-
-        public class Dispose : PerformanceCounterDiagnosticsTest
-        {
-            [Fact]
-            public void DoesNotThrow()
-            {
-                sut.Dispose();
-            }
-        }
     }
 }

--- a/test/Actors/Diagnostics/PerformanceCounterDiagnosticsTest.cs
+++ b/test/Actors/Diagnostics/PerformanceCounterDiagnosticsTest.cs
@@ -355,5 +355,14 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
                 }
             }
         }
+
+        public class Dispose : PerformanceCounterDiagnosticsTest
+        {
+            [Fact]
+            public void DoesNotThrow()
+            {
+                sut.Dispose();
+            }
+        }
     }
 }

--- a/test/Actors/Runtime/ActorServiceTest.cs
+++ b/test/Actors/Runtime/ActorServiceTest.cs
@@ -11,7 +11,6 @@ using Fuzzy;
 using Inspector;
 using Microsoft.ServiceFabric.Actors.Diagnostics;
 using Microsoft.ServiceFabric.Diagnostics;
-using Microsoft.ServiceFabric.TestFramework;
 using Moq;
 using Xunit;
 
@@ -28,17 +27,19 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         readonly Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticsFactory;
         readonly Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>> mockCreateDiagnosticsFactory = new Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>();
         readonly DiagnosticsFactory diagnosticsFactory;
+        readonly IDiagnostics diagnostics;
 
         public ActorServiceTest()
         {
             diagnosticsFactory = new Mock<DiagnosticsFactory>(serviceContext, typeInformation, new ActorMethodFriendlyNameBuilder(typeInformation)) { DefaultValue = DefaultValue.Mock }.Object;
 
-            this.createDiagnosticsFactory = typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Value;
+            createDiagnosticsFactory = typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Value;
             typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(mockCreateDiagnosticsFactory.Object);
             mockCreateDiagnosticsFactory.Setup(_ => _.Invoke(It.IsAny<ServiceContext>(), It.IsAny<ActorTypeInformation>(), It.IsAny<ActorMethodFriendlyNameBuilder>())).Returns(diagnosticsFactory);
 
             sut = new ActorService(serviceContext, typeInformation);
             sut.InitializeInternal(new ActorMethodFriendlyNameBuilder(sut.ActorTypeInformation));
+            diagnostics = sut.Field<IDiagnostics>().Value;
         }
 
         public void Dispose()
@@ -58,24 +59,19 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             [Fact]
             public void IsDisposedByOnCloseAsync()
             {
-                var diagnostics = sut.Field<IDiagnostics>();
-
                 sut.DeclaredBy(typeof(ActorService)).Method<Func<CancellationToken, Task>>("OnCloseAsync").Invoke(TestContext.Current.CancellationToken);
 
-                Mock.Get(diagnostics.Value).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(diagnostics).Verify(d => d.Dispose(), Times.Once);
                 Mock.Get(diagnosticsFactory).Verify(d => d.Dispose(), Times.Once);
             }
         }
 
         public class OnRoleChange : ActorServiceTest
         {
-            readonly IDiagnostics diagnostics = Mock.Of<IDiagnostics>();
-
             readonly Func<ReplicaRole, CancellationToken, Task> sutMethod;
 
             public OnRoleChange()
             {
-                sut.Field<IDiagnostics>().Set(diagnostics);
                 sutMethod = sut.DeclaredBy(typeof(ActorService)).Method<Func<ReplicaRole, CancellationToken, Task>>("OnChangeRoleAsync");
 
                 var actorManager = new ActorManager(sut, Mock.Of<IClock>(), diagnostics);

--- a/test/Actors/Runtime/ActorServiceTest.cs
+++ b/test/Actors/Runtime/ActorServiceTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public ActorServiceTest()
         {
-            diagnosticsFactory = new Mock<DiagnosticsFactory>(serviceContext, typeInformation, new ActorMethodFriendlyNameBuilder(typeInformation)).Object;
+            diagnosticsFactory = new Mock<DiagnosticsFactory>(serviceContext, typeInformation, new ActorMethodFriendlyNameBuilder(typeInformation)) { DefaultValue = DefaultValue.Mock }.Object;
 
             this.createDiagnosticsFactory = typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Value;
             typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(mockCreateDiagnosticsFactory.Object);
@@ -58,8 +58,11 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             [Fact]
             public void IsDisposedByOnCloseAsync()
             {
+                var diagnostics = sut.Field<IDiagnostics>();
+
                 sut.DeclaredBy(typeof(ActorService)).Method<Func<CancellationToken, Task>>("OnCloseAsync").Invoke(TestContext.Current.CancellationToken);
 
+                Mock.Get(diagnostics.Value).Verify(d => d.Dispose(), Times.Once);
                 Mock.Get(diagnosticsFactory).Verify(d => d.Dispose(), Times.Once);
             }
         }

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
+using System.Fabric.Interop;
 using Fuzzy;
 using Inspector;
 using Moq;
@@ -13,31 +14,30 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
-    public class MeterProviderTest
+    public class MeterProviderTest : IDisposable
     {
         static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
 
+        readonly IMeterProvider<int> sut;
+
         readonly ServiceContext serviceContext = fuzzy.ServiceContext();
 
-        public class Constructor : MeterProviderTest, IDisposable
+        public MeterProviderTest()
         {
-            public Constructor()
-            {
-                typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(() => Mock.Of<IFabricMeterProvider>());
-            }
+            typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(() => Mock.Of<IFabricMeterProvider>());
+            sut = new Mock<MeterProvider<int>>(serviceContext).Object;
+        }
 
-            public void Dispose()
-            {
-                typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(NativeTelemetry.FabricCreateMeterProvider);
-            }
+        public virtual void Dispose() => typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(NativeTelemetry.FabricCreateMeterProvider);
+
+        public class Constructor : MeterProviderTest
+        {
 
             [Fact]
             public void SetsRequiredDimensionsFromServiceContext()
             {
-                var sut = new TestMeterProvider<int>(serviceContext);
-
-                var actualSystemDimensionNames = (string[])sut.Private().Field<IReadOnlyCollection<string>>().Value;
-                var actualSystemDimensionValues = (string[])sut.Protected().Field<IReadOnlyCollection<string>>().Value;
+                string[] actualSystemDimensionNames = (string[])sut.Private().Field<IReadOnlyCollection<string>>().Value;
+                string[] actualSystemDimensionValues = (string[])sut.Protected().Field<IReadOnlyCollection<string>>().Value;
 
                 Assert.Equal(serviceContext.PartitionId.ToString(), actualSystemDimensionValues[0]);
                 Assert.Equal(serviceContext.ServiceTypeName, actualSystemDimensionValues[1]);
@@ -55,52 +55,50 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             [Fact]
             public void ThrowAnArgumentExceptionWhenServiceContextNull()
             {
-                var sut = new TestMeterProvider<int>(null);
+                var sut = new Mock<MeterProvider<int>>(null).Object;
 
-                var actualSystemDimensionNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
-                var actualSystemDimensionValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
+                IReadOnlyCollection<string> actualSystemDimensionNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
+                IReadOnlyCollection<string> actualSystemDimensionValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
 
                 Assert.Empty(actualSystemDimensionValues);
                 Assert.Empty(actualSystemDimensionNames);
             }
         }
 
-        public class Class : MeterProviderTest
+        public class DisposeTest : MeterProviderTest
         {
-            [Fact]
-            public void HasFabricCreateMeterProviderFunc()
+            public DisposeTest() => typeof(MeterProvider<int>).Field<Func<object, int>>().Set(objectParam => fuzzy.Int32());
+            override public void Dispose()
             {
-                Func<IFabricMeterProvider> expected = typeof(NativeTelemetry).Method<Func<IFabricMeterProvider>>(nameof(NativeTelemetry.FabricCreateMeterProvider));
-                Func<IFabricMeterProvider> actual = typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>();
-                Assert.Equal(expected, actual);
+                base.Dispose();
+                typeof(MeterProvider<int>).Field<Func<object, int>>().Set(Utility.FinalReleaseComObject);
+            }
+
+            [Fact]
+            public void DisposesNativeFabricMeterProvider()
+            {
+                sut.Dispose();
+
+                Assert.True(sut.Field<bool>().Value);
             }
         }
 
-        class TestMeterProvider<TValueType> : MeterProvider<TValueType>
+        public class CreateMeterProvider : DisposeTest
         {
-            public TestMeterProvider(ServiceContext serviceContext)
-                : base(serviceContext)
-            {
-            }
+            readonly Func<string, string, IEnumerable<string>, IFabricMeter> sutMethod;
 
-            public override IMeter<TValueType> CreateMeter(string metricNamespace, string name)
-            {
-                throw new NotImplementedException();
-            }
+            readonly string metricNamespace = fuzzy.String();
+            readonly string metricName = fuzzy.String();
+            readonly IEnumerable<string> dimensions = fuzzy.List(() => fuzzy.String());
 
-            public override IMeter1D<TValueType> CreateMeter(string metricNamespace, string name, string dimension1Name)
-            {
-                throw new NotImplementedException();
-            }
+            public CreateMeterProvider() => sutMethod = sut.Protected().Method<Func<string, string, IEnumerable<string>, IFabricMeter>>();
 
-            public override IMeter2D<TValueType> CreateMeter(string metricNamespace, string name, string dimension1Name, string dimension2Name)
+            [Fact]
+            public void ThrowsIfDisposed()
             {
-                throw new NotImplementedException();
-            }
+                sut.Dispose();
 
-            public override IMeter3D<TValueType> CreateMeter(string metricNamespace, string name, string dimension1Name, string dimension2Name, string dimension3Name)
-            {
-                throw new NotImplementedException();
+                Assert.Throws<ObjectDisposedException>(() => sutMethod.Invoke(metricNamespace, metricName, dimensions));
             }
         }
     }

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Fabric;
 using System.Fabric.Interop;
+using System.Linq;
 using Fuzzy;
 using Inspector;
 using Moq;
@@ -20,11 +21,12 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         readonly IMeterProvider<int> sut;
 
+        readonly IFabricMeterProvider fabricMeterProvider = Mock.Of<IFabricMeterProvider>();
         readonly ServiceContext serviceContext = fuzzy.ServiceContext();
 
         public MeterProviderTest()
         {
-            typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(() => Mock.Of<IFabricMeterProvider>());
+            typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(() => fabricMeterProvider);
             sut = new Mock<MeterProvider<int>>(serviceContext).Object;
         }
 
@@ -36,20 +38,20 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             [Fact]
             public void SetsRequiredDimensionsFromServiceContext()
             {
-                string[] actualSystemDimensionNames = (string[])sut.Private().Field<IReadOnlyCollection<string>>().Value;
-                string[] actualSystemDimensionValues = (string[])sut.Protected().Field<IReadOnlyCollection<string>>().Value;
+                var actualSystemDimensionNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
+                var actualSystemDimensionValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
 
-                Assert.Equal(serviceContext.PartitionId.ToString(), actualSystemDimensionValues[0]);
-                Assert.Equal(serviceContext.ServiceTypeName, actualSystemDimensionValues[1]);
-                Assert.Equal(serviceContext.ServiceName.ToString(), actualSystemDimensionValues[2]);
-                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationName, actualSystemDimensionValues[3]);
-                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationTypeName, actualSystemDimensionValues[4]);
+                Assert.Equal(serviceContext.PartitionId.ToString(), actualSystemDimensionValues.ElementAt(0));
+                Assert.Equal(serviceContext.ServiceTypeName, actualSystemDimensionValues.ElementAt(1));
+                Assert.Equal(serviceContext.ServiceName.ToString(), actualSystemDimensionValues.ElementAt(2));
+                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationName, actualSystemDimensionValues.ElementAt(3));
+                Assert.Equal(serviceContext.CodePackageActivationContext.ApplicationTypeName, actualSystemDimensionValues.ElementAt(4));
 
-                Assert.Equal(nameof(ServiceContext.PartitionId), actualSystemDimensionNames[0]);
-                Assert.Equal(nameof(ServiceContext.ServiceTypeName), actualSystemDimensionNames[1]);
-                Assert.Equal(nameof(ServiceContext.ServiceName), actualSystemDimensionNames[2]);
-                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationName), actualSystemDimensionNames[3]);
-                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationTypeName), actualSystemDimensionNames[4]);
+                Assert.Equal(nameof(ServiceContext.PartitionId), actualSystemDimensionNames.ElementAt(0));
+                Assert.Equal(nameof(ServiceContext.ServiceTypeName), actualSystemDimensionNames.ElementAt(1));
+                Assert.Equal(nameof(ServiceContext.ServiceName), actualSystemDimensionNames.ElementAt(2));
+                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationName), actualSystemDimensionNames.ElementAt(3));
+                Assert.Equal(nameof(ServiceContext.CodePackageActivationContext.ApplicationTypeName), actualSystemDimensionNames.ElementAt(4));
             }
 
             [Fact]
@@ -57,8 +59,8 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             {
                 var sut = new Mock<MeterProvider<int>>(null).Object;
 
-                IReadOnlyCollection<string> actualSystemDimensionNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
-                IReadOnlyCollection<string> actualSystemDimensionValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
+                var actualSystemDimensionNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
+                var actualSystemDimensionValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
 
                 Assert.Empty(actualSystemDimensionValues);
                 Assert.Empty(actualSystemDimensionNames);
@@ -67,38 +69,55 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public class DisposeTest : MeterProviderTest
         {
-            public DisposeTest() => typeof(MeterProvider<int>).Field<Func<object, int>>().Set(objectParam => fuzzy.Int32());
+            readonly Func<object, int> finalReleaseComObject = Mock.Of<Func<object, int>>();
+
+            // Set the finalReleaseComObject delegate to a mock function, so we can verify that it was called in Dispose.
+            public DisposeTest() =>
+                typeof(MeterProvider<int>).Field<Func<object, int>>().Set(finalReleaseComObject);
+
             override public void Dispose()
             {
                 base.Dispose();
+
+                // Restore the original finalReleaseComObject delegate after the test, to avoid affecting other tests.
                 typeof(MeterProvider<int>).Field<Func<object, int>>().Set(Utility.FinalReleaseComObject);
             }
 
             [Fact]
-            public void DisposesNativeFabricMeterProvider()
+            public void ReleasesNativeFabricMeterProvider()
             {
                 sut.Dispose();
 
-                Assert.True(sut.Field<bool>().Value);
+                Mock.Get(finalReleaseComObject).Verify(f => f(fabricMeterProvider), Times.Once);
+                Assert.Null(sut.Private().Field<IFabricMeterProvider>().Value);
+            }
+
+            [Fact]
+            public void SubsequentDisposesDoNotReleaseNativeFabricMeterProvider()
+            {
+                sut.Dispose();
+                sut.Dispose();
+                Mock.Get(finalReleaseComObject).Verify(f => f(fabricMeterProvider), Times.Once);
             }
         }
 
         public class CreateMeterProvider : DisposeTest
         {
-            readonly Func<string, string, IEnumerable<string>, IFabricMeter> sutMethod;
+            readonly Func<string, string, IEnumerable<string>, IFabricMeter> createMeterProvider;
 
             readonly string metricNamespace = fuzzy.String();
             readonly string metricName = fuzzy.String();
             readonly IEnumerable<string> dimensions = fuzzy.List(() => fuzzy.String());
 
-            public CreateMeterProvider() => sutMethod = sut.Protected().Method<Func<string, string, IEnumerable<string>, IFabricMeter>>();
+            public CreateMeterProvider() =>
+                createMeterProvider = sut.Protected().Method<Func<string, string, IEnumerable<string>, IFabricMeter>>();
 
             [Fact]
             public void ThrowsIfDisposed()
             {
                 sut.Dispose();
 
-                Assert.Throws<ObjectDisposedException>(() => sutMethod.Invoke(metricNamespace, metricName, dimensions));
+                Assert.Throws<ObjectDisposedException>(() => createMeterProvider.Invoke(metricNamespace, metricName, dimensions));
             }
         }
     }

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             }
 
             [Fact]
-            public void ThrowAnArgumentExceptionWhenServiceContextNull()
+            public void SetsEmptyDimensionsIfNullServiceContext()
             {
                 var sut = new Mock<MeterProvider<int>>(null).Object;
 

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             public DisposeTest() =>
                 typeof(MeterProvider<int>).Field<Func<object, int>>().Set(finalReleaseComObject);
 
-            override public void Dispose()
+            public override void Dispose()
             {
                 base.Dispose();
 

--- a/test/Diagnostics/Metrics/Implementation/MeterTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterTest.cs
@@ -5,12 +5,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Fabric.Interop;
 using System.Linq;
 using System.Reflection;
 using Fuzzy;
 using Inspector;
 using Moq;
 using Xunit;
+
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
@@ -87,7 +89,21 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             }
         }
 
-        public class RecordViaNative : MeterTest
+        public class DisposeTest : MeterTest, IDisposable
+        {
+            public DisposeTest() => typeof(Meter).Field<Func<object, int>>().Set(objectParam => fuzzy.Int32());
+            public void Dispose() => typeof(Meter).Field<Func<object, int>>().Set(Utility.FinalReleaseComObject);
+
+            [Fact]
+            public void DisposesNativeFabricMeterProvider()
+            {
+                sut.Dispose();
+
+                Assert.True(sut.Private().Field<bool>().Value);
+            }
+        }
+
+        public class RecordViaNative : DisposeTest
         {
             readonly string dimension1Value = fuzzy.String();
             readonly string dimension2Value = fuzzy.String();
@@ -95,25 +111,16 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
             readonly Method<Action<long, int, string, string, string>> sutMethod;
 
-            public RecordViaNative()
-            {
-                sutMethod = sut.Protected().Method<Action<long, int, string, string, string>>();
-            }
+            public RecordViaNative() => sutMethod = sut.Protected().Method<Action<long, int, string, string, string>>();
 
 
             [Fact]
-            public void ThrowsExceptionIfNumberOfCustomDimensionsNegative()
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    sutMethod.Invoke(value, fuzzy.Int32().Maximum(-1), dimension1Value, dimension2Value, dimension3Value));
-            }
+            public void ThrowsExceptionIfNumberOfCustomDimensionsNegative() => Assert.Throws<ArgumentOutOfRangeException>(() =>
+                                                                                                sutMethod.Invoke(value, fuzzy.Int32().Maximum(-1), dimension1Value, dimension2Value, dimension3Value));
 
             [Fact]
-            public void ThrowsExceptionIfNumberOfCustomDimensionsHigherThanSupported()
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    sutMethod.Invoke(value, fuzzy.Int32().Minimum(4), dimension1Value, dimension2Value, dimension3Value));
-            }
+            public void ThrowsExceptionIfNumberOfCustomDimensionsHigherThanSupported() => Assert.Throws<ArgumentOutOfRangeException>(() =>
+                                                                                                           sutMethod.Invoke(value, fuzzy.Int32().Minimum(4), dimension1Value, dimension2Value, dimension3Value));
 
             [Fact]
             public void CallsNativeMeterRecordWithZeroCustomDimensionsAndAllSystemDimensions()
@@ -157,6 +164,15 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
                 Mock.Get(fabricMeter).Verify(m => m.Record(value, (uint)expectedArray.Length, It.IsAny<IntPtr>()), Times.Once);
                 Assert.Equal(expectedArray, actualDimensions);
+            }
+
+
+            [Fact]
+            public void ThrowsIfDisposed()
+            {
+                sut.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => sutMethod.Invoke(value, 3, dimension1Value, dimension2Value, dimension3Value));
             }
         }
     }

--- a/test/Diagnostics/Metrics/Implementation/MeterTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterTest.cs
@@ -91,15 +91,31 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         public class DisposeTest : MeterTest, IDisposable
         {
-            public DisposeTest() => typeof(Meter).Field<Func<object, int>>().Set(objectParam => fuzzy.Int32());
+            readonly Func<object, int> finalReleaseComObject = Mock.Of<Func<object, int>>();
+
+            // Set the finalReleaseComObject delegate to a mock function, so we can verify that it was called in Dispose.
+            public DisposeTest() =>
+                typeof(Meter).Field<Func<object, int>>().Set(finalReleaseComObject);
+
+            // Restore the original finalReleaseComObject delegate after the test, to avoid affecting other tests.
             public void Dispose() => typeof(Meter).Field<Func<object, int>>().Set(Utility.FinalReleaseComObject);
 
             [Fact]
-            public void DisposesNativeFabricMeterProvider()
+            public void ReleasesNativeFabricMeter()
             {
                 sut.Dispose();
 
-                Assert.True(sut.Private().Field<bool>().Value);
+                Mock.Get(finalReleaseComObject).Verify(f => f(fabricMeter), Times.Once);
+                Assert.Null(sut.Private().Field<IFabricMeter>().Value);
+            }
+
+            [Fact]
+            public void SubsequentDisposesDoNotReleaseNativeFabricMeterProvider()
+            {
+                sut.Dispose();
+                sut.Dispose();
+
+                Mock.Get(finalReleaseComObject).Verify(f => f(fabricMeter), Times.Once);
             }
         }
 
@@ -115,12 +131,12 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
 
             [Fact]
-            public void ThrowsExceptionIfNumberOfCustomDimensionsNegative() => Assert.Throws<ArgumentOutOfRangeException>(() =>
-                                                                                                sutMethod.Invoke(value, fuzzy.Int32().Maximum(-1), dimension1Value, dimension2Value, dimension3Value));
+            public void ThrowsExceptionIfNumberOfCustomDimensionsNegative() =>
+                Assert.Throws<ArgumentOutOfRangeException>(() => sutMethod.Invoke(value, fuzzy.Int32().Maximum(-1), dimension1Value, dimension2Value, dimension3Value));
 
             [Fact]
-            public void ThrowsExceptionIfNumberOfCustomDimensionsHigherThanSupported() => Assert.Throws<ArgumentOutOfRangeException>(() =>
-                                                                                                           sutMethod.Invoke(value, fuzzy.Int32().Minimum(4), dimension1Value, dimension2Value, dimension3Value));
+            public void ThrowsExceptionIfNumberOfCustomDimensionsHigherThanSupported() =>
+                Assert.Throws<ArgumentOutOfRangeException>(() => sutMethod.Invoke(value, fuzzy.Int32().Minimum(4), dimension1Value, dimension2Value, dimension3Value));
 
             [Fact]
             public void CallsNativeMeterRecordWithZeroCustomDimensionsAndAllSystemDimensions()

--- a/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
@@ -204,5 +204,31 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             }
         }
 
+        public class Dispose : AggregatedDiagnosticEventsTest
+        {
+            internal interface IDisposableDiagnosticEvents : IDiagnosticEvents, IDisposable { }
+
+            [Fact]
+            public void DisposesDisposableChildren()
+            {
+                var disposableChild = Mock.Of<IDisposableDiagnosticEvents>();
+                var nonDisposableChild = Mock.Of<IDiagnosticEvents>();
+
+                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { disposableChild, nonDisposableChild });
+                aggregated.Dispose();
+
+                Mock.Get(disposableChild).Verify(d => d.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenNoDisposableChildren()
+            {
+                var nonDisposableChild = Mock.Of<IDiagnosticEvents>();
+
+                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { nonDisposableChild });
+                aggregated.Dispose();
+            }
+        }
+
     }
 }

--- a/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 
 namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
-{    
+{
     public class AggregatedDiagnosticEventsTest
     {
         internal interface ITestDiagnosticsEvents : IDiagnosticEvents { }
@@ -27,7 +27,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             Mock.Of<IDiagnosticEvents>()
         };
 
-        private AggregatedDiagnosticEvents sut;
+        readonly AggregatedDiagnosticEvents sut;
 
         protected AggregatedDiagnosticEventsTest() => sut = new AggregatedDiagnosticEvents(diagnosticEvents);
 
@@ -63,16 +63,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             }
 
             [Fact]
-            public void ThrowsOnNullEventsList()
-            {
-                Assert.Throws<ArgumentException>(() => new AggregatedDiagnosticEvents(null));
-            }
+            public void ThrowsOnNullEventsList() => Assert.Throws<ArgumentException>(() => new AggregatedDiagnosticEvents(null));
 
             [Fact]
-            public void ThrowsOnAnyNullEvents()
-            {
-                Assert.Throws<ArgumentException>(() => new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { diagnosticEvent, null }));
-            }
+            public void ThrowsOnAnyNullEvents() => Assert.Throws<ArgumentException>(() => new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { diagnosticEvent, null }));
 
             [Fact]
             public void AssignsEmptyEvent()
@@ -86,9 +80,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             [Fact]
             public void AssignsSingleEvent()
             {
-                Assert.NotNull(this.sut.Field<IEnumerable<IDiagnosticEvents>>());
-                Assert.Single(this.sut.Field<IEnumerable<IDiagnosticEvents>>().Value);
-                Assert.IsAssignableFrom<IDiagnosticEvents>(this.sut.Field<IEnumerable<IDiagnosticEvents>>().Value.First());
+                Assert.NotNull(sut.Field<IEnumerable<IDiagnosticEvents>>());
+                Assert.Single(sut.Field<IEnumerable<IDiagnosticEvents>>().Value);
+                Assert.IsAssignableFrom<IDiagnosticEvents>(sut.Field<IEnumerable<IDiagnosticEvents>>().Value.First());
             }
 
             [Fact]
@@ -209,21 +203,12 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             [Fact]
             public void DisposesAllChildren()
             {
-                var child1 = Mock.Of<IDiagnosticEvents>();
-                var child2 = Mock.Of<IDiagnosticEvents>();
+                var sut = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { diagnosticEvent, anotherDiagnosticEvents });
 
-                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { child1, child2 });
-                aggregated.Dispose();
+                sut.Dispose();
 
-                Mock.Get(child1).Verify(d => d.Dispose(), Times.Once);
-                Mock.Get(child2).Verify(d => d.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DoesNotThrowWhenEmpty()
-            {
-                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents>());
-                aggregated.Dispose();
+                Mock.Get(diagnosticEvent).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(anotherDiagnosticEvents).Verify(d => d.Dispose(), Times.Once);
             }
         }
 

--- a/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/AggregatedDiagnosticEventsTest.cs
@@ -206,26 +206,23 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
 
         public class Dispose : AggregatedDiagnosticEventsTest
         {
-            internal interface IDisposableDiagnosticEvents : IDiagnosticEvents, IDisposable { }
-
             [Fact]
-            public void DisposesDisposableChildren()
+            public void DisposesAllChildren()
             {
-                var disposableChild = Mock.Of<IDisposableDiagnosticEvents>();
-                var nonDisposableChild = Mock.Of<IDiagnosticEvents>();
+                var child1 = Mock.Of<IDiagnosticEvents>();
+                var child2 = Mock.Of<IDiagnosticEvents>();
 
-                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { disposableChild, nonDisposableChild });
+                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { child1, child2 });
                 aggregated.Dispose();
 
-                Mock.Get(disposableChild).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(child1).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(child2).Verify(d => d.Dispose(), Times.Once);
             }
 
             [Fact]
-            public void DoesNotThrowWhenNoDisposableChildren()
+            public void DoesNotThrowWhenEmpty()
             {
-                var nonDisposableChild = Mock.Of<IDiagnosticEvents>();
-
-                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents> { nonDisposableChild });
+                var aggregated = new AggregatedDiagnosticEvents(new List<IDiagnosticEvents>());
                 aggregated.Dispose();
             }
         }

--- a/test/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEventsTest.cs
@@ -48,22 +48,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
             }
 
             [Fact]
-            public void ThrowsOnNullProvider()
-            {
-                Assert.Throws<ArgumentException>(() =>
-                {
-                    new PerformanceCounterDiagnosticEvents(null, clock);
-                });
-            }
+            public void ThrowsOnNullProvider() => Assert.Throws<ArgumentException>(() => new PerformanceCounterDiagnosticEvents(null, clock));
 
             [Fact]
-            public void ThrowsOnNullClock()
-            {
-                Assert.Throws<ArgumentException>(() =>
-                {
-                    new PerformanceCounterDiagnosticEvents(performanceCounterProvider, null);
-                });
-            }
+            public void ThrowsOnNullClock() => Assert.Throws<ArgumentException>(() => new PerformanceCounterDiagnosticEvents(performanceCounterProvider, null));
         }
 
         public class OnEvent : PerformanceCounterDiagnosticEventsTest
@@ -241,15 +229,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
                 Mock.Get(outstandingRequestsCounterWriter).Verify(x => x.UpdateCounterValue(It.IsAny<long>()), Times.Never);
                 performanceCounterProvider.Property<FabricAverageCount64PerformanceCounterWriter>(nameof(performanceCounterProvider.ServiceRequestDeserializationTimeCounterWriter))
                     .Set(requestDeserializationTimeCounterWriter);
-            }
-        }
-
-        public class Dispose : PerformanceCounterDiagnosticEventsTest
-        {
-            [Fact]
-            public void DoesNotThrow()
-            {
-                sut.Dispose();
             }
         }
     }

--- a/test/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/PerformanceCounterDiagnosticEventsTest.cs
@@ -243,5 +243,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.Diagnostic
                     .Set(requestDeserializationTimeCounterWriter);
             }
         }
+
+        public class Dispose : PerformanceCounterDiagnosticEventsTest
+        {
+            [Fact]
+            public void DoesNotThrow()
+            {
+                sut.Dispose();
+            }
+        }
     }
 }

--- a/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
@@ -53,18 +53,18 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 
         public class OnEvents : TelemetryDiagnosticEventsTest
         {
-            readonly IMeter<TimeSpan> mockRequestProcessingTime;
-            readonly IMeter<TimeSpan> mockRequestDeserializationTime;
-            readonly IMeter<TimeSpan> mockResponseSerializationTime;
+            readonly IMeter<TimeSpan> requestProcessingTime;
+            readonly IMeter<TimeSpan> requestDeserializationTime;
+            readonly IMeter<TimeSpan> responseSerializationTime;
             readonly DateTime endTime;
             readonly DateTime startTime;
             readonly double durationMilliseconds = fuzzy.Double(0, 5000);
 
             public OnEvents()
             {
-                mockRequestProcessingTime = sut.Field<IMeter<TimeSpan>>("requestProcessingTime").Value;
-                mockRequestDeserializationTime = sut.Field<IMeter<TimeSpan>>("requestDeserializationTime").Value;
-                mockResponseSerializationTime = sut.Field<IMeter<TimeSpan>>("responseSerializationTime").Value;
+                requestProcessingTime = sut.Field<IMeter<TimeSpan>>("requestProcessingTime").Value;
+                requestDeserializationTime = sut.Field<IMeter<TimeSpan>>("requestDeserializationTime").Value;
+                responseSerializationTime = sut.Field<IMeter<TimeSpan>>("responseSerializationTime").Value;
 
                 startTime = DateTime.UtcNow;
                 endTime = startTime.AddMilliseconds(durationMilliseconds);
@@ -79,9 +79,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
                 sut.OnCreateTransportMessageBegin();
                 sut.OnRemotingRequestBegin();
 
-                Mock.Get(mockRequestProcessingTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
-                Mock.Get(mockRequestDeserializationTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
-                Mock.Get(mockResponseSerializationTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
+                Mock.Get(requestProcessingTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
+                Mock.Get(requestDeserializationTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
+                Mock.Get(responseSerializationTime).Verify(x => x.Record(It.IsAny<TimeSpan>()), Times.Never);
             }
 
             [Fact]
@@ -89,7 +89,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             {
                 sut.OnRequestResponseEnd(startTime);
 
-                Mock.Get(mockRequestProcessingTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
+                Mock.Get(requestProcessingTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             {
                 sut.OnRemotingRequestEnd(startTime);
 
-                Mock.Get(mockRequestDeserializationTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
+                Mock.Get(requestDeserializationTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
             }
 
             [Fact]
@@ -105,21 +105,21 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             {
                 sut.OnCreateTransportMessageEnd(startTime);
 
-                Mock.Get(mockResponseSerializationTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
+                Mock.Get(responseSerializationTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
             }
         }
 
         public class Dispose : TelemetryDiagnosticEventsTest
         {
-            readonly IMeter<TimeSpan> mockRequestProcessingTime;
-            readonly IMeter<TimeSpan> mockRequestDeserializationTime;
-            readonly IMeter<TimeSpan> mockResponseSerializationTime;
+            readonly IMeter<TimeSpan> requestProcessingTime;
+            readonly IMeter<TimeSpan> requestDeserializationTime;
+            readonly IMeter<TimeSpan> responseSerializationTime;
 
             public Dispose()
             {
-                mockRequestProcessingTime = sut.Field<IMeter<TimeSpan>>("requestProcessingTime").Value;
-                mockRequestDeserializationTime = sut.Field<IMeter<TimeSpan>>("requestDeserializationTime").Value;
-                mockResponseSerializationTime = sut.Field<IMeter<TimeSpan>>("responseSerializationTime").Value;
+                requestProcessingTime = sut.Field<IMeter<TimeSpan>>("requestProcessingTime").Value;
+                requestDeserializationTime = sut.Field<IMeter<TimeSpan>>("requestDeserializationTime").Value;
+                responseSerializationTime = sut.Field<IMeter<TimeSpan>>("responseSerializationTime").Value;
             }
 
             [Fact]
@@ -127,9 +127,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
             {
                 sut.Dispose();
 
-                Mock.Get(mockRequestProcessingTime).Verify(m => m.Dispose(), Times.Once);
-                Mock.Get(mockRequestDeserializationTime).Verify(m => m.Dispose(), Times.Once);
-                Mock.Get(mockResponseSerializationTime).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(requestProcessingTime).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(requestDeserializationTime).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(responseSerializationTime).Verify(m => m.Dispose(), Times.Once);
             }
         }
     }

--- a/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
@@ -7,7 +7,6 @@ using System;
 using Fuzzy;
 using Inspector;
 using Microsoft.ServiceFabric.Diagnostics.Metrics;
-using Microsoft.ServiceFabric.TestFramework;
 using Moq;
 using Xunit;
 using IClock = Microsoft.ServiceFabric.Diagnostics.IClock;

--- a/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
+++ b/test/Services.Remoting/V2/Diagnostic/TelemetryDiagnosticEventsTest.cs
@@ -109,5 +109,29 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
                 Mock.Get(mockResponseSerializationTime).Verify(x => x.Record(It.Is<TimeSpan>(ts => Math.Abs(ts.TotalMilliseconds - durationMilliseconds) < 0.0001)), Times.Once);
             }
         }
+
+        public class Dispose : TelemetryDiagnosticEventsTest
+        {
+            readonly IMeter<TimeSpan> mockRequestProcessingTime;
+            readonly IMeter<TimeSpan> mockRequestDeserializationTime;
+            readonly IMeter<TimeSpan> mockResponseSerializationTime;
+
+            public Dispose()
+            {
+                mockRequestProcessingTime = sut.Field<IMeter<TimeSpan>>("requestProcessingTime").Value;
+                mockRequestDeserializationTime = sut.Field<IMeter<TimeSpan>>("requestDeserializationTime").Value;
+                mockResponseSerializationTime = sut.Field<IMeter<TimeSpan>>("responseSerializationTime").Value;
+            }
+
+            [Fact]
+            public void DisposesAllMeters()
+            {
+                sut.Dispose();
+
+                Mock.Get(mockRequestProcessingTime).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(mockRequestDeserializationTime).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(mockResponseSerializationTime).Verify(m => m.Dispose(), Times.Once);
+            }
+        }
     }
 }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
@@ -17,7 +17,6 @@ using Microsoft.ServiceFabric.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic;
 using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
-using Microsoft.ServiceFabric.TestFramework;
 using Moq;
 using Xunit;
 
@@ -150,6 +149,66 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 
                 // cleanup
                 Mock.Get(clock).Setup(c => c.UtcNow).Returns(currentTime);
+            }
+        }
+
+        public class Dispose : FabricTransportMessageHandlerTest
+        {
+            [Fact]
+            public void DisposesDiagnosticEvents()
+            {
+                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
+
+                sut.Dispose();
+
+                Mock.Get(diagnosticEvents).Verify(d => d.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DisposesPerformanceCounterProvider()
+            {
+                var provider = sut.Field<ServiceRemotingPerformanceCounterProvider>().Value;
+                Assert.NotNull(provider);
+
+                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
+                sut.Dispose();
+
+                // ServiceRemotingPerformanceCounterProvider is not mockable (concrete class),
+                // but verifying it doesn't throw confirms the disposal path works.
+            }
+
+            [Fact]
+            public void DisposesDisposableRemotingMessageHandler()
+            {
+                var disposableHandler = new Mock<IServiceRemotingMessageHandler>();
+                disposableHandler.As<IDisposable>();
+                disposableHandler.SetupAllProperties();
+                disposableHandler.DefaultValue = DefaultValue.Mock;
+
+                var handlerSut = new FabricTransportMessageHandler(
+                    disposableHandler.Object,
+                    new Mock<IServiceRemotingMessageSerializersManager>() { DefaultValue = DefaultValue.Mock }.Object,
+                    new ExceptionSerializer(
+                        new IExceptionConvertor[] { new DefaultExceptionConvertor() },
+                        new FabricTransportRemotingListenerSettings { RemotingExceptionDepth = 2 }
+                    ),
+                    Guid.NewGuid(),
+                    fuzzy.Int64(),
+                    new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock }.Object);
+
+                // Replace diagnosticEvents with a mock to avoid cascading into real TelemetryDiagnosticEvents
+                handlerSut.Field<IDiagnosticEvents>().Set(Mock.Of<IDiagnosticEvents>());
+
+                handlerSut.Dispose();
+
+                disposableHandler.As<IDisposable>().Verify(d => d.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenRemotingMessageHandlerIsNotDisposable()
+            {
+                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
+                sut.Dispose();
             }
         }
     }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
@@ -29,17 +29,17 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         readonly FabricTransportMessageHandler sut;
 
         readonly IDiagnosticEvents diagnosticEvents = Mock.Of<IDiagnosticEvents>();
+        readonly IServiceRemotingMessageHandler serviceRemotingMessageHandler = (IServiceRemotingMessageHandler)new Mock<IServiceRemotingMessageHandler>() { DefaultValue = DefaultValue.Mock }.As<IDisposable>().Object;
         readonly DateTime currentTime = fuzzy.DateTime();
         readonly IClock clock = Mock.Of<IClock>();
 
-
         public FabricTransportMessageHandlerTest()
         {
-            Mock.Get(this.clock).Setup(c => c.UtcNow)
+            Mock.Get(clock).Setup(c => c.UtcNow)
                 .Returns(currentTime);
 
-            this.sut = new FabricTransportMessageHandler(
-                new Mock<IServiceRemotingMessageHandler>() { DefaultValue = DefaultValue.Mock }.Object,
+            sut = new FabricTransportMessageHandler(
+                serviceRemotingMessageHandler,
                 new Mock<IServiceRemotingMessageSerializersManager>() { DefaultValue = DefaultValue.Mock }.Object,
                 new ExceptionSerializer(
                     new IExceptionConvertor[] { new DefaultExceptionConvertor() },
@@ -47,7 +47,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 ),
                 Guid.NewGuid(),
                 fuzzy.Int64(),
-                Mock.Of<IMeterProvider<TimeSpan>>());
+                new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock }.Object);
         }
 
         public class Constructor : FabricTransportMessageHandlerTest
@@ -80,13 +80,13 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             }
         }
 
-        public class RequestReponse : FabricTransportMessageHandlerTest
+        public class RequestResponse : FabricTransportMessageHandlerTest
         {
 
-            FabricTransportMessage fabricTransportMessage = new FabricTransportMessage(new FabricTransportRequestHeader(Mock.Of<Stream>()), new FabricTransportRequestBody(Mock.Of<Stream>()));
-            FabricTransportRequestContext requestContext = new FabricTransportRequestContext(null, null);
+            readonly FabricTransportMessage fabricTransportMessage = new(new FabricTransportRequestHeader(Mock.Of<Stream>()), new FabricTransportRequestBody(Mock.Of<Stream>()));
+            readonly FabricTransportRequestContext requestContext = new(null, null);
 
-            public RequestReponse()
+            public RequestResponse()
             {
                 // After creating SUT, we replace DiagnosticsSource with a mock
                 sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
@@ -98,8 +98,8 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             {
                 await sut.RequestResponseAsync(requestContext, fabricTransportMessage);
 
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRequestResponseBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRequestResponseEnd(currentTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRequestResponseBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRequestResponseEnd(currentTime), Times.Once);
             }
 
             [Fact]
@@ -107,8 +107,8 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             {
                 await sut.RequestResponseAsync(requestContext, fabricTransportMessage);
 
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnCreateTransportMessageBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnCreateTransportMessageEnd(currentTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnCreateTransportMessageBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnCreateTransportMessageEnd(currentTime), Times.Once);
             }
 
             [Fact]
@@ -116,8 +116,8 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             {
                 await sut.RequestResponseAsync(requestContext, fabricTransportMessage);
 
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRemotingRequestBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRemotingRequestEnd(currentTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRemotingRequestBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRemotingRequestEnd(currentTime), Times.Once);
             }
 
             [Fact]
@@ -127,25 +127,22 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
                 var remotingMethodStartTime = currentTime.AddMinutes(1);
                 var transportMethodStartTime = currentTime.AddMinutes(2);
 
-                Action onSerializationBeginCallback = () =>
-                {
-                    Mock.Get(clock).Setup(c => c.UtcNow).Returns(transportMethodStartTime);
-                };
+                Action onSerializationBeginCallback = () => Mock.Get(clock).Setup(c => c.UtcNow).Returns(transportMethodStartTime);
                 Action onRequestBeginCallback = () =>
                 {
                     Mock.Get(clock).Setup(c => c.UtcNow).Returns(remotingMethodStartTime);
-                    Mock.Get(this.diagnosticEvents).InSequence(sequence).Setup(d => d.OnRemotingRequestBegin()).Callback(onSerializationBeginCallback);
+                    Mock.Get(diagnosticEvents).InSequence(sequence).Setup(d => d.OnRemotingRequestBegin()).Callback(onSerializationBeginCallback);
                 };
-                Mock.Get(this.diagnosticEvents).InSequence(sequence).Setup(d => d.OnRequestResponseBegin()).Callback(onRequestBeginCallback);
+                Mock.Get(diagnosticEvents).InSequence(sequence).Setup(d => d.OnRequestResponseBegin()).Callback(onRequestBeginCallback);
 
                 await sut.RequestResponseAsync(requestContext, fabricTransportMessage);
 
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRequestResponseBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRequestResponseEnd(currentTime), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRemotingRequestBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnRemotingRequestEnd(remotingMethodStartTime), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnCreateTransportMessageBegin(), Times.Once);
-                Mock.Get(this.diagnosticEvents).Verify(d => d.OnCreateTransportMessageEnd(transportMethodStartTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRequestResponseBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRequestResponseEnd(currentTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRemotingRequestBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnRemotingRequestEnd(remotingMethodStartTime), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnCreateTransportMessageBegin(), Times.Once);
+                Mock.Get(diagnosticEvents).Verify(d => d.OnCreateTransportMessageEnd(transportMethodStartTime), Times.Once);
 
                 // cleanup
                 Mock.Get(clock).Setup(c => c.UtcNow).Returns(currentTime);
@@ -154,61 +151,22 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 
         public class Dispose : FabricTransportMessageHandlerTest
         {
+            public Dispose() => sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
+
             [Fact]
             public void DisposesDiagnosticEvents()
             {
-                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
-
                 sut.Dispose();
 
                 Mock.Get(diagnosticEvents).Verify(d => d.Dispose(), Times.Once);
             }
 
             [Fact]
-            public void DisposesPerformanceCounterProvider()
-            {
-                var provider = sut.Field<ServiceRemotingPerformanceCounterProvider>().Value;
-                Assert.NotNull(provider);
-
-                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
-                sut.Dispose();
-
-                // ServiceRemotingPerformanceCounterProvider is not mockable (concrete class),
-                // but verifying it doesn't throw confirms the disposal path works.
-            }
-
-            [Fact]
             public void DisposesDisposableRemotingMessageHandler()
             {
-                var disposableHandler = new Mock<IServiceRemotingMessageHandler>();
-                disposableHandler.As<IDisposable>();
-                disposableHandler.SetupAllProperties();
-                disposableHandler.DefaultValue = DefaultValue.Mock;
-
-                var handlerSut = new FabricTransportMessageHandler(
-                    disposableHandler.Object,
-                    new Mock<IServiceRemotingMessageSerializersManager>() { DefaultValue = DefaultValue.Mock }.Object,
-                    new ExceptionSerializer(
-                        new IExceptionConvertor[] { new DefaultExceptionConvertor() },
-                        new FabricTransportRemotingListenerSettings { RemotingExceptionDepth = 2 }
-                    ),
-                    Guid.NewGuid(),
-                    fuzzy.Int64(),
-                    new Mock<IMeterProvider<TimeSpan>>() { DefaultValue = DefaultValue.Mock }.Object);
-
-                // Replace diagnosticEvents with a mock to avoid cascading into real TelemetryDiagnosticEvents
-                handlerSut.Field<IDiagnosticEvents>().Set(Mock.Of<IDiagnosticEvents>());
-
-                handlerSut.Dispose();
-
-                disposableHandler.As<IDisposable>().Verify(d => d.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DoesNotThrowWhenRemotingMessageHandlerIsNotDisposable()
-            {
-                sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
                 sut.Dispose();
+
+                Mock.Get(serviceRemotingMessageHandler).As<IDisposable>().Verify(d => d.Dispose(), Times.Once);
             }
         }
     }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportMessageHandlerTest.cs
@@ -154,18 +154,11 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             public Dispose() => sut.Field<IDiagnosticEvents>().Set(diagnosticEvents);
 
             [Fact]
-            public void DisposesDiagnosticEvents()
+            public void DisposesAllDisposables()
             {
                 sut.Dispose();
 
                 Mock.Get(diagnosticEvents).Verify(d => d.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DisposesDisposableRemotingMessageHandler()
-            {
-                sut.Dispose();
-
                 Mock.Get(serviceRemotingMessageHandler).As<IDisposable>().Verify(d => d.Dispose(), Times.Once);
             }
         }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
@@ -27,29 +27,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
             sut.Field<IFabricTransportMessageHandler>().Set(mockTransportMessageHandler);
         }
 
-        public class Dispose : FabricTransportServiceRemotingListenerTest
+        public class Abort : FabricTransportServiceRemotingListenerTest
         {
             [Fact]
-            public void AbortDisposesMeterProvider()
+            public void AbortDisposesAllDisposables()
             {
                 sut.Abort();
 
                 Mock.Get(mockMeterProvider).Verify(m => m.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void AbortDisposesFabricTransportListener()
-            {
-                sut.Abort();
-
                 Mock.Get(mockFabricTransportListener).Verify(m => m.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void AbortDisposesMessageHandler()
-            {
-                sut.Abort();
-
                 Mock.Get(mockTransportMessageHandler).Verify(m => m.Dispose(), Times.Once);
             }
         }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
@@ -30,12 +30,26 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
         public class Dispose : FabricTransportServiceRemotingListenerTest
         {
             [Fact]
-            public void AbortDisposesEverything()
+            public void AbortDisposesMeterProvider()
             {
                 sut.Abort();
 
                 Mock.Get(mockMeterProvider).Verify(m => m.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void AbortDisposesFabricTransportListener()
+            {
+                sut.Abort();
+
                 Mock.Get(mockFabricTransportListener).Verify(m => m.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void AbortDisposesMessageHandler()
+            {
+                sut.Abort();
+
                 Mock.Get(mockTransportMessageHandler).Verify(m => m.Dispose(), Times.Once);
             }
         }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
@@ -14,49 +14,29 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 {
     public abstract class FabricTransportServiceRemotingListenerTest
     {
+        readonly FabricTransportServiceRemotingListener sut = Type<FabricTransportServiceRemotingListener>.Uninitialized();
+
+        readonly IMeterProvider<TimeSpan> mockMeterProvider = Mock.Of<IMeterProvider<TimeSpan>>();
+        readonly IFabricTransportListener mockFabricTransportListener = Mock.Of<IFabricTransportListener>();
+        readonly IFabricTransportMessageHandler mockTransportMessageHandler = Mock.Of<IFabricTransportMessageHandler>();
+
+        public FabricTransportServiceRemotingListenerTest()
+        {
+            sut.Field<IMeterProvider<TimeSpan>>().Set(mockMeterProvider);
+            sut.Field<IFabricTransportListener>().Set(mockFabricTransportListener);
+            sut.Field<IFabricTransportMessageHandler>().Set(mockTransportMessageHandler);
+        }
+
         public class Dispose : FabricTransportServiceRemotingListenerTest
         {
             [Fact]
-            public void DisposesMeterProvider()
+            public void AbortDisposesEverything()
             {
-                var sut = Type<FabricTransportServiceRemotingListener>.Uninitialized();
-
-                var mockMeterProvider = Mock.Of<IMeterProvider<TimeSpan>>();
-                var mockFabricTransportListener = Type<FabricTransportListener>.Uninitialized();
-                var mockTransportMessageHandler = Type<FabricTransportMessageHandler>.Uninitialized();
-
-                // Set up diagnostic events on the handler so Dispose() doesn't null-ref
-                mockTransportMessageHandler.Field<Diagnostic.IDiagnosticEvents>().Set(Mock.Of<Diagnostic.IDiagnosticEvents>());
-
-                sut.Field<IMeterProvider<TimeSpan>>().Set(mockMeterProvider);
-                sut.Field<FabricTransportListener>().Set(mockFabricTransportListener);
-                sut.Field<FabricTransportMessageHandler>().Set(mockTransportMessageHandler);
-
                 sut.Abort();
 
                 Mock.Get(mockMeterProvider).Verify(m => m.Dispose(), Times.Once);
-            }
-
-            [Fact]
-            public void DisposesTransportMessageHandler()
-            {
-                var sut = Type<FabricTransportServiceRemotingListener>.Uninitialized();
-
-                var mockMeterProvider = Mock.Of<IMeterProvider<TimeSpan>>();
-                var mockDiagnosticEvents = Mock.Of<Diagnostic.IDiagnosticEvents>();
-                var mockFabricTransportListener = Type<FabricTransportListener>.Uninitialized();
-                var mockTransportMessageHandler = Type<FabricTransportMessageHandler>.Uninitialized();
-
-                mockTransportMessageHandler.Field<Diagnostic.IDiagnosticEvents>().Set(mockDiagnosticEvents);
-
-                sut.Field<IMeterProvider<TimeSpan>>().Set(mockMeterProvider);
-                sut.Field<FabricTransportListener>().Set(mockFabricTransportListener);
-                sut.Field<FabricTransportMessageHandler>().Set(mockTransportMessageHandler);
-
-                sut.Abort();
-
-                // Verify handler's Dispose cascades to its diagnosticEvents
-                Mock.Get(mockDiagnosticEvents).Verify(d => d.Dispose(), Times.Once);
+                Mock.Get(mockFabricTransportListener).Verify(m => m.Dispose(), Times.Once);
+                Mock.Get(mockTransportMessageHandler).Verify(m => m.Dispose(), Times.Once);
             }
         }
     }

--- a/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
+++ b/test/Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListenerTest.cs
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Inspector;
+using Microsoft.ServiceFabric.Diagnostics.Metrics;
+using Microsoft.ServiceFabric.FabricTransport.Runtime;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
+{
+    public abstract class FabricTransportServiceRemotingListenerTest
+    {
+        public class Dispose : FabricTransportServiceRemotingListenerTest
+        {
+            [Fact]
+            public void DisposesMeterProvider()
+            {
+                var sut = Type<FabricTransportServiceRemotingListener>.Uninitialized();
+
+                var mockMeterProvider = Mock.Of<IMeterProvider<TimeSpan>>();
+                var mockFabricTransportListener = Type<FabricTransportListener>.Uninitialized();
+                var mockTransportMessageHandler = Type<FabricTransportMessageHandler>.Uninitialized();
+
+                // Set up diagnostic events on the handler so Dispose() doesn't null-ref
+                mockTransportMessageHandler.Field<Diagnostic.IDiagnosticEvents>().Set(Mock.Of<Diagnostic.IDiagnosticEvents>());
+
+                sut.Field<IMeterProvider<TimeSpan>>().Set(mockMeterProvider);
+                sut.Field<FabricTransportListener>().Set(mockFabricTransportListener);
+                sut.Field<FabricTransportMessageHandler>().Set(mockTransportMessageHandler);
+
+                sut.Abort();
+
+                Mock.Get(mockMeterProvider).Verify(m => m.Dispose(), Times.Once);
+            }
+
+            [Fact]
+            public void DisposesTransportMessageHandler()
+            {
+                var sut = Type<FabricTransportServiceRemotingListener>.Uninitialized();
+
+                var mockMeterProvider = Mock.Of<IMeterProvider<TimeSpan>>();
+                var mockDiagnosticEvents = Mock.Of<Diagnostic.IDiagnosticEvents>();
+                var mockFabricTransportListener = Type<FabricTransportListener>.Uninitialized();
+                var mockTransportMessageHandler = Type<FabricTransportMessageHandler>.Uninitialized();
+
+                mockTransportMessageHandler.Field<Diagnostic.IDiagnosticEvents>().Set(mockDiagnosticEvents);
+
+                sut.Field<IMeterProvider<TimeSpan>>().Set(mockMeterProvider);
+                sut.Field<FabricTransportListener>().Set(mockFabricTransportListener);
+                sut.Field<FabricTransportMessageHandler>().Set(mockTransportMessageHandler);
+
+                sut.Abort();
+
+                // Verify handler's Dispose cascades to its diagnosticEvents
+                Mock.Get(mockDiagnosticEvents).Verify(d => d.Dispose(), Times.Once);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enable deterministic dispose of metric related COM objects:
- `IMeter/1D/2D/3D` and `IMeterProvider` now inherit `IDisposable`
- Implement `Dispose()` method in `Meter`/`MeterProvider` classes that releases the COM object
- Throw an exception if `Meter`/`MeterProvider` are disposed while calling `Record`/`CreateMeter`
- Add `MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))` to the methods that get COM objects in order for `FinalReleaseComObject` to work on .NETCore.

Integrate the changes in Actors and Remoting:
- Dispose `AggregatedDiagnostics` in `OnCloseAsync`
- Dispose `MeterProvider` and `IDiagnostics` in classes where they are created (`FabricTransportServiceRemotingListener` and `FabricTransportMessageHandler`)

Other:
- Various opportunistic coding standard refactors, in line with new .editorconfig
- IFabricTransportMessageHandler now inherits from IDisposable, to make FabricTransportMessageHandler implement IDisposable exsplicitly
- Various changes to enable unit testability of the changeset, such as introduction of `IFabricTransportListener` for `FabricTransportListener`