### PR TITLE
Switch GitHub-hosted Copilot Coding Agent to Windows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ This repository contains the Service Fabric .NET libraries.
 ## Quick Reference
 
 - **Restore**: `dotnet restore`
-  - Restore packages the beginning to reduce subsequent build times
+  - Restore packages at the beginning to reduce subsequent build times
 - **Build**: `dotnet build -c Release --no-restore`
   - Build specific projects to reduce build time
 - **Test**: `dotnet test -c Release --no-build`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This repository contains the Service Fabric .NET libraries.
   - Restore packages at the beginning to reduce subsequent build times
 - **Build**: `dotnet build -c Release --no-restore`
   - Build specific projects to reduce build time
-- **Test**: `dotnet test -c Release --no-build`
+- **Test**: `dotnet test -c Release --no-restore --no-build`
   - Run tests for specific projects to reduce test execution time
   - We have known test failures in `Debug` configuration
   - Run tests with `-f net472` and/or `-f net10.0` to speed up change verification

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,8 +4,15 @@ This repository contains the Service Fabric .NET libraries.
 
 ## Quick Reference
 
-- **Build**: `dotnet build`
-- **Test**: `dotnet test -c Release -f net10.0`
+- **Restore**: `dotnet restore`
+  - Restore packages the beginning to reduce subsequent build times
+- **Build**: `dotnet build -c Release --no-restore`
+  - Build specific projects to reduce build time
+- **Test**: `dotnet test -c Release --no-build`
+  - Run tests for specific projects to reduce test execution time
+  - We have known test failures in `Debug` configuration
+  - Run tests with `-f net472` and/or `-f net10.0` to speed up change verification
+  - Run all tests on all frameworks before considering the change completed
 - **Pack**: `dotnet pack` (output: `out/packages/`)
 - **Prerequisites**: Run `init.cmd` (Windows) or `init.sh` (Linux) first
 - See [CONTRIBUTING.md](../CONTRIBUTING.md) for full setup instructions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This repository contains the Service Fabric .NET libraries.
   - Restore packages at the beginning to reduce subsequent build times
 - **Build**: `dotnet build -c Release --no-restore`
   - Build specific projects to reduce build time
-- **Test**: `dotnet test -c Release --no-restore --no-build`
+- **Test**: `dotnet test -c Release --no-restore`
   - Run tests for specific projects to reduce test execution time
   - We have known test failures in `Debug` configuration
   - Run tests with `-f net472` and/or `-f net10.0` to speed up change verification

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,15 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - run: .\SkipStrongName.ps1
+      - run: .\UninstallSfSdkFromGac.ps1
+      - run: dotnet restore

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,6 +3,9 @@ name: Copilot Setup Steps
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: windows-latest


### PR DESCRIPTION
CCA runs on Linux by default and since we have more tests on Windows, `net472` tests in particular, having CCA run on Windows instead should, in theory, allow the agent to iterate faster by catching Windows-specific errors immediately instead of waiting for the CI build to complete. At least that's what Claude Sonnet 4.6 concluded.