### PR TITLE
Add InternalsVisibleTo for security subsystem services (TVS, MITS)

### DIFF
--- a/src/Diagnostics/AssemblyInfo.cs
+++ b/src/Diagnostics/AssemblyInfo.cs
@@ -52,6 +52,16 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("System.Fabric.BackupRestore.Test.Common" + PublicKey)]
 [assembly: InternalsVisibleTo("System.Fabric.BackupRestore.Test.Common" + TestKey)]
 
+// Making internals visible for security subsystem services using Metrics
+[assembly: InternalsVisibleTo("TokenValidationSvc" + PublicKey)]
+[assembly: InternalsVisibleTo("TokenValidationSvc" + TestKey)]
+[assembly: InternalsVisibleTo("TokenValidationService.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("TokenValidationService.Test" + TestKey)]
+[assembly: InternalsVisibleTo("ManagedIdentityTokenService" + PublicKey)]
+[assembly: InternalsVisibleTo("ManagedIdentityTokenService" + TestKey)]
+[assembly: InternalsVisibleTo("System.Fabric.ManagedIdentity.Test" + PublicKey)]
+[assembly: InternalsVisibleTo("System.Fabric.ManagedIdentity.Test" + TestKey)]
+
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + TestKey)]
 [assembly: InternalsVisibleTo("System.Fabric.Common.Test" + PublicKey)]


### PR DESCRIPTION
Add InternalsVisibleTo entries for TokenValidationSvc and ManagedIdentityTokenService so they can use the Diagnostics Metrics API (IMeterProvider<T>, IMeter1D<T>, IMeter2D<T>) directly, following the same pattern as BRS/BackupRestore.

These services are security-critical SF system services that need metrics instrumentation through the SF OTel pipeline to Geneva. Without IVT, they cannot reference the internal Diagnostics types and must use workarounds that bypass the pipeline.

Assemblies added:
- TokenValidationSvc (prod + test key)
- TokenValidationService.Test (prod + test key)
- ManagedIdentityTokenService (prod + test key)
- System.Fabric.ManagedIdentity.Test (prod + test key)