### PR TITLE
Switch from hard-coded versions to Nerdbank.GitVersioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,15 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - run: .\SkipStrongName.ps1
       - run: .\UninstallSfSdkFromGac.ps1
       - run: dotnet build -bl:"$env:Logs/build.binLog"
       - run: dotnet test --no-build --logger trx -bl:"$env:Logs/test.binLog"
       - run: dotnet pack --no-build -bl:"$env:Logs/pack.binLog"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-windows
@@ -38,13 +40,15 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - run: dotnet build -bl:"$Logs/build.binLog"
       - run: dotnet test --no-build --logger trx --framework net8.0 -bl:"$Logs/test-net8.binLog"
       - run: dotnet test --no-build --logger trx --framework net9.0 -bl:"$Logs/test-net9.binLog"
       - run: dotnet test --no-build --logger trx --framework net10.0 -bl:"$Logs/test-net10.binLog"
       - run: dotnet pack --no-build -bl:"$Logs/pack.binLog"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-linux

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "accessibilities",
         "DSTS",
+        "Nerdbank",
         "netframework",
         "netstandard",
         "resx"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
         <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.892-beta" />
         <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" /> <!-- Transitive dependency -->
         <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
         <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" /> <!-- Transitive dependency -->

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -3,13 +3,5 @@
   <PropertyGroup>
     <RepoRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .gitignore))\</RepoRoot>
     <RequestedVerbosity Condition=" '$(RequestedVerbosity)' == '' ">minimal</RequestedVerbosity>
-
-    <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
-    <!-- We migrated Diagnostics package from WindowsFabric repo and we need to keep the versioning consistent -->
-    <MajorVersion>12</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <BuildVersion>0</BuildVersion>
-    <Revision>28</Revision>
-
   </PropertyGroup>
 </Project>

--- a/properties/service_fabric_managed_common.props
+++ b/properties/service_fabric_managed_common.props
@@ -41,15 +41,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <!-- Set Version numbers. These are used for generating Assemblies. -->
-  <PropertyGroup>
-    <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
-    <PackageVersionSuffix>-beta</PackageVersionSuffix>
-    <Version>$(MajorVersion).$(MinorVersion).$(BuildVersion)$(PackageVersionSuffix).$(Revision)</Version>
-    <AssemblyFileVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)</AssemblyFileVersion>
-    <FileVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)</FileVersion>
-  </PropertyGroup>
-
   <PropertyGroup>
     <Product>Microsoft Azure Service Fabric</Product>
     <Copyright>Copyright (c) Microsoft Corporation.  All rights reserved.</Copyright>

--- a/src/Actors.Wcf/Microsoft.ServiceFabric.Actors.Wcf.csproj
+++ b/src/Actors.Wcf/Microsoft.ServiceFabric.Actors.Wcf.csproj
@@ -8,6 +8,9 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Actors\Microsoft.ServiceFabric.Actors.csproj" />
     <ProjectReference Include="..\Services.Wcf\Microsoft.ServiceFabric.Services.Wcf.csproj" />
   </ItemGroup>

--- a/src/Actors/Microsoft.ServiceFabric.Actors.csproj
+++ b/src/Actors/Microsoft.ServiceFabric.Actors.csproj
@@ -8,6 +8,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
+++ b/src/AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
@@ -3,11 +3,10 @@
     <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
-  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.Extensions.Configuration"/>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Microsoft.ServiceFabric.Services.csproj" />

--- a/src/AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
+++ b/src/AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
@@ -5,13 +5,10 @@
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Microsoft.ServiceFabric" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys"/>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore\Microsoft.ServiceFabric.AspNetCore.csproj" />

--- a/src/AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
+++ b/src/AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
@@ -5,13 +5,10 @@
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Condition="'$(TargetFramework)' == 'net462'"/>
     <PackageReference Include="Microsoft.ServiceFabric" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel"/>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore\Microsoft.ServiceFabric.AspNetCore.csproj" />

--- a/src/AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -5,11 +5,10 @@
     <PackageId>$(AssemblyName).Abstractions</PackageId>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
-  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting"/>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Condition="'$(TargetFramework)' == 'net462'"/>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/Client.Http/Microsoft.ServiceFabric.Client.Http.csproj
+++ b/src/Client.Http/Microsoft.ServiceFabric.Client.Http.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.csproj
+++ b/src/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.csproj
@@ -5,6 +5,9 @@
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Data.Interfaces\Microsoft.ServiceFabric.Data.Interfaces.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.csproj
+++ b/src/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.csproj
@@ -6,6 +6,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/Data/Microsoft.ServiceFabric.Data.csproj
+++ b/src/Data/Microsoft.ServiceFabric.Data.csproj
@@ -5,6 +5,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
+++ b/src/Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
@@ -7,6 +7,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/FabActUtil/FabActUtil.csproj
+++ b/src/FabActUtil/FabActUtil.csproj
@@ -13,6 +13,9 @@
     <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Actors\Microsoft.ServiceFabric.Actors.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FabricTransport/Microsoft.ServiceFabric.FabricTransport.csproj
+++ b/src/FabricTransport/Microsoft.ServiceFabric.FabricTransport.csproj
@@ -7,6 +7,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/src/Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
+++ b/src/Powershell.Http/Microsoft.ServiceFabric.Powershell.Http.csproj
@@ -25,10 +25,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client"/>
     <PackageReference Include="Microsoft.Win32.Registry" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="PowerShellStandard.Library" />
     <PackageReference Include="YamlDotNet" />
-  </ItemGroup>  
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="..\..\refs\SfSbzYamlMergeLib.dll" />
     <Reference Include="..\..\refs\Microsoft.ServiceFabric.YamlUtils.dll" />

--- a/src/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
+++ b/src/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" />
     <PackageReference Include="System.Reflection.Emit" />

--- a/src/Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.csproj
+++ b/src/Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.csproj
@@ -8,6 +8,9 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />
     <ProjectReference Include="..\Services.Remoting\Microsoft.ServiceFabric.Services.Remoting.csproj" />
     <ProjectReference Include="..\Services\Microsoft.ServiceFabric.Services.csproj" />

--- a/src/Services/Microsoft.ServiceFabric.Services.csproj
+++ b/src/Services/Microsoft.ServiceFabric.Services.csproj
@@ -5,6 +5,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Constants\Microsoft.ServiceFabric.Constants.csproj" PrivateAssets="All" />

--- a/version.json
+++ b/version.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "12.0.0-beta.{height}",
+  "versionHeightOffset": 28,
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/develop$"
+  ]
+}


### PR DESCRIPTION
The `Nerdbank.GitVersioning` package is maintained by the .NET Foundation. When referenced by a C# project, it dynamically generates version numbers based on the settings in the `version.json` file and the number of commits in the Git history since it was updated, a.k.a. "height".

Instead of hard-coding versions in the `service_fabric*.props` files we now specify only the base version number in the `version.json`. The number will be automatically incremented for each new commit. The last hard-coded version was `12.0.0-beta.28` and the first Git-based version produced from develop should be `12.0.0-beta.29`.

For branches other than `develop`, Nerdbank will automatically append the Git commit to differentiate versions with the same height but different branches. For example, the PR validation build produced version `12.0.0-beta.30.g6cd49399a9.` because it checked out the pull request merge commit `6cd49399a930344cc22bcfab02155a61164a3d0c`. Also note that because of the extra merge commit, the build version is 30 instead of 29 that we should have once the changes are merged into develop as a single squash commit.

The `build.yml` was modified to checkout the Git repository with full commit history instead of the shallow 1-commit history checked out by default. Although fetching the full commit history is an overkill, our repository is small enough that it didn't produce a noticeable increase in the duration of the checkout step.

The `build.yml` actions `checkout` and `upload-artifact` were also upgraded to their latest versions to avoid deprecation warnings about older Node.js versions they used.