### PR TITLE
Expose Backup Validation Metadata

### DIFF
--- a/src/Client.Http/Client.Http/Generated/Serialization/BackupInfoConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/BackupInfoConverter.cs
@@ -43,6 +43,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var epochOfLastBackupRecord = default(Epoch);
             var lsnOfLastBackupRecord = default(string);
             var creationTimeUtc = default(DateTime?);
+            var lastValidationDateTime = default(DateTime?);
+            var validationResult = default(BackupValidationResult?);
             var serviceManifestVersion = default(string);
             var failureError = default(FabricErrorError);
 
@@ -89,6 +91,14 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     creationTimeUtc = reader.ReadValueAsDateTime();
                 }
+                else if (string.Compare("LastValidationDateTime", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    lastValidationDateTime = reader.ReadValueAsDateTime();
+                }
+                else if (string.Compare("ValidationResult", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    validationResult = BackupValidationResultConverter.Deserialize(reader);
+                }
                 else if (string.Compare("ServiceManifestVersion", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     serviceManifestVersion = reader.ReadValueAsString();
@@ -115,6 +125,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 epochOfLastBackupRecord: epochOfLastBackupRecord,
                 lsnOfLastBackupRecord: lsnOfLastBackupRecord,
                 creationTimeUtc: creationTimeUtc,
+                lastValidationDateTime: lastValidationDateTime,
+                validationResult: validationResult,
                 serviceManifestVersion: serviceManifestVersion,
                 failureError: failureError);
         }
@@ -129,6 +141,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             // Required properties are always serialized, optional properties are serialized when not null.
             writer.WriteStartObject();
             writer.WriteProperty(obj.BackupType, "BackupType", BackupTypeConverter.Serialize);
+            writer.WriteProperty(obj.ValidationResult, "ValidationResult", BackupValidationResultConverter.Serialize);
             if (obj.BackupId != null)
             {
                 writer.WriteProperty(obj.BackupId, "BackupId", JsonWriterExtensions.WriteGuidValue);
@@ -172,6 +185,11 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             if (obj.CreationTimeUtc != null)
             {
                 writer.WriteProperty(obj.CreationTimeUtc, "CreationTimeUtc", JsonWriterExtensions.WriteDateTimeValue);
+            }
+
+            if (obj.LastValidationDateTime != null)
+            {
+                writer.WriteProperty(obj.LastValidationDateTime, "LastValidationDateTime", JsonWriterExtensions.WriteDateTimeValue);
             }
 
             if (obj.ServiceManifestVersion != null)

--- a/src/Client.Http/Client.Http/Generated/Serialization/BackupInfoConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/BackupInfoConverter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var epochOfLastBackupRecord = default(Epoch);
             var lsnOfLastBackupRecord = default(string);
             var creationTimeUtc = default(DateTime?);
-            var lastValidationDateTime = default(DateTime?);
+            var validationTimeUtc = default(DateTime?);
             var validationResult = default(BackupValidationResult?);
             var serviceManifestVersion = default(string);
             var failureError = default(FabricErrorError);
@@ -91,9 +91,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     creationTimeUtc = reader.ReadValueAsDateTime();
                 }
-                else if (string.Compare("LastValidationDateTime", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ValidationTimeUtc", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    lastValidationDateTime = reader.ReadValueAsDateTime();
+                    validationTimeUtc = reader.ReadValueAsDateTime();
                 }
                 else if (string.Compare("ValidationResult", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 epochOfLastBackupRecord: epochOfLastBackupRecord,
                 lsnOfLastBackupRecord: lsnOfLastBackupRecord,
                 creationTimeUtc: creationTimeUtc,
-                lastValidationDateTime: lastValidationDateTime,
+                validationTimeUtc: validationTimeUtc,
                 validationResult: validationResult,
                 serviceManifestVersion: serviceManifestVersion,
                 failureError: failureError);
@@ -187,9 +187,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.CreationTimeUtc, "CreationTimeUtc", JsonWriterExtensions.WriteDateTimeValue);
             }
 
-            if (obj.LastValidationDateTime != null)
+            if (obj.ValidationTimeUtc != null)
             {
-                writer.WriteProperty(obj.LastValidationDateTime, "LastValidationDateTime", JsonWriterExtensions.WriteDateTimeValue);
+                writer.WriteProperty(obj.ValidationTimeUtc, "ValidationTimeUtc", JsonWriterExtensions.WriteDateTimeValue);
             }
 
             if (obj.ServiceManifestVersion != null)

--- a/src/Client.Http/Client.Http/Generated/Serialization/BackupValidationResultConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/BackupValidationResultConverter.cs
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="BackupValidationResult" />.
+    /// </summary>
+    internal class BackupValidationResultConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static BackupValidationResult? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(BackupValidationResult);
+
+            if (string.Compare(value, "None", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = BackupValidationResult.None;
+            }
+            else if (string.Compare(value, "Success", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = BackupValidationResult.Success;
+            }
+            else if (string.Compare(value, "ChecksumMismatchFailure", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = BackupValidationResult.ChecksumMismatchFailure;
+            }
+            else if (string.Compare(value, "BackupChainMissingFailure", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = BackupValidationResult.BackupChainMissingFailure;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, BackupValidationResult? value)
+        {
+            switch (value)
+            {
+                case BackupValidationResult.None:
+                    writer.WriteStringValue("None");
+                    break;
+                case BackupValidationResult.Success:
+                    writer.WriteStringValue("Success");
+                    break;
+                case BackupValidationResult.ChecksumMismatchFailure:
+                    writer.WriteStringValue("ChecksumMismatchFailure");
+                    break;
+                case BackupValidationResult.BackupChainMissingFailure:
+                    writer.WriteStringValue("BackupChainMissingFailure");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type BackupValidationResult");
+            }
+        }
+    }
+}

--- a/src/Client.Http/Common/Generated/BackupInfo.cs
+++ b/src/Client.Http/Common/Generated/BackupInfo.cs
@@ -28,6 +28,13 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="epochOfLastBackupRecord">Epoch of the last record in this backup.</param>
         /// <param name="lsnOfLastBackupRecord">LSN of the last record in this backup.</param>
         /// <param name="creationTimeUtc">The date time when this backup was taken.</param>
+        /// <param name="lastValidationDateTime">The date time when this backup was last validated.</param>
+        /// <param name="validationResult">The overall validation result for this backup. Possible values include: 'None',
+        /// 'Success', 'ChecksumMismatchFailure', 'BackupChainMissingFailure'
+        /// 
+        /// Overall validation result for this backup.
+        /// 
+        /// </param>
         /// <param name="serviceManifestVersion">Manifest Version of the service this partition backup belongs to.</param>
         /// <param name="failureError">Denotes the failure encountered in getting backup point information.</param>
         public BackupInfo(
@@ -41,6 +48,8 @@ namespace Microsoft.ServiceFabric.Common
             Epoch epochOfLastBackupRecord = default(Epoch),
             string lsnOfLastBackupRecord = default(string),
             DateTime? creationTimeUtc = default(DateTime?),
+            DateTime? lastValidationDateTime = default(DateTime?),
+            BackupValidationResult? validationResult = default(BackupValidationResult?),
             string serviceManifestVersion = default(string),
             FabricErrorError failureError = default(FabricErrorError))
         {
@@ -54,6 +63,8 @@ namespace Microsoft.ServiceFabric.Common
             this.EpochOfLastBackupRecord = epochOfLastBackupRecord;
             this.LsnOfLastBackupRecord = lsnOfLastBackupRecord;
             this.CreationTimeUtc = creationTimeUtc;
+            this.LastValidationDateTime = lastValidationDateTime;
+            this.ValidationResult = validationResult;
             this.ServiceManifestVersion = serviceManifestVersion;
             this.FailureError = failureError;
         }
@@ -109,6 +120,19 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets the date time when this backup was taken.
         /// </summary>
         public DateTime? CreationTimeUtc { get; }
+
+        /// <summary>
+        /// Gets the date time when this backup was last validated.
+        /// </summary>
+        public DateTime? LastValidationDateTime { get; }
+
+        /// <summary>
+        /// Gets the overall validation result for this backup. Possible values include: 'None', 'Success',
+        /// 'ChecksumMismatchFailure', 'BackupChainMissingFailure'
+        /// 
+        /// Overall validation result for this backup.
+        /// </summary>
+        public BackupValidationResult? ValidationResult { get; }
 
         /// <summary>
         /// Gets manifest Version of the service this partition backup belongs to.

--- a/src/Client.Http/Common/Generated/BackupInfo.cs
+++ b/src/Client.Http/Common/Generated/BackupInfo.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="epochOfLastBackupRecord">Epoch of the last record in this backup.</param>
         /// <param name="lsnOfLastBackupRecord">LSN of the last record in this backup.</param>
         /// <param name="creationTimeUtc">The date time when this backup was taken.</param>
-        /// <param name="lastValidationDateTime">The date time when this backup was last validated.</param>
+        /// <param name="validationTimeUtc">The date time when this backup was last validated.</param>
         /// <param name="validationResult">The overall validation result for this backup. Possible values include: 'None',
         /// 'Success', 'ChecksumMismatchFailure', 'BackupChainMissingFailure'
         /// 
@@ -48,7 +48,7 @@ namespace Microsoft.ServiceFabric.Common
             Epoch epochOfLastBackupRecord = default(Epoch),
             string lsnOfLastBackupRecord = default(string),
             DateTime? creationTimeUtc = default(DateTime?),
-            DateTime? lastValidationDateTime = default(DateTime?),
+            DateTime? validationTimeUtc = default(DateTime?),
             BackupValidationResult? validationResult = default(BackupValidationResult?),
             string serviceManifestVersion = default(string),
             FabricErrorError failureError = default(FabricErrorError))
@@ -63,7 +63,7 @@ namespace Microsoft.ServiceFabric.Common
             this.EpochOfLastBackupRecord = epochOfLastBackupRecord;
             this.LsnOfLastBackupRecord = lsnOfLastBackupRecord;
             this.CreationTimeUtc = creationTimeUtc;
-            this.LastValidationDateTime = lastValidationDateTime;
+            this.ValidationTimeUtc = validationTimeUtc;
             this.ValidationResult = validationResult;
             this.ServiceManifestVersion = serviceManifestVersion;
             this.FailureError = failureError;
@@ -124,7 +124,7 @@ namespace Microsoft.ServiceFabric.Common
         /// <summary>
         /// Gets the date time when this backup was last validated.
         /// </summary>
-        public DateTime? LastValidationDateTime { get; }
+        public DateTime? ValidationTimeUtc { get; }
 
         /// <summary>
         /// Gets the overall validation result for this backup. Possible values include: 'None', 'Success',

--- a/src/Client.Http/Common/Generated/BackupValidationResult.cs
+++ b/src/Client.Http/Common/Generated/BackupValidationResult.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for BackupValidationResult.
+    /// </summary>
+    public enum BackupValidationResult
+    {
+        /// <summary>
+        /// No validation was performed on this backup.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// All validation checks passed successfully.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// Checksum validation failed because the backup data integrity check did not match.
+        /// </summary>
+        ChecksumMismatchFailure,
+
+        /// <summary>
+        /// Backup chain validation failed because one or more backups in the chain are missing or corrupted.
+        /// </summary>
+        BackupChainMissingFailure,
+    }
+}


### PR DESCRIPTION
Adds two new properties to the BackupInfo model to surface backup validation metadata from the Service Fabric REST API:

ValidationTimeUtc (DateTime?) — The date/time when the backup was last validated.
ValidationResult (BackupValidationResult?) — The overall validation result for the backup.
New enum: BackupValidationResult
None — No validation was performed
Success — All validation checks passed
ChecksumMismatchFailure — Backup data integrity check did not match
BackupChainMissingFailure — One or more backups in the chain are missing or corrupted