### PR TITLE
Change CreateMeter API to use FABRIC_METER_DESCRIPTION struct

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,3 +101,23 @@ projects. We omit the `Microsoft.ServiceFabric` prefix and the `Tests` suffix fr
 - **C# version**: `latestMajor` (set in `Directory.Build.props`)
 - **Assembly signing**: Delay-signed with `properties/Key.snk`
 - **Conditional compilation**: `#if NET` for .NET Core code, `#if NETFRAMEWORK` for .NET Framework code
+
+## COM Interop Conventions
+
+- Product code must work identically on `net462` (legacy COM interop) and `net8.0+` (ComWrappers/`[GeneratedComInterface]`).
+  Prefer a single implementation over `#if`-separated code paths.
+- For COM method parameters that contain strings or string arrays, prefer passing a blittable struct via `IntPtr` rather
+  than using `[MarshalAs]` attributes. Marshalling attributes behave differently between legacy COM and ComWrappers,
+  but a blittable `IntPtr` passes through both runtimes without any marshalling.
+- Define native structs with `[StructLayout(LayoutKind.Sequential, Pack = 8)]` using only `IntPtr` and `uint` fields.
+  Include an `IntPtr Reserved` field for future extensibility (allowing `_EX1`, `_EX2` extensions).
+- Use `GCHandle.Alloc(value, GCHandleType.Pinned)` + `stackalloc` to pin strings and build pointer arrays on the caller
+  side. See `Meter.RecordViaNative` and `MeterProvider.CreateNativeMeter` for the canonical pattern.
+- Do not use `PinCollection` for new code unless the interop call requires it for other reasons.
+
+## Instruction File Conventions
+
+- Keep instruction files in `.github/instructions/` focused on a single topic.
+- When an instruction file grows beyond ~250 lines, split it by topic into separate files.
+- Name files after the topic they cover, e.g., `moq.instructions.md`, `fuzzy.instructions.md`.
+- Each file should have YAML frontmatter with an `applyTo` pattern scoping it to relevant files.

--- a/.github/instructions/moq.instructions.md
+++ b/.github/instructions/moq.instructions.md
@@ -1,0 +1,76 @@
+---
+description: "Use when writing or reviewing tests."
+applyTo: "test/**"
+---
+
+# Moq Conventions
+
+Use [Moq](https://github.com/devlooped/moq) to stub or observe behavior of dependencies external to the component being
+tested.
+
+## Use simple mocks by default
+
+Prefer storing mock objects in variables of their own type, rather than `Mock<T>`, to make the code more terse and readable.
+```csharp
+readonly ICommunicationListener listener = Mock.Of<ICommunicationListener>();
+Mock.Get(listener).Verify(l => l.OpenAsync(It.IsAny<CancellationToken>()), Times.Once);
+```
+
+## Enable default implementations explicitly
+
+Moq doesn't implement abstract/interface methods by default and has to be explicitly instructed to.
+```csharp
+readonly IServiceInstance instance = new Mock<IServiceInstance> { DefaultValue = DefaultValue.Mock }.Object;
+```
+
+## Make test failures readable
+
+When using `.Verify(...)`, always run the failing test first and make sure the failure message is understandable to a human reader.
+When failure messages become difficult to understand in non-trivial assertions, replace `.Verify(...)` assertions with
+`.Setup(...)` and `.Callback(...)` in the arrange section of the test to capture the actual values and use plain xUnit
+`Assert.*` calls instead of `.Verify(...)`.
+
+### Example: Verifying native struct parameters passed as IntPtr
+
+When a mock method takes an `IntPtr` pointing to a native struct (e.g., `FABRIC_METER_DESCRIPTION`), use Moq's `Callback`
+to capture the struct contents **during** the call, while the `GCHandle` pins are still alive. Then assert on the captured
+values afterward. Do not use `Verify` with `It.Is<IntPtr>(...)` — the pointer is dangling after the call returns.
+
+```csharp
+// Arrange
+string actualNamespace;
+string actualName;
+string[] actualDimensionNames;
+
+Mock.Get(provider)
+    .Setup(x => x.CreateMeter(It.IsAny<IntPtr>()))
+    .Callback((IntPtr ptr) =>
+    {
+        var desc = Marshal.PtrToStructure<FABRIC_METER_DESCRIPTION>(ptr);
+        actualNamespace = Marshal.PtrToStringUni(desc.Namespace);
+        actualName = Marshal.PtrToStringUni(desc.Name);
+        actualDimensionNames = PtrToStringArray(desc.DimensionNames, (int)desc.TotalDimensionsCount);
+    })
+    .Returns(fabricMeter);
+
+static string[] PtrToStringArray(IntPtr array, int count)
+{
+    var result = new string[count];
+    for (int i = 0; i < count; i++)
+        result[i] = Marshal.PtrToStringUni(Marshal.ReadIntPtr(array, i * IntPtr.Size));
+    return result;
+}
+
+// Act
+sut.CreateMeter(...);
+
+// Assert
+Assert.Equal(testNamespace, actualNamespace);
+Assert.Equal(testMetric, actualName);
+Assert.Equal(systemDimensionsNames, actualDimensionNames);
+```
+
+Naming conventions for captured values:
+- Use the `actual` prefix (consistent with xUnit `Assert.Equal(expected, actual)` parameter naming)
+- Name fields to match the struct property names, e.g., `actualNamespace`, `actualName`, `actualDimensionNames`
+- Asserting array equality implicitly verifies count, so don't capture or assert counts separately

--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -248,23 +248,6 @@ when inputs of the same type are needed by different test classes. You can also 
 needed once if it helps to reduce complexity of the test setup. Use extensions in the `TestFramework` project for types
 needed by multiple test projects.
 
-## Use Moq for mocking
-
-Use [Moq](https://github.com/devlooped/moq) to stub or observe behavior of dependencies external to the component being
-tested.
-
-```csharp
-// Simple mock (most cases)
-readonly ICommunicationListener listener = Mock.Of<ICommunicationListener>();
-
-// Mock needing configuration
-readonly IServiceInstance instance = new Mock<IServiceInstance> { DefaultValue = DefaultValue.Mock }.Object;
-
-// Setup and verify via Mock.Get
-Mock.Get(listener).Setup(l => l.OpenAsync(It.IsAny<CancellationToken>())).ReturnsAsync("endpoint");
-Mock.Get(listener).Verify(l => l.OpenAsync(It.IsAny<CancellationToken>()), Times.Once);
-```
-
 ## Use xUnit Assertions
 
 Use the most specific xUnit `Assert.*` methods:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "accessibilities",
         "cref",
         "DSTS",
+        "frontmatter",
         "inheritdoc",
         "langword",
         "nameof",

--- a/src/Diagnostics/InteropExtensions.cs
+++ b/src/Diagnostics/InteropExtensions.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.ServiceFabric.Diagnostics;
+
+static unsafe class Interop
+{
+    internal static void Free(GCHandle* handles, int count)
+    {
+        for (int i = 0; i < count; i++)
+            if (handles[i].IsAllocated)
+                handles[i].Free();
+    }
+}

--- a/src/Diagnostics/Metrics/Implementation/FABRIC_METER_DESCRIPTION.cs
+++ b/src/Diagnostics/Metrics/Implementation/FABRIC_METER_DESCRIPTION.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+struct FABRIC_METER_DESCRIPTION
+{
+    public IntPtr Namespace;
+    public IntPtr Name;
+    public uint TotalDimensionsCount;
+    public IntPtr DimensionNames;
+    public uint FixedDimensionCount;
+    public IntPtr FixedDimensionValues;
+    public IntPtr Reserved;
+}

--- a/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
@@ -11,14 +11,13 @@ using System.Runtime.InteropServices.Marshalling;
 using GeneratedComInterfaceAttribute = System.Runtime.InteropServices.ComImportAttribute;
 #endif
 
-namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
+namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
+
+[GeneratedComInterface]
+[Guid("15AD37D2-F641-4188-824B-0D68CB4F6C17")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+partial interface IFabricMeterProvider
 {
-    [GeneratedComInterface]
-    [Guid("15AD37D2-F641-4188-824B-0D68CB4F6C17")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    partial interface IFabricMeterProvider
-    {
-        [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
-        IFabricMeter CreateMeter([MarshalAs(UnmanagedType.LPWStr)] string metricNamespace, [MarshalAs(UnmanagedType.LPWStr)] string name, uint totalDimensionsCount, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] dimensionNames, uint fixedDimensionCount, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] fixedDimensionValues);
-    }
+    [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
+    IFabricMeter CreateMeter(IntPtr meterDescription);
 }

--- a/src/Diagnostics/Metrics/Implementation/Meter.cs
+++ b/src/Diagnostics/Metrics/Implementation/Meter.cs
@@ -69,11 +69,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             }
             finally
             {
-                for (int i = 0; i < variableDimensionCount; i++)
-                {
-                    if (dimensionPins[i].IsAllocated)
-                        dimensionPins[i].Free();
-                }
+                Interop.Free(dimensionPins, variableDimensionCount);
             }
         }
     }

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Fabric;
 using System.Fabric.Interop;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
@@ -52,15 +53,56 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         bool IsDisposed() => fabricMeterProvider == null;
 
-        protected IFabricMeter CreateNativeMeter(string metricNamespace, string metricName, IEnumerable<string> variableDimensionNames)
+        protected unsafe IFabricMeter CreateNativeMeter(string metricNamespace, string metricName, IEnumerable<string> variableDimensionNames)
         {
             if (IsDisposed())
                 throw new ObjectDisposedException(nameof(MeterProvider<>));
 
             string[] allDimensionNames = [.. fixedDimensionNames, .. variableDimensionNames];
-            string[] fixedDimensionsValues = [.. fixedDimensionValues];
+            string[] fixedDimValues = [.. fixedDimensionValues];
+            int totalPins = 2 + allDimensionNames.Length + fixedDimValues.Length;
 
-            return fabricMeterProvider.CreateMeter(metricNamespace, metricName, (uint)allDimensionNames.Length, allDimensionNames, (uint)fixedDimensionsValues.Length, fixedDimensionsValues);
+            GCHandle* pins = stackalloc GCHandle[totalPins];
+            IntPtr* dimensionNamePtrs = stackalloc IntPtr[allDimensionNames.Length];
+            IntPtr* fixedValuePtrs = stackalloc IntPtr[fixedDimValues.Length];
+
+            try
+            {
+                int p = 0;
+                pins[p++] = GCHandle.Alloc(metricNamespace, GCHandleType.Pinned);
+                pins[p++] = GCHandle.Alloc(metricName, GCHandleType.Pinned);
+
+                for (int i = 0; i < allDimensionNames.Length; i++)
+                    pins[p++] = GCHandle.Alloc(allDimensionNames[i], GCHandleType.Pinned);
+
+                for (int i = 0; i < fixedDimValues.Length; i++)
+                    pins[p++] = GCHandle.Alloc(fixedDimValues[i], GCHandleType.Pinned);
+
+                for (int i = 0; i < allDimensionNames.Length; i++)
+                    dimensionNamePtrs[i] = pins[2 + i].AddrOfPinnedObject();
+
+                for (int i = 0; i < fixedDimValues.Length; i++)
+                    fixedValuePtrs[i] = pins[2 + allDimensionNames.Length + i].AddrOfPinnedObject();
+
+                var description = new FABRIC_METER_DESCRIPTION
+                {
+                    Namespace = pins[0].AddrOfPinnedObject(),
+                    Name = pins[1].AddrOfPinnedObject(),
+                    TotalDimensionsCount = (uint)allDimensionNames.Length,
+                    DimensionNames = (IntPtr)dimensionNamePtrs,
+                    FixedDimensionCount = (uint)fixedDimValues.Length,
+                    FixedDimensionValues = (IntPtr)fixedValuePtrs,
+                    Reserved = IntPtr.Zero
+                };
+
+                return fabricMeterProvider.CreateMeter((IntPtr)(&description));
+            }
+            finally
+            {
+                for (int i = 0; i < totalPins; i++)
+                    if (pins[i].IsAllocated)
+                        pins[i].Free();
+            }
         }
 
         public void Dispose()

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -99,9 +99,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
             }
             finally
             {
-                for (int i = 0; i < totalPins; i++)
-                    if (pins[i].IsAllocated)
-                        pins[i].Free();
+                Interop.Free(pins, totalPins);
             }
         }
 

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -84,16 +84,14 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
                 for (int i = 0; i < fixedDimValues.Length; i++)
                     fixedValuePtrs[i] = pins[2 + allDimensionNames.Length + i].AddrOfPinnedObject();
 
-                var description = new FABRIC_METER_DESCRIPTION
-                {
-                    Namespace = pins[0].AddrOfPinnedObject(),
-                    Name = pins[1].AddrOfPinnedObject(),
-                    TotalDimensionsCount = (uint)allDimensionNames.Length,
-                    DimensionNames = (IntPtr)dimensionNamePtrs,
-                    FixedDimensionCount = (uint)fixedDimValues.Length,
-                    FixedDimensionValues = (IntPtr)fixedValuePtrs,
-                    Reserved = IntPtr.Zero
-                };
+                FABRIC_METER_DESCRIPTION description;
+                description.Namespace = pins[0].AddrOfPinnedObject();
+                description.Name = pins[1].AddrOfPinnedObject();
+                description.TotalDimensionsCount = (uint)allDimensionNames.Length;
+                description.DimensionNames = (IntPtr)dimensionNamePtrs;
+                description.FixedDimensionCount = (uint)fixedDimValues.Length;
+                description.FixedDimensionValues = (IntPtr)fixedValuePtrs;
+                description.Reserved = IntPtr.Zero;
 
                 return fabricMeterProvider.CreateMeter((IntPtr)(&description));
             }

--- a/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
-using System.Linq;
+using System.Runtime.InteropServices;
 using Fuzzy;
 using Inspector;
 using Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
@@ -36,6 +36,12 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
             readonly IFabricMeterProvider fabricMeterProvider = new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object;
             readonly IFabricMeter fabricMeter = Mock.Of<IFabricMeter>();
 
+            // Values captured from FABRIC_METER_DESCRIPTION during CreateMeter call
+            string actualNamespace;
+            string actualName;
+            string[] actualDimensionNames;
+            string[] actualFixedDimensionValues;
+
             public CreateMeter()
             {
                 sut = new Int64MeterProvider(serviceContext);
@@ -43,54 +49,72 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 systemDimensionsValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
                 sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
 
-                Mock.Get(fabricMeterProvider).Setup(x => x.CreateMeter(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<string[]>(), It.IsAny<uint>(), It.IsAny<string[]>())).Returns(fabricMeter);
+                Mock.Get(fabricMeterProvider)
+                    .Setup(x => x.CreateMeter(It.IsAny<IntPtr>()))
+                    .Callback((IntPtr ptr) =>
+                    {
+                        var desc = Marshal.PtrToStructure<FABRIC_METER_DESCRIPTION>(ptr);
+                        actualNamespace = Marshal.PtrToStringUni(desc.Namespace);
+                        actualName = Marshal.PtrToStringUni(desc.Name);
+                        actualDimensionNames = PtrToStringArray(desc.DimensionNames, (int)desc.TotalDimensionsCount);
+                        actualFixedDimensionValues = PtrToStringArray(desc.FixedDimensionValues, (int)desc.FixedDimensionCount);
+                    })
+                    .Returns(fabricMeter);
+            }
+
+            static string[] PtrToStringArray(IntPtr array, int count)
+            {
+                var result = new string[count];
+                for (int i = 0; i < count; i++)
+                    result[i] = Marshal.PtrToStringUni(Marshal.ReadIntPtr(array, i * IntPtr.Size));
+                return result;
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter()
             {
-                var combinedDimensionNames = systemDimensionsNames.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter<long> meter = sut.CreateMeter(testNamespace, testMetric);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal(systemDimensionsNames, actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((Int64Meter)meter).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter1D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter1D<long> meter1D = sut.CreateMeter(testNamespace, testMetric, testDimension1);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((Int64Meter1D)meter1D).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter2D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1, testDimension2 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter2D<long> meter2D = sut.CreateMeter(testNamespace, testMetric, testDimension1, testDimension2);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1, testDimension2], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((Int64Meter2D)meter2D).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter3D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1, testDimension2, testDimension3 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter3D<long> meter3D = sut.CreateMeter(testNamespace, testMetric, testDimension1, testDimension2, testDimension3);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1, testDimension2, testDimension3], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((Int64Meter3D)meter3D).Field<IFabricMeter>().Value);
             }
         }

--- a/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
-using System.Linq;
+using System.Runtime.InteropServices;
 using Fuzzy;
 using Inspector;
 using Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
@@ -36,6 +36,12 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
             readonly IFabricMeterProvider fabricMeterProvider = new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object;
             readonly IFabricMeter fabricMeter = Mock.Of<IFabricMeter>();
 
+            // Values captured from FABRIC_METER_DESCRIPTION during CreateMeter call
+            string actualNamespace;
+            string actualName;
+            string[] actualDimensionNames;
+            string[] actualFixedDimensionValues;
+
             public CreateMeter()
             {
                 sut = new TimeSpanMeterProvider(serviceContext);
@@ -43,54 +49,72 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 systemDimensionsValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
                 sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
 
-                Mock.Get(fabricMeterProvider).Setup(x => x.CreateMeter(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<string[]>(), It.IsAny<uint>(), It.IsAny<string[]>())).Returns(fabricMeter);
+                Mock.Get(fabricMeterProvider)
+                    .Setup(x => x.CreateMeter(It.IsAny<IntPtr>()))
+                    .Callback((IntPtr ptr) =>
+                    {
+                        var desc = Marshal.PtrToStructure<FABRIC_METER_DESCRIPTION>(ptr);
+                        actualNamespace = Marshal.PtrToStringUni(desc.Namespace);
+                        actualName = Marshal.PtrToStringUni(desc.Name);
+                        actualDimensionNames = PtrToStringArray(desc.DimensionNames, (int)desc.TotalDimensionsCount);
+                        actualFixedDimensionValues = PtrToStringArray(desc.FixedDimensionValues, (int)desc.FixedDimensionCount);
+                    })
+                    .Returns(fabricMeter);
+            }
+
+            static string[] PtrToStringArray(IntPtr array, int count)
+            {
+                var result = new string[count];
+                for (int i = 0; i < count; i++)
+                    result[i] = Marshal.PtrToStringUni(Marshal.ReadIntPtr(array, i * IntPtr.Size));
+                return result;
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter()
             {
-                var combinedDimensionNames = systemDimensionsNames.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter<TimeSpan> meter = sut.CreateMeter(testNamespace, testMetric);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal(systemDimensionsNames, actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((TimeSpanMeter)meter).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter1D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter1D<TimeSpan> meter1D = sut.CreateMeter(testNamespace, testMetric, testDimension1);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((TimeSpanMeter1D)meter1D).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter2D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1, testDimension2 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter2D<TimeSpan> meter2D = sut.CreateMeter(testNamespace, testMetric, testDimension1, testDimension2);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1, testDimension2], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((TimeSpanMeter2D)meter2D).Field<IFabricMeter>().Value);
             }
 
             [Fact]
             public void CreatesMeterWithCorrectDimensionsAndMeter3D()
             {
-                var combinedDimensionNames = new List<string>(systemDimensionsNames) { testDimension1, testDimension2, testDimension3 }.ToArray();
-                var fixedDimensionValues = systemDimensionsValues.ToArray();
-
                 IMeter3D<TimeSpan> meter3D = sut.CreateMeter(testNamespace, testMetric, testDimension1, testDimension2, testDimension3);
 
-                Mock.Get(fabricMeterProvider).Verify(x => x.CreateMeter(testNamespace, testMetric, (uint)combinedDimensionNames.Length, It.Is<string[]>(arr => arr.SequenceEqual(combinedDimensionNames)), (uint)fixedDimensionValues.Length, It.Is<string[]>(arr => arr.SequenceEqual(fixedDimensionValues))), Times.Once);
+                Assert.Equal(testNamespace, actualNamespace);
+                Assert.Equal(testMetric, actualName);
+                Assert.Equal([.. systemDimensionsNames, testDimension1, testDimension2, testDimension3], actualDimensionNames);
+                Assert.Equal(systemDimensionsValues, actualFixedDimensionValues);
                 Assert.Same(fabricMeter, ((TimeSpanMeter3D)meter3D).Field<IFabricMeter>().Value);
             }
         }


### PR DESCRIPTION
## Summary

Replace individual parameters on `IFabricMeterProvider.CreateMeter` with a single `IntPtr` to a `FABRIC_METER_DESCRIPTION` struct. This allows extending the API in the future via the `Reserved` pointer without introducing new COM interfaces.

## Motivation

The previous `CreateMeter` signature took individual parameters:
```csharp
IFabricMeter CreateMeter(string metricNamespace, string name, uint count, string[] dimensionNames);
```

Adding new parameters (e.g., fixed dimension values) would require creating `IFabricMeterProvider2`, `IFabricMeterProvider3`, etc. By switching to a struct with a `Reserved` field (following the established `FABRIC_TRANSPORT_SETTINGS` pattern), future extensions only need `FABRIC_METER_DESCRIPTION_EX1`, etc.

## Changes

### `FABRIC_METER_DESCRIPTION` struct
```csharp
[StructLayout(LayoutKind.Sequential, Pack = 8)]
struct FABRIC_METER_DESCRIPTION
{
    public IntPtr MetricNamespace;       // LPCWSTR
    public IntPtr Name;                  // LPCWSTR
    public uint TotalDimensionsCount;
    public IntPtr DimensionNames;        // LPCWSTR*
    public uint FixedDimensionCount;
    public IntPtr FixedDimensionValues;  // LPCWSTR*
    public IntPtr Reserved;
}
```

### `IFabricMeterProvider.CreateMeter`
Takes a single `IntPtr` pointing to the struct. The struct is fully blittable, so it works identically on both net462 (legacy COM interop) and net8.0+ (ComWrappers) with no marshalling attributes.

### `MeterProvider.CreateNativeMeter`
Uses `GCHandle` pinning and `stackalloc` to build the struct, matching the pattern in `Meter.RecordViaNative`.

## Testing

All Diagnostics, Actors, and Services.Remoting tests pass across net472, net8.0, net9.0, and net10.0.