### PR TITLE
Suppress ASPDEPR008/IWebHost deprecation warning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "accessibilities",
+        "ASPDEPR",
         "cref",
         "DSTS",
         "frontmatter",

--- a/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <PropertyGroup>
-    <!-- Continue IWebHost support until its removed from ASP.NET Core https://aka.ms/aspnet/deprecate/008 -->
+    <!-- Continue IWebHost support until it's removed from ASP.NET Core https://aka.ms/aspnet/deprecate/008 -->
     <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">$(NoWarn);ASPDEPR008</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">

--- a/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Continue IWebHost support until its removed from ASP.NET Core https://aka.ms/aspnet/deprecate/008 -->
-    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">ASPDEPR008</NoWarn>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
+  <PropertyGroup>
+    <!-- Continue IWebHost support until its removed from ASP.NET Core https://aka.ms/aspnet/deprecate/008 -->
+    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">$(NoWarn);ASPDEPR008</NoWarn>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- TODO Fix https://aka.ms/aspnet/deprecate/008 and remove -->
-    <WarningsNotAsErrors>ASPDEPR008</WarningsNotAsErrors>
+    <!-- Continue IWebHost support until its removed from ASP.NET Core https://aka.ms/aspnet/deprecate/008 -->
+    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">ASPDEPR008</NoWarn>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">


### PR DESCRIPTION
Even though [.NET 10 deprecated the IWebHost](https://github.com/aspnet/Announcements/issues/526) we will need to continue supporting this interface until it's removed from the .NET Framework/Core versions we support. This warning is generated only in the tests targeting `net10.0` and the only place where it needs to be suppressed.