### PR TITLE
Make Copilot Coding Agent run PowerShell scripts correctly

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: .\SkipStrongName.ps1
-      - run: .\UninstallSfSdkFromGac.ps1
+      - run: |
+          .\SkipStrongName.ps1
+          .\UninstallSfSdkFromGac.ps1
+        shell: pwsh # CCA uses Bash on Windows by default
       - run: dotnet restore


### PR DESCRIPTION
Specify `pwsh` explicitly in `copilot-setup-steps.yml` because CCA uses bash by default.