### PR TITLE
Dispose Diagnsotics in ActorService Abort

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -9,7 +9,7 @@
     <MajorVersion>12</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <BuildVersion>0</BuildVersion>
-    <Revision>27</Revision>
+    <Revision>28</Revision>
 
   </PropertyGroup>
 </Project>

--- a/src/Actors/Runtime/ActorService.cs
+++ b/src/Actors/Runtime/ActorService.cs
@@ -18,374 +18,307 @@ using Microsoft.ServiceFabric.Services;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 
-namespace Microsoft.ServiceFabric.Actors.Runtime
+namespace Microsoft.ServiceFabric.Actors.Runtime;
+
+/// <summary>
+/// Represents the base class for Microsoft Service Fabric based reliable actors service.
+/// </summary>
+/// <remarks>
+/// Derive from this class to implement your own custom actor service if you want to override
+/// any service level behavior for your actors.
+/// </remarks>
+public class ActorService : StatefulServiceBase, IActorService
 {
+    const string traceType = "ActorService";
+
+    readonly ActorTypeInformation actorTypeInformation;
+    readonly IActorStateProvider stateProvider;
+    readonly ActorServiceSettings settings;
+    readonly IActorActivator actorActivator;
+    readonly ActorManagerAdapter actorManagerAdapter;
+    readonly Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory;
+    ActorMethodFriendlyNameBuilder methodFriendlyNameBuilder;
+    ReplicaRole replicaRole;
+    Remoting.V2.Runtime.ActorMethodDispatcherMap methodDispatcherMapV2;
+
+    readonly IClock clock = new SystemClock();
+    readonly IDiagnostics diagnostics;
+    readonly DiagnosticsFactory diagnosticsFactory;
+
+    static Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticFactory =
+        (serviceContext, actorTypeInformation, methodNameBuilder) => new DiagnosticsFactory(serviceContext, actorTypeInformation, methodNameBuilder);
+
     /// <summary>
-    /// Represents the base class for Microsoft Service Fabric based reliable actors service.
+    /// Initializes a new instance of the <see cref="ActorService"/> class.
     /// </summary>
-    /// <remarks>
-    /// Derive from this class to implement your own custom actor service if you want to override
-    /// any service level behavior for your actors.
-    /// </remarks>
-    public class ActorService : StatefulServiceBase, IActorService
+    /// <param name="context">Service context the actor service is operating under.</param>
+    /// <param name="actorTypeInfo">The type information of the Actor.</param>
+    /// <param name="actorFactory">The factory method to create Actor objects.</param>
+    /// <param name="stateManagerFactory">The factory method to create <see cref="IActorStateManager"/></param>
+    /// <param name="stateProvider">The state provider to store and access the state of the Actor objects.</param>
+    /// <param name="settings">The settings used to configure the behavior of the Actor service.</param>
+    public ActorService(
+        StatefulServiceContext context,
+        ActorTypeInformation actorTypeInfo,
+        Func<ActorService, ActorId, ActorBase> actorFactory = null,
+        Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = null,
+        IActorStateProvider stateProvider = null,
+        ActorServiceSettings settings = null)
+        : base(
+            context,
+            stateProvider ?? ActorStateProviderHelper.CreateDefaultStateProvider(actorTypeInfo))
     {
-        private const string TraceType = "ActorService";
+        actorTypeInformation = actorTypeInfo;
+        this.stateProvider = (IActorStateProvider)StateProviderReplica;
+        this.settings = ActorServiceSettings.DeepCopyFromOrDefaultOnNull(settings);
 
-        readonly ActorTypeInformation actorTypeInformation;
-        readonly IActorStateProvider stateProvider;
-        readonly ActorServiceSettings settings;
-        readonly IActorActivator actorActivator;
-        readonly ActorManagerAdapter actorManagerAdapter;
-        readonly Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory;
-        ActorMethodFriendlyNameBuilder methodFriendlyNameBuilder;
-        ReplicaRole replicaRole;
-        Remoting.V2.Runtime.ActorMethodDispatcherMap methodDispatcherMapV2;
+        // Set internal components
+        actorActivator = new ActorActivator(actorFactory ?? DefaultActorFactory);
+        this.stateManagerFactory = stateManagerFactory ?? DefaultActorStateManagerFactory;
+        actorManagerAdapter = new ActorManagerAdapter { ActorManager = new MockActorManager(this) };
+        replicaRole = ReplicaRole.Unknown;
+        methodFriendlyNameBuilder = new ActorMethodFriendlyNameBuilder(actorTypeInformation);
 
-        readonly IClock clock = new SystemClock();
-        readonly IDiagnostics diagnostics;
-        readonly DiagnosticsFactory diagnosticsFactory;
+        diagnosticsFactory = createDiagnosticFactory(context, actorTypeInfo, methodFriendlyNameBuilder);
+        diagnostics = diagnosticsFactory.CreateDiagnostics(clock);
 
-        static Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticFactory = (serviceContext, actorTypeInformation, methodNameBuilder) =>
-        {
-            return new DiagnosticsFactory(serviceContext, actorTypeInformation, methodNameBuilder);
-        };
+        ActorTelemetry.ActorServiceInitializeEvent(ActorManager.ActorService.Context, StateProviderReplica.GetType().ToString());
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ActorService"/> class.
-        /// </summary>
-        /// <param name="context">Service context the actor service is operating under.</param>
-        /// <param name="actorTypeInfo">The type information of the Actor.</param>
-        /// <param name="actorFactory">The factory method to create Actor objects.</param>
-        /// <param name="stateManagerFactory">The factory method to create <see cref="IActorStateManager"/></param>
-        /// <param name="stateProvider">The state provider to store and access the state of the Actor objects.</param>
-        /// <param name="settings">The settings used to configure the behavior of the Actor service.</param>
-        public ActorService(
-            StatefulServiceContext context,
-            ActorTypeInformation actorTypeInfo,
-            Func<ActorService, ActorId, ActorBase> actorFactory = null,
-            Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = null,
-            IActorStateProvider stateProvider = null,
-            ActorServiceSettings settings = null)
-            : base(
-                context,
-                stateProvider ?? ActorStateProviderHelper.CreateDefaultStateProvider(actorTypeInfo))
-        {
-            this.actorTypeInformation = actorTypeInfo;
-            this.stateProvider = (IActorStateProvider)this.StateProviderReplica;
-            this.settings = ActorServiceSettings.DeepCopyFromOrDefaultOnNull(settings);
+    /// <summary>
+    /// Gets the ActorTypeInformation for actor service.
+    /// </summary>
+    /// <value>
+    /// <see cref="Runtime.ActorTypeInformation"/>
+    /// for the actor hosted by the service replica.
+    /// </value>
+    public ActorTypeInformation ActorTypeInformation => actorTypeInformation;
 
-            // Set internal components
-            this.actorActivator = new ActorActivator(actorFactory ?? this.DefaultActorFactory);
-            this.stateManagerFactory = stateManagerFactory ?? DefaultActorStateManagerFactory;
-            this.actorManagerAdapter = new ActorManagerAdapter { ActorManager = new MockActorManager(this) };
-            this.replicaRole = ReplicaRole.Unknown;
-            this.methodFriendlyNameBuilder = new ActorMethodFriendlyNameBuilder(actorTypeInformation);
+    /// <summary>
+    /// Gets a <see cref="IActorStateProvider"/> that represents the state provider for the actor service.
+    /// </summary>
+    /// <value>
+    /// <see cref="IActorStateProvider"/>
+    /// representing the state provider for the actor service.
+    /// </value>
+    public IActorStateProvider StateProvider => stateProvider;
 
-            this.diagnosticsFactory = createDiagnosticFactory(context, actorTypeInfo, methodFriendlyNameBuilder);
-            this.diagnostics = this.diagnosticsFactory.CreateDiagnostics(clock);
+    /// <summary>
+    /// Gets the settings for the actor service.
+    /// </summary>
+    /// <value>
+    /// Settings for the actor service.
+    /// </value>
+    public ActorServiceSettings Settings => settings;
 
-            ActorTelemetry.ActorServiceInitializeEvent(
-                this.ActorManager.ActorService.Context,
-                this.StateProviderReplica.GetType().ToString());
-        }
+    internal IActorActivator ActorActivator => actorActivator;
 
-        /// <summary>
-        /// Gets the ActorTypeInformation for actor service.
-        /// </summary>
-        /// <value>
-        /// <see cref="Runtime.ActorTypeInformation"/>
-        /// for the actor hosted by the service replica.
-        /// </value>
-        public ActorTypeInformation ActorTypeInformation
-        {
-            get { return this.actorTypeInformation; }
-        }
+    internal Remoting.V2.Runtime.ActorMethodDispatcherMap MethodDispatcherMapV2
+    {
+        get => methodDispatcherMapV2; set => methodDispatcherMapV2 = value;
+    }
 
-        /// <summary>
-        /// Gets a <see cref="IActorStateProvider"/> that represents the state provider for the actor service.
-        /// </summary>
-        /// <value>
-        /// <see cref="IActorStateProvider"/>
-        /// representing the state provider for the actor service.
-        /// </value>
-        public IActorStateProvider StateProvider
-        {
-            get { return this.stateProvider; }
-        }
+    internal ActorMethodFriendlyNameBuilder MethodFriendlyNameBuilder => methodFriendlyNameBuilder;
 
-        /// <summary>
-        /// Gets the settings for the actor service.
-        /// </summary>
-        /// <value>
-        /// Settings for the actor service.
-        /// </value>
-        public ActorServiceSettings Settings
-        {
-            get { return this.settings; }
-        }
+    internal IActorManager ActorManager => actorManagerAdapter.ActorManager;
 
-        internal IActorActivator ActorActivator
-        {
-            get { return this.actorActivator; }
-        }
+    internal IClock Clock => clock;
 
-        internal Remoting.V2.Runtime.ActorMethodDispatcherMap MethodDispatcherMapV2
-        {
-            get { return this.methodDispatcherMapV2; }
-            set { this.methodDispatcherMapV2 = value; }
-        }
+    internal IDiagnostics Diagnostics => diagnostics;
 
-        internal ActorMethodFriendlyNameBuilder MethodFriendlyNameBuilder
-        {
-            get { return this.methodFriendlyNameBuilder; }
-        }
+    #region IActorService Members
 
-        internal IActorManager ActorManager
-        {
-            get { return this.actorManagerAdapter.ActorManager; }
-        }
+    /// <summary>
+    /// Deletes an Actor from the Actor service.
+    /// </summary>
+    /// <param name="actorId">The <see cref="ActorId"/> of the actor to be deleted.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns>A task that represents the asynchronous operation of call to server.</returns>
+    /// <remarks>
+    /// <para>An active actor, will be deactivated and its state will also be deleted from state provider.</para>
+    /// <para>An in-active actor's state will be deleted from state provider.</para>
+    /// <para>If this method is called for a non-existent actor id in the system, it will be a no-op.</para>
+    /// </remarks>
+    Task IActorService.DeleteActorAsync(ActorId actorId, CancellationToken cancellationToken)
+    {
+        var requestId = LogContext.GetRequestIdOrDefault();
+        return ActorManager.DeleteActorAsync(
+            requestId == default(Guid) ? Guid.NewGuid().ToString() : requestId.ToString(),
+            actorId,
+            cancellationToken);
+    }
 
-        internal IClock Clock
-        {
-            get { return this.clock; }
-        }
+    /// <summary>
+    /// Gets the list of Actors by querying the actor service.
+    /// </summary>
+    /// <param name="continuationToken">A continuation token to start querying the results from.
+    /// A null value of continuation token means start returning values form the beginning.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns>A task that represents the asynchronous operation of call to server.</returns>
+    Task<PagedResult<ActorInformation>> IActorService.GetActorsAsync(ContinuationToken continuationToken, CancellationToken cancellationToken) => ActorManager.GetActorsFromStateProvider(continuationToken, cancellationToken);
 
-        internal IDiagnostics Diagnostics
-        {
-            get { return this.diagnostics; }
-        }
+    /// <inheritdoc/>
+    Task<ReminderPagedResult<KeyValuePair<ActorId, List<ActorReminderState>>>> IActorService.GetRemindersAsync(ActorId actorId, ContinuationToken continuationToken, CancellationToken cancellationToken) => ActorManager.GetRemindersFromStateProviderAsync(actorId, continuationToken, cancellationToken);
 
-        #region IActorService Members
+    #endregion
 
-        /// <summary>
-        /// Deletes an Actor from the Actor service.
-        /// </summary>
-        /// <param name="actorId">The <see cref="ActorId"/> of the actor to be deleted.</param>
-        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        /// <returns>A task that represents the asynchronous operation of call to server.</returns>
-        /// <remarks>
-        /// <para>An active actor, will be deactivated and its state will also be deleted from state provider.</para>
-        /// <para>An in-active actor's state will be deleted from state provider.</para>
-        /// <para>If this method is called for a non-existent actor id in the system, it will be a no-op.</para>
-        /// </remarks>
-        Task IActorService.DeleteActorAsync(ActorId actorId, CancellationToken cancellationToken)
-        {
-            var requestId = LogContext.GetRequestIdOrDefault();
-            return this.ActorManager.DeleteActorAsync(
-                requestId == default(Guid) ? Guid.NewGuid().ToString() : requestId.ToString(),
-                actorId,
-                cancellationToken);
-        }
-
-        /// <summary>
-        /// Gets the list of Actors by querying the actor service.
-        /// </summary>
-        /// <param name="continuationToken">A continuation token to start querying the results from.
-        /// A null value of continuation token means start returning values form the beginning.</param>
-        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        /// <returns>A task that represents the asynchronous operation of call to server.</returns>
-        Task<PagedResult<ActorInformation>> IActorService.GetActorsAsync(
-            ContinuationToken continuationToken,
-            CancellationToken cancellationToken)
-        {
-            return this.ActorManager.GetActorsFromStateProvider(
-                continuationToken,
-                cancellationToken);
-        }
-
-        /// <inheritdoc/>
-        Task<ReminderPagedResult<KeyValuePair<ActorId, List<ActorReminderState>>>> IActorService.GetRemindersAsync(
-           ActorId actorId,
-           ContinuationToken continuationToken,
-           CancellationToken cancellationToken)
-        {
-            return this.ActorManager.GetRemindersFromStateProviderAsync(
-                actorId,
-                continuationToken,
-                cancellationToken);
-        }
-
-        #endregion
-
-        internal async Task StartRemindersIfNeededAsync(bool actorCallsAllowed, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (actorCallsAllowed)
-            {
-                ActorTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.Context.TraceId,
-                    "ActorCallsAllowed : TRUE - Starting reminders.");
-                try
-                {
-                    await this.ActorManager.StartLoadingRemindersAsync(cancellationToken);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    var healthInfo = new HealthInformation("ActorService", "LoadReminders", HealthState.Error)
-                    {
-                        TimeToLive = TimeSpan.MaxValue,
-                        RemoveWhenExpired = false,
-                        Description = ex.Message,
-                    };
-
-                    this.Partition.ReportPartitionHealth(healthInfo, new HealthReportSendOptions { Immediate = true });
-
-                    throw;
-                }
-            }
-            else
-            {
-                ActorTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.Context.TraceId,
-                    "ActorCallsAllowed : FALSE");
-
-                //// TODO: Stop reminders from firing
-            }
-        }
-
-        internal IActorStateManager CreateStateManager(ActorBase actor)
-        {
-            return this.stateManagerFactory.Invoke(actor, this.StateProvider);
-        }
-
-        internal void InitializeInternal(ActorMethodFriendlyNameBuilder methodNameBuilder)
-        {
-            this.methodFriendlyNameBuilder = methodNameBuilder;
-            this.MethodDispatcherMapV2 =
-                new Actors.Remoting.V2.Runtime.ActorMethodDispatcherMap(this.ActorTypeInformation);
-        }
-
-        #region StatefulServiceBase Overrides
-
-        /// <summary>
-        /// Overrides <see cref="Microsoft.ServiceFabric.Services.Runtime.StatefulServiceBase.CreateServiceReplicaListeners()"/>.
-        /// </summary>
-        /// <returns>Endpoint string pairs like
-        /// {"Endpoints":{"Listener1":"Endpoint1","Listener2":"Endpoint2" ...}}</returns>
-        protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
-        {
-            var types = new List<Type> { this.ActorTypeInformation.ImplementationType };
-            types.AddRange(this.ActorTypeInformation.InterfaceTypes);
-
-            var provider = ActorRemotingProviderAttribute.GetProvider(types);
-            var serviceReplicaListeners = new List<ServiceReplicaListener>();
-
-            var listeners = provider.CreateServiceRemotingListeners();
-            foreach (var kvp in listeners)
-            {
-                serviceReplicaListeners.Add(new ServiceReplicaListener(t => kvp.Value(this), kvp.Key));
-            }
-
-            return serviceReplicaListeners;
-        }
-
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
-        /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>
-        /// A task that represents the asynchronous operation of loading reminders when the replica becomes primary.
-        /// </returns>
-        /// <remarks>
-        /// If you need to override this method, please make sure to call this method from your overridden method.
-        /// Also make sure your implementation of overridden method conforms to the guideline specified for
-        /// <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
-        /// <para>
-        /// Failing to do so can cause failover, reconfiguration or upgrade of your actor service to get stuck and
-        /// can impact availibility of your service.
-        /// </para>
-        /// </remarks>
-        protected override Task RunAsync(CancellationToken cancellationToken) =>
-            ActorManager.StartLoadingRemindersAsync(cancellationToken);
-
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnChangeRoleAsync(ReplicaRole, CancellationToken)"/>.
-        /// </summary>
-        /// <param name="newRole">The new role for the replica.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous operation performed when the replica becomes primary.</returns>
-        protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
+    internal async Task StartRemindersIfNeededAsync(bool actorCallsAllowed, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (actorCallsAllowed)
         {
             ActorTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.Context.TraceId,
-                "Begin change role. New role: {0}.",
-                newRole);
-
-            if (newRole == ReplicaRole.Primary)
+                traceType,
+                Context.TraceId,
+                "ActorCallsAllowed : TRUE - Starting reminders.");
+            try
             {
-                this.actorManagerAdapter.ActorManager = new ActorManager(this, clock, diagnostics);
-                await this.actorManagerAdapter.OpenAsync(this.Partition, cancellationToken);
-                this.diagnostics.ActorChangeRole(this.replicaRole, newRole);
+                await ActorManager.StartLoadingRemindersAsync(cancellationToken);
+                return;
             }
-            else
+            catch (Exception ex)
             {
-                this.diagnostics.ActorChangeRole(this.replicaRole, newRole);
-                await this.actorManagerAdapter.CloseAsync(cancellationToken);
+                var healthInfo = new HealthInformation("ActorService", "LoadReminders", HealthState.Error)
+                {
+                    TimeToLive = TimeSpan.MaxValue,
+                    RemoveWhenExpired = false,
+                    Description = ex.Message,
+                };
+
+                Partition.ReportPartitionHealth(healthInfo, new HealthReportSendOptions { Immediate = true });
+
+                throw;
             }
-
-            this.replicaRole = newRole;
-
+        }
+        else
+        {
             ActorTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.Context.TraceId,
-                "End change role. New role: {0}.",
-                newRole);
-        }
-
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnCloseAsync(CancellationToken)"/>.
-        /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous operation performed when the replica is closed.</returns>
-        protected override async Task OnCloseAsync(CancellationToken cancellationToken)
-        {
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "Begin close.");
-
-            ActorTelemetry.ActorServiceReplicaCloseEvent(this.ActorManager.ActorService.Context);
-
-            await this.actorManagerAdapter.CloseAsync(cancellationToken);
-
-            DisposeDiagnostics();
-
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "End close.");
-        }
-
-        /// <summary>
-        /// Overrides <see cref="StatefulServiceBase.OnAbort()"/>.
-        /// </summary>
-        protected override void OnAbort()
-        {
-            ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "Abort.");
-
-            this.actorManagerAdapter.Abort();
-
-            DisposeDiagnostics();
-        }
-
-        void DisposeDiagnostics()
-        {
-            diagnostics.Dispose();
-            diagnosticsFactory.Dispose();
-        }
-
-        #endregion
-        private static IActorStateManager DefaultActorStateManagerFactory(
-            ActorBase actorBase,
-            IActorStateProvider actorStateProvider)
-        {
-            return new ActorStateManager(actorBase, actorStateProvider, actorBase.ActorService.Diagnostics, actorBase.ActorService.Clock);
-        }
-
-        private ActorBase DefaultActorFactory(ActorService actorService, ActorId actorId)
-        {
-            return (ActorBase)Activator.CreateInstance(
-                this.ActorTypeInformation.ImplementationType,
-                actorService,
-                actorId);
+                traceType,
+                Context.TraceId,
+                "ActorCallsAllowed : FALSE");
         }
     }
+
+    internal IActorStateManager CreateStateManager(ActorBase actor) => stateManagerFactory.Invoke(actor, StateProvider);
+
+    internal void InitializeInternal(ActorMethodFriendlyNameBuilder methodNameBuilder)
+    {
+        methodFriendlyNameBuilder = methodNameBuilder;
+        MethodDispatcherMapV2 = new Actors.Remoting.V2.Runtime.ActorMethodDispatcherMap(ActorTypeInformation);
+    }
+
+    #region StatefulServiceBase Overrides
+
+    /// <summary>
+    /// Overrides <see cref="Microsoft.ServiceFabric.Services.Runtime.StatefulServiceBase.CreateServiceReplicaListeners()"/>.
+    /// </summary>
+    /// <returns>Endpoint string pairs like
+    /// {"Endpoints":{"Listener1":"Endpoint1","Listener2":"Endpoint2" ...}}</returns>
+    protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
+    {
+        var types = new List<Type> { ActorTypeInformation.ImplementationType };
+        types.AddRange(ActorTypeInformation.InterfaceTypes);
+
+        var provider = ActorRemotingProviderAttribute.GetProvider(types);
+        var serviceReplicaListeners = new List<ServiceReplicaListener>();
+
+        var listeners = provider.CreateServiceRemotingListeners();
+        foreach (var kvp in listeners)
+        {
+            serviceReplicaListeners.Add(new ServiceReplicaListener(t => kvp.Value(this), kvp.Key));
+        }
+
+        return serviceReplicaListeners;
+    }
+
+    /// <summary>
+    /// Overrides <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
+    /// </summary>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation of loading reminders when the replica becomes primary.
+    /// </returns>
+    /// <remarks>
+    /// If you need to override this method, please make sure to call this method from your overridden method.
+    /// Also make sure your implementation of overridden method conforms to the guideline specified for
+    /// <see cref="StatefulServiceBase.RunAsync(CancellationToken)"/>.
+    /// <para>
+    /// Failing to do so can cause failover, reconfiguration or upgrade of your actor service to get stuck and
+    /// can impact availibility of your service.
+    /// </para>
+    /// </remarks>
+    protected override Task RunAsync(CancellationToken cancellationToken) => ActorManager.StartLoadingRemindersAsync(cancellationToken);
+
+    /// <summary>
+    /// Overrides <see cref="StatefulServiceBase.OnChangeRoleAsync(ReplicaRole, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="newRole">The new role for the replica.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation performed when the replica becomes primary.</returns>
+    protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
+    {
+        ActorTrace.Source.WriteInfoWithId(
+            traceType,
+            Context.TraceId,
+            "Begin change role. New role: {0}.",
+            newRole);
+
+        if (newRole == ReplicaRole.Primary)
+        {
+            actorManagerAdapter.ActorManager = new ActorManager(this, clock, diagnostics);
+            await actorManagerAdapter.OpenAsync(Partition, cancellationToken);
+            diagnostics.ActorChangeRole(replicaRole, newRole);
+        }
+        else
+        {
+            diagnostics.ActorChangeRole(replicaRole, newRole);
+            await actorManagerAdapter.CloseAsync(cancellationToken);
+        }
+
+        replicaRole = newRole;
+
+        ActorTrace.Source.WriteInfoWithId(traceType, Context.TraceId, "End change role. New role: {0}.", newRole);
+    }
+
+    /// <summary>
+    /// Overrides <see cref="StatefulServiceBase.OnCloseAsync(CancellationToken)"/>.
+    /// </summary>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation performed when the replica is closed.</returns>
+    protected override async Task OnCloseAsync(CancellationToken cancellationToken)
+    {
+        ActorTrace.Source.WriteInfoWithId(traceType, Context.TraceId, "Begin close.");
+
+        ActorTelemetry.ActorServiceReplicaCloseEvent(ActorManager.ActorService.Context);
+
+        await actorManagerAdapter.CloseAsync(cancellationToken);
+
+        DisposeDiagnostics();
+
+        ActorTrace.Source.WriteInfoWithId(traceType, Context.TraceId, "End close.");
+    }
+
+    /// <summary>
+    /// Overrides <see cref="StatefulServiceBase.OnAbort()"/>.
+    /// </summary>
+    protected override void OnAbort()
+    {
+        ActorTrace.Source.WriteInfoWithId(traceType, Context.TraceId, "Abort.");
+
+        actorManagerAdapter.Abort();
+
+        DisposeDiagnostics();
+    }
+
+    void DisposeDiagnostics()
+    {
+        diagnostics.Dispose();
+        diagnosticsFactory.Dispose();
+    }
+
+    #endregion
+    private static IActorStateManager DefaultActorStateManagerFactory(ActorBase actorBase, IActorStateProvider actorStateProvider) =>
+        new ActorStateManager(actorBase, actorStateProvider, actorBase.ActorService.Diagnostics, actorBase.ActorService.Clock);
+
+    private ActorBase DefaultActorFactory(ActorService actorService, ActorId actorId) => (ActorBase)Activator.CreateInstance(ActorTypeInformation.ImplementationType, actorService, actorId);
 }

--- a/src/Actors/Runtime/ActorService.cs
+++ b/src/Actors/Runtime/ActorService.cs
@@ -348,8 +348,8 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             ActorTelemetry.ActorServiceReplicaCloseEvent(this.ActorManager.ActorService.Context);
 
             await this.actorManagerAdapter.CloseAsync(cancellationToken);
-            this.diagnostics.Dispose();
-            this.diagnosticsFactory.Dispose();
+
+            DisposeDiagnostics();
 
             ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "End close.");
         }
@@ -362,6 +362,14 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             ActorTrace.Source.WriteInfoWithId(TraceType, this.Context.TraceId, "Abort.");
 
             this.actorManagerAdapter.Abort();
+
+            DisposeDiagnostics();
+        }
+
+        void DisposeDiagnostics()
+        {
+            diagnostics.Dispose();
+            diagnosticsFactory.Dispose();
         }
 
         #endregion

--- a/src/Actors/Runtime/IActorStateProviderInternal.cs
+++ b/src/Actors/Runtime/IActorStateProviderInternal.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     internal interface IActorStateProviderInternal
     {
         /// <summary>
-        /// Gets TraceType used for tracing.
+        /// Gets traceType used for tracing.
         /// </summary>
         string TraceType { get; }
 

--- a/test/Actors/Runtime/ActorServiceTest.cs
+++ b/test/Actors/Runtime/ActorServiceTest.cs
@@ -14,85 +14,92 @@ using Microsoft.ServiceFabric.Diagnostics;
 using Moq;
 using Xunit;
 
-namespace Microsoft.ServiceFabric.Actors.Runtime
+namespace Microsoft.ServiceFabric.Actors.Runtime;
+
+public class ActorServiceTest : IDisposable
 {
-    public class ActorServiceTest : IDisposable
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    readonly ActorService sut;
+
+    readonly StatefulServiceContext serviceContext = fuzzy.StatefulServiceContext();
+    readonly ActorTypeInformation typeInformation = ActorTypeInformation.Get(typeof(TestActor));
+    readonly Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticsFactory;
+    readonly Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>> mockCreateDiagnosticsFactory = new Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>();
+    readonly DiagnosticsFactory diagnosticsFactory;
+    readonly IDiagnostics diagnostics;
+
+    public ActorServiceTest()
     {
-        static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+        diagnosticsFactory = new Mock<DiagnosticsFactory>(serviceContext, typeInformation, new ActorMethodFriendlyNameBuilder(typeInformation)) { DefaultValue = DefaultValue.Mock }.Object;
 
-        readonly ActorService sut;
+        createDiagnosticsFactory = typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Value;
+        typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(mockCreateDiagnosticsFactory.Object);
+        mockCreateDiagnosticsFactory.Setup(_ => _.Invoke(It.IsAny<ServiceContext>(), It.IsAny<ActorTypeInformation>(), It.IsAny<ActorMethodFriendlyNameBuilder>())).Returns(diagnosticsFactory);
 
-        readonly StatefulServiceContext serviceContext = fuzzy.StatefulServiceContext();
-        readonly ActorTypeInformation typeInformation = ActorTypeInformation.Get(typeof(TestActor));
-        readonly Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory> createDiagnosticsFactory;
-        readonly Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>> mockCreateDiagnosticsFactory = new Mock<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>();
-        readonly DiagnosticsFactory diagnosticsFactory;
-        readonly IDiagnostics diagnostics;
+        sut = new ActorService(serviceContext, typeInformation);
+        sut.InitializeInternal(new ActorMethodFriendlyNameBuilder(sut.ActorTypeInformation));
+        diagnostics = sut.Field<IDiagnostics>().Value;
+    }
 
-        public ActorServiceTest()
+    public void Dispose() =>
+    typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(createDiagnosticsFactory);
+
+    public class Diagnostics : ActorServiceTest
+    {
+        [Fact]
+        public void IsCreatedByConstructor()
         {
-            diagnosticsFactory = new Mock<DiagnosticsFactory>(serviceContext, typeInformation, new ActorMethodFriendlyNameBuilder(typeInformation)) { DefaultValue = DefaultValue.Mock }.Object;
-
-            createDiagnosticsFactory = typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Value;
-            typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(mockCreateDiagnosticsFactory.Object);
-            mockCreateDiagnosticsFactory.Setup(_ => _.Invoke(It.IsAny<ServiceContext>(), It.IsAny<ActorTypeInformation>(), It.IsAny<ActorMethodFriendlyNameBuilder>())).Returns(diagnosticsFactory);
-
-            sut = new ActorService(serviceContext, typeInformation);
-            sut.InitializeInternal(new ActorMethodFriendlyNameBuilder(sut.ActorTypeInformation));
-            diagnostics = sut.Field<IDiagnostics>().Value;
+            mockCreateDiagnosticsFactory.Verify(d => d.Invoke(It.Is<ServiceContext>(c => c == serviceContext), It.Is<ActorTypeInformation>(i => i == typeInformation), It.IsAny<ActorMethodFriendlyNameBuilder>()), Times.Once);
+            Mock.Get(diagnosticsFactory).Verify(d => d.CreateDiagnostics(It.IsAny<IClock>()), Times.Once);
         }
 
-        public void Dispose()
+        [Fact]
+        public void IsDisposedByOnCloseAsync()
         {
-            typeof(ActorService).Field<Func<ServiceContext, ActorTypeInformation, ActorMethodFriendlyNameBuilder, DiagnosticsFactory>>().Set(this.createDiagnosticsFactory);
+            sut.DeclaredBy(typeof(ActorService)).Method<Func<CancellationToken, Task>>("OnCloseAsync").Invoke(TestContext.Current.CancellationToken);
+
+            Mock.Get(diagnostics).Verify(d => d.Dispose(), Times.Once);
+            Mock.Get(diagnosticsFactory).Verify(d => d.Dispose(), Times.Once);
         }
 
-        public class Diagnostics : ActorServiceTest
+        [Fact]
+        public void IsDisposedByAbort()
         {
-            [Fact]
-            public void IsCreatedByConstructor()
-            {
-                mockCreateDiagnosticsFactory.Verify(d => d.Invoke(It.Is<ServiceContext>(c => c == serviceContext), It.Is<ActorTypeInformation>(i => i == typeInformation), It.IsAny<ActorMethodFriendlyNameBuilder>()), Times.Once);
-                Mock.Get(diagnosticsFactory).Verify(d => d.CreateDiagnostics(It.IsAny<IClock>()), Times.Once);
-            }
+            sut.DeclaredBy(typeof(ActorService)).Method<Action>("OnAbort").Invoke();
 
-            [Fact]
-            public void IsDisposedByOnCloseAsync()
-            {
-                sut.DeclaredBy(typeof(ActorService)).Method<Func<CancellationToken, Task>>("OnCloseAsync").Invoke(TestContext.Current.CancellationToken);
-
-                Mock.Get(diagnostics).Verify(d => d.Dispose(), Times.Once);
-                Mock.Get(diagnosticsFactory).Verify(d => d.Dispose(), Times.Once);
-            }
+            Mock.Get(diagnostics).Verify(d => d.Dispose(), Times.Once);
+            Mock.Get(diagnosticsFactory).Verify(d => d.Dispose(), Times.Once);
         }
 
-        public class OnRoleChange : ActorServiceTest
+    }
+
+    public class OnRoleChange : ActorServiceTest
+    {
+        readonly Func<ReplicaRole, CancellationToken, Task> sutMethod;
+
+        public OnRoleChange()
         {
-            readonly Func<ReplicaRole, CancellationToken, Task> sutMethod;
+            sutMethod = sut.DeclaredBy(typeof(ActorService)).Method<Func<ReplicaRole, CancellationToken, Task>>("OnChangeRoleAsync");
 
-            public OnRoleChange()
-            {
-                sutMethod = sut.DeclaredBy(typeof(ActorService)).Method<Func<ReplicaRole, CancellationToken, Task>>("OnChangeRoleAsync");
+            var actorManager = new ActorManager(sut, Mock.Of<IClock>(), diagnostics);
+            sut.Field<ActorManagerAdapter>().Value.ActorManager = actorManager;
+        }
 
-                var actorManager = new ActorManager(sut, Mock.Of<IClock>(), diagnostics);
-                sut.Field<ActorManagerAdapter>().Value.ActorManager = actorManager;
-            }
+        [Fact]
+        public void RoleChangePrimaryEmitsDiagnostics()
+        {
+            sutMethod.Invoke(ReplicaRole.Primary, TestContext.Current.CancellationToken);
 
-            [Fact]
-            public void RoleChangePrimaryEmitsDiagnostics()
-            {
-                sutMethod.Invoke(ReplicaRole.Primary, TestContext.Current.CancellationToken);
+            Mock.Get(diagnostics).Verify(d => d.ActorChangeRole(It.IsAny<ReplicaRole>(), ReplicaRole.Primary), Times.Once);
+        }
 
-                Mock.Get(diagnostics).Verify(d => d.ActorChangeRole(It.IsAny<ReplicaRole>(), ReplicaRole.Primary), Times.Once);
-            }
+        [Fact]
+        public void RoleChangeNonPrimaryEmitsDiagnostics()
+        {
+            sutMethod.Invoke(ReplicaRole.IdleSecondary, TestContext.Current.CancellationToken);
 
-            [Fact]
-            public void RoleChangeNonPrimaryEmitsDiagnostics()
-            {
-                sutMethod.Invoke(ReplicaRole.IdleSecondary, TestContext.Current.CancellationToken);
-
-                Mock.Get(diagnostics).Verify(d => d.ActorChangeRole(It.IsAny<ReplicaRole>(), ReplicaRole.IdleSecondary), Times.Once);
-            }
+            Mock.Get(diagnostics).Verify(d => d.ActorChangeRole(It.IsAny<ReplicaRole>(), ReplicaRole.IdleSecondary), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Diagnostic related objects are already being disposes in ActorService `OnCloseAsync`. 
Introduce the same dispose in `OnAbort` code path, as it was missed during the initial handling of deterministic release.

Opportunistically fix some of the .editorconfig warnings.