### PR TITLE
Bump package version to 12.0.0.beta-27

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>26</Revision>
+    <Revision>27</Revision>
 
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In order to publish new packages, bump the version to 12.0.0.beta-27.