### PR TITLE
Put Microsoft.ServiceFabric.Data.* assemblies under test

### DIFF
--- a/code.slnx
+++ b/code.slnx
@@ -32,6 +32,7 @@
     <Project Path="test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj" />
     <Project Path="test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj" />
     <Project Path="test/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.Tests.csproj" />
+    <Project Path="test/Data/Microsoft.ServiceFabric.Data.Tests.csproj" />
     <Project Path="test/Diagnostics/Microsoft.ServiceFabric.Diagnostics.Tests.csproj" />
     <Project Path="test/FabricTransport/Microsoft.ServiceFabric.FabricTransport.Tests.csproj" />
     <Project Path="test/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj" />

--- a/code.slnx
+++ b/code.slnx
@@ -31,6 +31,7 @@
     <Project Path="test/Actors/Microsoft.ServiceFabric.Actors.Tests.csproj" />
     <Project Path="test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj" />
     <Project Path="test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj" />
+    <Project Path="test/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.Tests.csproj" />
     <Project Path="test/Diagnostics/Microsoft.ServiceFabric.Diagnostics.Tests.csproj" />
     <Project Path="test/FabricTransport/Microsoft.ServiceFabric.FabricTransport.Tests.csproj" />
     <Project Path="test/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj" />

--- a/eng/SkipStrongName.ps1
+++ b/eng/SkipStrongName.ps1
@@ -14,6 +14,7 @@ $assemblies = # Keep the list sorted with VSCode / Sort Lines Ascending
     "Microsoft.ServiceFabric.AspNetCore.Kestrel",
     "Microsoft.ServiceFabric.AspNetCore.Tests",
     "Microsoft.ServiceFabric.AspNetCore",
+    "Microsoft.ServiceFabric.Data.Interfaces.Tests",
     "Microsoft.ServiceFabric.Data.Interfaces.V2.Tests",
     "Microsoft.ServiceFabric.Data.Interfaces.V2",
     "Microsoft.ServiceFabric.Data.Interfaces",

--- a/eng/SkipStrongName.ps1
+++ b/eng/SkipStrongName.ps1
@@ -18,6 +18,7 @@ $assemblies = # Keep the list sorted with VSCode / Sort Lines Ascending
     "Microsoft.ServiceFabric.Data.Interfaces.V2.Tests",
     "Microsoft.ServiceFabric.Data.Interfaces.V2",
     "Microsoft.ServiceFabric.Data.Interfaces",
+    "Microsoft.ServiceFabric.Data.Tests",
     "Microsoft.ServiceFabric.Data",
     "Microsoft.ServiceFabric.Diagnostics.Tests",
     "Microsoft.ServiceFabric.Diagnostics",

--- a/src/Data.Interfaces.V2/README.md
+++ b/src/Data.Interfaces.V2/README.md
@@ -7,7 +7,10 @@ string keys, versioned key/value enumeration, advanced dictionary operations, an
 
 - `OrdinalString` — a `string` wrapper that uses ordinal comparison for `IComparable<T>` and `IEquatable<T>`. Use instead
   of `string` as a Reliable Dictionary key to avoid data corruption and unexpected enumeration results caused by the default
-  culture-sensitive string comparison.
+  culture-sensitive string comparison. For `default(OrdinalString)`, `==` and `Equals` treat two defaults as equal and
+  member access on the underlying value throws `NullReferenceException` matching `default(string)` semantics.
+  `GetHashCode` currently also throws `NullReferenceException`, which violates the `Equals`/`GetHashCode` contract
+  and is a known bug.
 - `IReliableDictionary3<TKey, TValue>` — **(Beta)** extends `IReliableDictionary2` with versioned key/value enumeration.
 - `IReliableDictionary4<TKey, TValue>` — **(Beta)** extends `IReliableDictionary3` with key removal without disk reads.
 - `VersionedKeyValuePair<TKey, TValue>` — a key/value pair tagged with a sequence number for change tracking.

--- a/src/Data.Interfaces/AssemblyInfo.cs
+++ b/src/Data.Interfaces/AssemblyInfo.cs
@@ -7,8 +7,10 @@ using System.Runtime.CompilerServices;
 using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Interfaces.Tests" + PublicKey)]
 
 // fix by bug : 16505120 : only needed for internal settings that we will move to Data.Interfaces.V2.
 #if NETFRAMEWORK
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Interfaces.V2" + PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Interfaces.V2.Tests" + PublicKey)]
 #endif

--- a/src/Data/AssemblyInfo.cs
+++ b/src/Data/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("System.Fabric.ReplicatedStore" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.ReplicatedStore" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Impl" + PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Tests" + PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ServiceFabric.Data.Extensions.V2" + PublicKey)]
 [assembly: InternalsVisibleTo("System.Fabric.Common.Test" + TestKey)]
 [assembly: InternalsVisibleTo("FabSrvStateManager.Test" + TestKey)]

--- a/test/Data.Interfaces.V2/Collections/Beta/IReliableDictionaryExtensionsTest.cs
+++ b/test/Data.Interfaces.V2/Collections/Beta/IReliableDictionaryExtensionsTest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Collections.Beta;
+
+public abstract class IReliableDictionaryExtensionsTest
+{
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class RemoveAsync : IReliableDictionaryExtensionsTest
+    {
+        readonly Mock<IReliableDictionary4<string, int>> reliableDictionary4Interface = new(); // Hungarian suffix kept for consistency with SUT parameter name
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly string key = fuzzy.String();
+
+        [Fact]
+        public void ForwardsTransactionAndKeyToReliableDictionaryWithDefaultTimeoutAndCancellation()
+        {
+            Task<bool> expected = new TaskCompletionSource<bool>().Task;
+            _ = reliableDictionary4Interface
+                .Setup(_ => _.RemoveAsync(tx, key, TimeSpan.FromSeconds(4), CancellationToken.None))
+                .Returns(expected);
+
+            Task<bool> actual = reliableDictionary4Interface.Object.RemoveAsync(tx, key);
+
+            Assert.Same(expected, actual);
+            reliableDictionary4Interface.Verify(
+                _ => _.RemoveAsync(It.IsAny<ITransaction>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Extension method dereferences reliableDictionary4Interface unconditionally, producing NullReferenceException instead of ArgumentNullException.
+        public void ThrowsArgumentNullExceptionWhenReliableDictionary4InterfaceIsNull()
+        {
+            // The SUT extension method synchronously dereferences its receiver to invoke RemoveAsync on it,
+            // so calling it on a null reference throws NullReferenceException instead of the ArgumentNullException
+            // expected from a guard clause. This test stays explicit until the SUT adds an explicit null check
+            // on the reliableDictionary4Interface parameter.
+            var e = Assert.Throws<ArgumentNullException>(() => { _ = ((IReliableDictionary4<string, int>)null).RemoveAsync(tx, key); });
+
+            Assert.Equal(nameof(reliableDictionary4Interface), e.ParamName);
+        }
+    }
+}

--- a/test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj
+++ b/test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.ServiceFabric.Data</RootNamespace>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Inspector" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Data.Interfaces.V2/OrdinalStringTest.cs
+++ b/test/Data.Interfaces.V2/OrdinalStringTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 
 using System;
@@ -14,166 +14,304 @@ public abstract class OrdinalStringTest
     // Constructor parameters
     readonly string value = fuzzy.String();
 
-    // Test fixture
     static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
-    static readonly string precomposed = "caf\u00e9";
-    static readonly string decomposed = "cafe\u0301";
 
     OrdinalStringTest() =>
-        sut = new OrdinalString(value);
+        sut = new(value);
 
-    public new sealed class ToString : OrdinalStringTest
+    public sealed class CompareTo : OrdinalStringTest
     {
+        new readonly IComparable<OrdinalString> sut;
+
+        readonly OrdinalString other;
+
+        public CompareTo() =>
+            (sut, other) = (base.sut, EqualButNotSame(value));
+
         [Fact]
-        public void ReturnsValueGivenToConstructor() =>
-            Assert.Same(value, sut.ToString());
+        public void ReturnsZeroWhenOtherIsEqual() =>
+            Assert.Equal(0, sut.CompareTo(other));
+
+        [Fact]
+        public void ReturnsPositiveWhenOtherIsLessThanSut() =>
+            Assert.True(new OrdinalString(lower).CompareTo(new(upper)) > 0);
+
+        [Fact]
+        public void ReturnsNegativeWhenOtherIsGreaterThanSut() =>
+            Assert.True(new OrdinalString(upper).CompareTo(new(lower)) < 0);
+
+        [Fact]
+        public void ReturnsNegativeWhenSutIsDefault() =>
+            Assert.True(default(OrdinalString).CompareTo(base.sut) < 0);
+
+        [Fact]
+        public void ReturnsPositiveWhenOtherIsDefault() =>
+            Assert.True(sut.CompareTo(default) > 0);
+
+        [Fact]
+        public void ReturnsZeroForTwoDefaultValues() =>
+            Assert.Equal(0, default(OrdinalString).CompareTo(default));
     }
 
-    public sealed class ImplicitConversion : OrdinalStringTest
+    public sealed class Equals_Object : OrdinalStringTest
     {
+        new readonly object sut;
+
+        readonly object obj;
+
+        public Equals_Object() =>
+            (sut, obj) = (base.sut, EqualButNotSame(value));
+
         [Fact]
-        public void CreatesOrdinalStringWithSameValue()
+        public void ReturnsTrueWhenObjIsEqualOrdinalString() =>
+            Assert.True(sut.Equals(obj));
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsDifferentOrdinalString() =>
+            Assert.False(sut.Equals(DifferentFrom(value)));
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsNotOrdinalString() =>
+            Assert.False(sut.Equals(value));
+    }
+
+    public sealed class Equals_OrdinalString : OrdinalStringTest
+    {
+        new readonly IEquatable<OrdinalString> sut;
+
+        readonly OrdinalString other;
+
+        public Equals_OrdinalString() =>
+            (sut, other) = (base.sut, EqualButNotSame(value));
+
+        [Fact]
+        public void ReturnsTrueWhenOtherIsEqual() =>
+            Assert.True(sut.Equals(other));
+
+        [Fact]
+        public void ReturnsFalseWhenOtherIsDifferent() =>
+            Assert.False(sut.Equals(DifferentFrom(value)));
+
+        [Fact]
+        public void ReturnsFalseWhenOtherDiffersInCaseOnly() =>
+            Assert.False(new OrdinalString(lower).Equals(new(upper)));
+
+        [Fact]
+        public void ReturnsFalseWhenValuesAreCanonicallyEquivalentButNotIdentical()
         {
-            OrdinalString result = value;
-            Assert.Same(value, result.ToString());
+            const string precomposed = "\u00E9"; // é
+            const string decomposed = "e\u0301"; // e + combining acute accent
+            Assert.False(new OrdinalString(precomposed).Equals(new(decomposed)));
         }
-    }
-
-    public sealed class ExplicitConversion : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsValueGivenToConstructor() =>
-            Assert.Same(value, (string)sut);
-    }
-
-    public new sealed class Equals : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueForEqualOrdinalString() =>
-            Assert.True(sut.Equals(new OrdinalString(value)));
 
         [Fact]
-        public void ReturnsFalseForOrdinallyDifferentOrdinalString() =>
-            Assert.False(new OrdinalString(precomposed).Equals(new OrdinalString(decomposed)));
+        public void ReturnsTrueForTwoDefaultValues() =>
+            Assert.True(default(OrdinalString).Equals(default));
 
         [Fact]
-        public void ReturnsTrueForEqualBoxedOrdinalString() =>
-            Assert.True(sut.Equals((object)new OrdinalString(value)));
+        public void ReturnsFalseWhenSutIsDefault() =>
+            Assert.False(default(OrdinalString).Equals(base.sut));
 
         [Fact]
-        public void ReturnsFalseForOrdinallyDifferentBoxedOrdinalString() =>
-            Assert.False(new OrdinalString(precomposed).Equals((object)new OrdinalString(decomposed)));
-
-        [Fact]
-        public void ReturnsFalseForNull() =>
-            Assert.False(sut.Equals(default(object)));
-    }
-
-    public sealed class EqualityOperator : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueForEqualValues() =>
-            Assert.True(new OrdinalString(value) == sut);
-
-        [Fact]
-        public void ReturnsFalseForOrdinallyDifferentValues() =>
-            Assert.False(new OrdinalString(precomposed) == new OrdinalString(decomposed));
-    }
-
-    public sealed class InequalityOperator : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueForOrdinallyDifferentValues() =>
-            Assert.True(new OrdinalString(precomposed) != new OrdinalString(decomposed));
-
-        [Fact]
-        public void ReturnsFalseForEqualValues() =>
-            Assert.False(new OrdinalString(value) != sut);
+        public void ReturnsFalseWhenOtherIsDefault() =>
+            Assert.False(sut.Equals(default));
     }
 
     public new sealed class GetHashCode : OrdinalStringTest
     {
-        [Fact]
-        public void ReturnsSameHashCodeForEqualValues() =>
-            Assert.Equal(sut.GetHashCode(), new OrdinalString(value).GetHashCode());
+        new readonly object sut;
+
+        public GetHashCode() =>
+            sut = base.sut;
 
         [Fact]
-        public void ReturnsDifferentHashCodeForOrdinallyDifferentValues() =>
-            Assert.NotEqual(new OrdinalString(precomposed).GetHashCode(), new OrdinalString(decomposed).GetHashCode());
+        public void ReturnsValueOfUnderlyingString() =>
+            Assert.Equal(value.GetHashCode(), sut.GetHashCode());
+
+        [Fact(Explicit = true)] // TODO: SUT bug. GetHashCode throws for default(OrdinalString).
+        public void ReturnsZeroForDefaultValue()
+        {
+            // GetHashCode dereferences value directly and throws NullReferenceException for
+            // default(OrdinalString), violating the Equals/GetHashCode contract (two default values
+            // compare equal but cannot be hashed). Fix: value?.GetHashCode() ?? 0.
+            object sut = default(OrdinalString);
+            int actual = sut.GetHashCode();
+            Assert.Equal(0, actual);
+        }
     }
 
-    public sealed class CompareTo : OrdinalStringTest
+    public sealed class Op_Equality : OrdinalStringTest
     {
-        [Fact]
-        public void ReturnsZeroForEqualValues() =>
-            Assert.Equal(0, sut.CompareTo(new OrdinalString(value)));
+        readonly OrdinalString left;
+        readonly OrdinalString right;
 
-        [Fact]
-        public void ReturnsPositiveWhenLeftIsGreater() =>
-            Assert.True(new OrdinalString(precomposed).CompareTo(new OrdinalString(decomposed)) > 0);
-
-        [Fact]
-        public void ReturnsNegativeWhenLeftIsSmaller() =>
-            Assert.True(new OrdinalString(decomposed).CompareTo(new OrdinalString(precomposed)) < 0);
-    }
-
-    public sealed class GreaterThanOperator : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueWhenLeftIsGreater() =>
-            Assert.True(new OrdinalString(precomposed) > new OrdinalString(decomposed));
-
-        [Fact]
-        public void ReturnsFalseWhenLeftIsSmaller() =>
-            Assert.False(new OrdinalString(decomposed) > new OrdinalString(precomposed));
-
-        [Fact]
-        public void ReturnsFalseForEqualValues() =>
-            Assert.False(new OrdinalString(value) > sut);
-    }
-
-    public sealed class LessThanOperator : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueWhenLeftIsSmaller() =>
-            Assert.True(new OrdinalString(decomposed) < new OrdinalString(precomposed));
-
-        [Fact]
-        public void ReturnsFalseWhenLeftIsGreater() =>
-            Assert.False(new OrdinalString(precomposed) < new OrdinalString(decomposed));
-
-        [Fact]
-        public void ReturnsFalseForEqualValues() =>
-            Assert.False(new OrdinalString(value) < sut);
-    }
-
-    public sealed class GreaterThanOrEqualOperator : OrdinalStringTest
-    {
-        [Fact]
-        public void ReturnsTrueWhenLeftIsGreater() =>
-            Assert.True(new OrdinalString(precomposed) >= new OrdinalString(decomposed));
-
-        [Fact]
-        public void ReturnsFalseWhenLeftIsSmaller() =>
-            Assert.False(new OrdinalString(decomposed) >= new OrdinalString(precomposed));
+        public Op_Equality() =>
+            (left, right) = (sut, EqualButNotSame(value));
 
         [Fact]
         public void ReturnsTrueForEqualValues() =>
-            Assert.True(new OrdinalString(value) >= sut);
+            Assert.True(left == right);
+
+        [Fact]
+        public void ReturnsFalseForDifferentValues() =>
+            Assert.False(left == DifferentFrom(value));
     }
 
-    public sealed class LessThanOrEqualOperator : OrdinalStringTest
+    public sealed class Op_Explicit_OrdinalString_To_String : OrdinalStringTest
     {
         [Fact]
-        public void ReturnsTrueWhenLeftIsSmaller() =>
-            Assert.True(new OrdinalString(decomposed) <= new OrdinalString(precomposed));
+        public void ReturnsWrappedString() =>
+            Assert.Same(value, (string)sut);
 
         [Fact]
-        public void ReturnsFalseWhenLeftIsGreater() =>
-            Assert.False(new OrdinalString(precomposed) <= new OrdinalString(decomposed));
-
-        [Fact]
-        public void ReturnsTrueForEqualValues() =>
-            Assert.True(new OrdinalString(value) <= sut);
+        public void ReturnsNullForDefaultValue() =>
+            Assert.Null((string)default(OrdinalString));
     }
+
+    public sealed class Op_GreaterThan : OrdinalStringTest
+    {
+        readonly OrdinalString left;
+        readonly OrdinalString right;
+
+        public Op_GreaterThan() =>
+            (left, right) = (new(value + fuzzy.String()), sut);
+
+        [Fact]
+        public void ReturnsTrueWhenLeftIsGreaterThanRight() =>
+            Assert.True(left > right);
+
+        [Fact]
+        public void ReturnsFalseWhenLeftIsNotGreaterThanRight() =>
+            Assert.False(right > left);
+
+        [Fact]
+        public void ReturnsFalseWhenLeftEqualsRight() =>
+            Assert.False(left > EqualButNotSame(left.ToString()));
+    }
+
+    public sealed class Op_GreaterThanOrEqual : OrdinalStringTest
+    {
+        readonly OrdinalString left;
+        readonly OrdinalString right;
+
+        public Op_GreaterThanOrEqual() =>
+            (left, right) = (new(value + fuzzy.String()), sut);
+
+        [Fact]
+        public void ReturnsTrueWhenLeftIsGreaterThanRight() =>
+            Assert.True(left >= right);
+
+        [Fact]
+        public void ReturnsTrueWhenLeftEqualsRight() =>
+            Assert.True(left >= EqualButNotSame(left.ToString()));
+
+        [Fact]
+        public void ReturnsFalseWhenLeftIsNotGreaterThanOrEqualToRight() =>
+            Assert.False(right >= left);
+    }
+
+    public sealed class Op_Implicit_String_To_OrdinalString : OrdinalStringTest
+    {
+        [Fact]
+        public void CreatesOrdinalStringWithSameValue()
+        {
+            OrdinalString actual = value;
+            Assert.Same(value, actual.ToString());
+        }
+
+        [Fact]
+        public void CreatesOrdinalStringWithNullValue()
+        {
+            OrdinalString actual = (string)null;
+            Assert.Null(actual.ToString());
+        }
+    }
+
+    public sealed class Op_Inequality : OrdinalStringTest
+    {
+        readonly OrdinalString left;
+        readonly OrdinalString right;
+
+        public Op_Inequality() =>
+            (left, right) = (sut, EqualButNotSame(value));
+
+        [Fact]
+        public void ReturnsFalseForEqualValues() =>
+            Assert.False(left != right);
+
+        [Fact]
+        public void ReturnsTrueForDifferentValues() =>
+            Assert.True(left != DifferentFrom(value));
+    }
+
+    public sealed class Op_LessThan : OrdinalStringTest
+    {
+        readonly OrdinalString left;
+        readonly OrdinalString right;
+
+        public Op_LessThan() =>
+            (left, right) = (sut, new(value + fuzzy.String()));
+
+        [Fact]
+        public void ReturnsTrueWhenLeftIsLessThanRight() =>
+            Assert.True(left < right);
+
+        [Fact]
+        public void ReturnsFalseWhenLeftIsNotLessThanRight() =>
+            Assert.False(right < left);
+
+        [Fact]
+        public void ReturnsFalseWhenLeftEqualsRight() =>
+            Assert.False(left < EqualButNotSame(left.ToString()));
+    }
+
+    public sealed class Op_LessThanOrEqual : OrdinalStringTest
+    {
+        readonly OrdinalString left;
+        readonly OrdinalString right;
+
+        public Op_LessThanOrEqual() =>
+            (left, right) = (sut, new(value + fuzzy.String()));
+
+        [Fact]
+        public void ReturnsTrueWhenLeftIsLessThanRight() =>
+            Assert.True(left <= right);
+
+        [Fact]
+        public void ReturnsTrueWhenLeftEqualsRight() =>
+            Assert.True(left <= EqualButNotSame(left.ToString()));
+
+        [Fact]
+        public void ReturnsFalseWhenLeftIsNotLessThanOrEqualToRight() =>
+            Assert.False(right <= left);
+    }
+
+    public new sealed class ToString : OrdinalStringTest
+    {
+        new readonly object sut;
+
+        public ToString() =>
+            sut = base.sut;
+
+        [Fact]
+        public void ReturnsWrappedString() =>
+            Assert.Same(value, sut.ToString());
+
+        [Fact]
+        public void ReturnsNullForDefaultValue()
+        {
+            object sut = default(OrdinalString);
+            Assert.Null(sut.ToString());
+        }
+    }
+
+    const string lower = "a";
+    const string upper = "A";
+
+    // Returns an OrdinalString with the same content as `s` but, when `s` is non-empty, a distinct
+    // underlying string instance so reference-equality assertions can't mask content-equality bugs.
+    // The empty string is always interned in .NET, so distinct identity can't be guaranteed for `""`.
+    static OrdinalString EqualButNotSame(string s) => new(new string(s.ToCharArray()));
+
+    static OrdinalString DifferentFrom(string s) => new(s + fuzzy.String());
 }

--- a/test/Data.Interfaces.V2/ReliableStateManagerReplicatorSettings2Test.cs
+++ b/test/Data.Interfaces.V2/ReliableStateManagerReplicatorSettings2Test.cs
@@ -1,0 +1,856 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Fabric;
+using System.Runtime.CompilerServices;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class ReliableStateManagerReplicatorSettings2Test
+{
+    readonly ReliableStateManagerReplicatorSettings2 sut = new();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class CopyBatchSizeInKB : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.CopyBatchSizeInKB = expected;
+            Assert.Equal(expected, sut.CopyBatchSizeInKB);
+        }
+    }
+
+    public sealed class EnableStableReads : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.EnableStableReads = value;
+            Assert.Equal(value, sut.EnableStableReads);
+        }
+    }
+
+    public new sealed class Equals : ReliableStateManagerReplicatorSettings2Test
+    {
+        readonly ReliableStateManagerReplicatorSettings2 obj;
+
+        public Equals()
+        {
+            Populate();
+            obj = CloneOf(sut);
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjPropertiesMatch() =>
+            Assert.True(sut.Equals(obj));
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsNull() =>
+            Assert.False(sut.Equals(null));
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsUnrelatedType() =>
+            Assert.False(sut.Equals(fuzzy.String()));
+
+        [Fact]
+        public void ReturnsTrueWhenObjIsBaseSettingsAndItsSetPropertiesMatch()
+        {
+            var baseOther = new ReliableStateManagerReplicatorSettings
+            {
+                SharedLogId = sut.SharedLogId,
+                SharedLogPath = sut.SharedLogPath,
+            };
+            Assert.True(sut.Equals(baseOther));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsBaseSettingsAndItsSetPropertyDiffers()
+        {
+            var baseOther = new ReliableStateManagerReplicatorSettings
+            {
+                SharedLogId = sut.SharedLogId + fuzzy.String(),
+            };
+            Assert.False(sut.Equals(baseOther));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenCopyBatchSizeInKBDiffers()
+        {
+            obj.CopyBatchSizeInKB = sut.CopyBatchSizeInKB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjCopyBatchSizeInKBIsNull()
+        {
+            obj.CopyBatchSizeInKB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenCopyBatchSizeInKBIsNull()
+        {
+            sut.CopyBatchSizeInKB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory(Explicit = true), InlineData(true), InlineData(false)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenEnableStableReadsDiffers(bool value)
+        {
+            sut.EnableStableReads = value;
+            obj.EnableStableReads = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjEnableStableReadsIsNull()
+        {
+            obj.EnableStableReads = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenEnableStableReadsIsNull()
+        {
+            sut.EnableStableReads = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory(Explicit = true), InlineData(true), InlineData(false)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenShouldAbortCopyForTruncationDiffers(bool value)
+        {
+            sut.ShouldAbortCopyForTruncation = value;
+            obj.ShouldAbortCopyForTruncation = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjShouldAbortCopyForTruncationIsNull()
+        {
+            obj.ShouldAbortCopyForTruncation = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenShouldAbortCopyForTruncationIsNull()
+        {
+            sut.ShouldAbortCopyForTruncation = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenReplicationBatchSizeDiffers()
+        {
+            obj.ReplicationBatchSize = sut.ReplicationBatchSize + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjReplicationBatchSizeIsNull()
+        {
+            obj.ReplicationBatchSize = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. InternalEquals ignores previously-detected property inequality.
+        public void ReturnsFalseWhenReplicationBatchSizeIsNull()
+        {
+            sut.ReplicationBatchSize = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenReplicationBatchSendIntervalDiffers()
+        {
+            obj.ReplicationBatchSendInterval = sut.ReplicationBatchSendInterval + fuzzy.TimeSpan().Seconds();
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjReplicationBatchSendIntervalIsNull()
+        {
+            obj.ReplicationBatchSendInterval = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenReplicationBatchSendIntervalIsNull()
+        {
+            sut.ReplicationBatchSendInterval = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenSharedLogIdDiffers()
+        {
+            obj.SharedLogId = sut.SharedLogId + fuzzy.String();
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(null), InlineData("")]
+        public void ReturnsFalseWhenSharedLogIdIsNullOrEmpty(string value)
+        {
+            sut.SharedLogId = value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(null), InlineData("")]
+        public void ReturnsTrueWhenObjSharedLogIdIsNullOrEmpty(string value)
+        {
+            obj.SharedLogId = value;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenSharedLogPathDiffers()
+        {
+            obj.SharedLogPath = sut.SharedLogPath + fuzzy.String();
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(null), InlineData("")]
+        public void ReturnsFalseWhenSharedLogPathIsNullOrEmpty(string value)
+        {
+            sut.SharedLogPath = value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(null), InlineData("")]
+        public void ReturnsTrueWhenObjSharedLogPathIsNullOrEmpty(string value)
+        {
+            obj.SharedLogPath = value;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxStreamSizeInMBDiffers()
+        {
+            obj.MaxStreamSizeInMB = sut.MaxStreamSizeInMB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxStreamSizeInMBIsNull()
+        {
+            sut.MaxStreamSizeInMB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxStreamSizeInMBIsNull()
+        {
+            obj.MaxStreamSizeInMB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxRecordSizeInKBDiffers()
+        {
+            obj.MaxRecordSizeInKB = sut.MaxRecordSizeInKB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxRecordSizeInKBIsNull()
+        {
+            sut.MaxRecordSizeInKB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxRecordSizeInKBIsNull()
+        {
+            obj.MaxRecordSizeInKB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxMetadataSizeInKBDiffers()
+        {
+            obj.MaxMetadataSizeInKB = sut.MaxMetadataSizeInKB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxMetadataSizeInKBIsNull()
+        {
+            sut.MaxMetadataSizeInKB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxMetadataSizeInKBIsNull()
+        {
+            obj.MaxMetadataSizeInKB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsFalseWhenOptimizeForLocalSSDDiffers(bool value)
+        {
+            sut.OptimizeForLocalSSD = value;
+            obj.OptimizeForLocalSSD = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenOptimizeForLocalSSDIsNull()
+        {
+            sut.OptimizeForLocalSSD = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjOptimizeForLocalSSDIsNull()
+        {
+            obj.OptimizeForLocalSSD = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsFalseWhenOptimizeLogForLowerDiskUsageDiffers(bool value)
+        {
+            sut.OptimizeLogForLowerDiskUsage = value;
+            obj.OptimizeLogForLowerDiskUsage = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenOptimizeLogForLowerDiskUsageIsNull()
+        {
+            sut.OptimizeLogForLowerDiskUsage = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjOptimizeLogForLowerDiskUsageIsNull()
+        {
+            obj.OptimizeLogForLowerDiskUsage = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenCheckpointThresholdInMBDiffers()
+        {
+            obj.CheckpointThresholdInMB = sut.CheckpointThresholdInMB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenCheckpointThresholdInMBIsNull()
+        {
+            sut.CheckpointThresholdInMB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjCheckpointThresholdInMBIsNull()
+        {
+            obj.CheckpointThresholdInMB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxAccumulatedBackupLogSizeInMBDiffers()
+        {
+            obj.MaxAccumulatedBackupLogSizeInMB = sut.MaxAccumulatedBackupLogSizeInMB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxAccumulatedBackupLogSizeInMBIsNull()
+        {
+            sut.MaxAccumulatedBackupLogSizeInMB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxAccumulatedBackupLogSizeInMBIsNull()
+        {
+            obj.MaxAccumulatedBackupLogSizeInMB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMinLogSizeInMBDiffers()
+        {
+            obj.MinLogSizeInMB = sut.MinLogSizeInMB + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMinLogSizeInMBIsNull()
+        {
+            sut.MinLogSizeInMB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMinLogSizeInMBIsNull()
+        {
+            obj.MinLogSizeInMB = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenTruncationThresholdFactorDiffers()
+        {
+            obj.TruncationThresholdFactor = sut.TruncationThresholdFactor + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenTruncationThresholdFactorIsNull()
+        {
+            sut.TruncationThresholdFactor = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjTruncationThresholdFactorIsNull()
+        {
+            obj.TruncationThresholdFactor = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenThrottlingThresholdFactorDiffers()
+        {
+            obj.ThrottlingThresholdFactor = sut.ThrottlingThresholdFactor + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenThrottlingThresholdFactorIsNull()
+        {
+            sut.ThrottlingThresholdFactor = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjThrottlingThresholdFactorIsNull()
+        {
+            obj.ThrottlingThresholdFactor = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenSlowApiMonitoringDurationDiffers()
+        {
+            obj.SlowApiMonitoringDuration = sut.SlowApiMonitoringDuration + fuzzy.TimeSpan().Seconds();
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenSlowApiMonitoringDurationIsNull()
+        {
+            sut.SlowApiMonitoringDuration = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjSlowApiMonitoringDurationIsNull()
+        {
+            obj.SlowApiMonitoringDuration = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void ReturnsFalseWhenLogTruncationIntervalSecondsDiffers()
+        {
+            obj.LogTruncationIntervalSeconds = sut.LogTruncationIntervalSeconds + fuzzy.SByte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenLogTruncationIntervalSecondsIsNull()
+        {
+            sut.LogTruncationIntervalSeconds = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjLogTruncationIntervalSecondsIsNull()
+        {
+            obj.LogTruncationIntervalSeconds = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsFalseWhenEnableIncrementalBackupsAcrossReplicasDiffers(bool value)
+        {
+            sut.EnableIncrementalBackupsAcrossReplicas = value;
+            obj.EnableIncrementalBackupsAcrossReplicas = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenEnableIncrementalBackupsAcrossReplicasIsNull()
+        {
+            sut.EnableIncrementalBackupsAcrossReplicas = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjEnableIncrementalBackupsAcrossReplicasIsNull()
+        {
+            obj.EnableIncrementalBackupsAcrossReplicas = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsFalseWhenEnableSendWindowSizeInBytesDiffers(bool value)
+        {
+            sut.EnableSendWindowSizeInBytes = value;
+            obj.EnableSendWindowSizeInBytes = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenEnableSendWindowSizeInBytesIsNull()
+        {
+            sut.EnableSendWindowSizeInBytes = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjEnableSendWindowSizeInBytesIsNull()
+        {
+            obj.EnableSendWindowSizeInBytes = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxReplicationQueueSendWindowSizeInBytesDiffers()
+        {
+            obj.MaxReplicationQueueSendWindowSizeInBytes = sut.MaxReplicationQueueSendWindowSizeInBytes + fuzzy.Byte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxReplicationQueueSendWindowSizeInBytesIsNull()
+        {
+            sut.MaxReplicationQueueSendWindowSizeInBytes = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxReplicationQueueSendWindowSizeInBytesIsNull()
+        {
+            obj.MaxReplicationQueueSendWindowSizeInBytes = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxCopyQueueSendWindowSizeInBytesDiffers()
+        {
+            obj.MaxCopyQueueSendWindowSizeInBytes = sut.MaxCopyQueueSendWindowSizeInBytes + fuzzy.Byte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenMaxCopyQueueSendWindowSizeInBytesIsNull()
+        {
+            sut.MaxCopyQueueSendWindowSizeInBytes = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjMaxCopyQueueSendWindowSizeInBytesIsNull()
+        {
+            obj.MaxCopyQueueSendWindowSizeInBytes = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsFalseWhenUseIndividualHeapPerReplicaDiffers(bool value)
+        {
+            sut.UseIndividualHeapPerReplica = value;
+            obj.UseIndividualHeapPerReplica = !value;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenUseIndividualHeapPerReplicaIsNull()
+        {
+            sut.UseIndividualHeapPerReplica = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjUseIndividualHeapPerReplicaIsNull()
+        {
+            obj.UseIndividualHeapPerReplica = null;
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT Bug. BaseInternalEquals doesn't compare InitialReplicaHeapSizeInKB
+        public void ReturnsFalseWhenInitialReplicaHeapSizeInKBDiffers()
+        {
+            obj.InitialReplicaHeapSizeInKB = sut.InitialReplicaHeapSizeInKB + fuzzy.Byte().Between(1, 5);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT Bug. BaseInternalEquals doesn't compare InitialReplicaHeapSizeInKB
+        public void ReturnsFalseWhenInitialReplicaHeapSizeInKBIsNull()
+        {
+            sut.InitialReplicaHeapSizeInKB = null;
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenObjInitialReplicaHeapSizeInKBIsNull()
+        {
+            obj.InitialReplicaHeapSizeInKB = null;
+            Assert.True(sut.Equals(obj));
+        }
+#endif
+
+        [Theory, MemberData(nameof(UncomparedBaseMutations))]
+        public void IgnoresUncomparedBaseProperty(string property, Action<ReliableStateManagerReplicatorSettings> mutate)
+        {
+            _ = property; // Shown in the test display name to identify the failing property.
+            mutate(obj);
+            Assert.True(sut.Equals(obj));
+        }
+
+        public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings>> UncomparedBaseMutations => new()
+        {
+            { nameof(ReliableStateManagerReplicatorSettings.RetryInterval), o => o.RetryInterval = fuzzy.TimeSpan() },
+            { nameof(ReliableStateManagerReplicatorSettings.BatchAcknowledgementInterval), o => o.BatchAcknowledgementInterval = fuzzy.TimeSpan() },
+            { nameof(ReliableStateManagerReplicatorSettings.ReplicatorAddress), o => o.ReplicatorAddress = fuzzy.String() },
+            { nameof(ReliableStateManagerReplicatorSettings.ReplicatorListenAddress), o => o.ReplicatorListenAddress = fuzzy.String() },
+            { nameof(ReliableStateManagerReplicatorSettings.ReplicatorPublishAddress), o => o.ReplicatorPublishAddress = fuzzy.String() },
+            { nameof(ReliableStateManagerReplicatorSettings.InitialCopyQueueSize), o => o.InitialCopyQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxCopyQueueSize), o => o.MaxCopyQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.InitialPrimaryReplicationQueueSize), o => o.InitialPrimaryReplicationQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxPrimaryReplicationQueueSize), o => o.MaxPrimaryReplicationQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxPrimaryReplicationQueueMemorySize), o => o.MaxPrimaryReplicationQueueMemorySize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.InitialSecondaryReplicationQueueSize), o => o.InitialSecondaryReplicationQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxSecondaryReplicationQueueSize), o => o.MaxSecondaryReplicationQueueSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxSecondaryReplicationQueueMemorySize), o => o.MaxSecondaryReplicationQueueMemorySize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxReplicationMessageSize), o => o.MaxReplicationMessageSize = fuzzy.Int64() },
+            { nameof(ReliableStateManagerReplicatorSettings.SecurityCredentials), o => o.SecurityCredentials = new NoneSecurityCredentials() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxWriteQueueDepthInKB), o => o.MaxWriteQueueDepthInKB = fuzzy.Int32() },
+            { nameof(ReliableStateManagerReplicatorSettings.SecondaryClearAcknowledgedOperations), o => o.SecondaryClearAcknowledgedOperations = fuzzy.Boolean() },
+        };
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Equals is asymmetric.
+        public void IsSymmetric()
+        {
+            // InternalEquals only inspects properties set on the right-hand side, so sut.Equals(sparse) returns true
+            // while sparse.Equals(sut) returns false, violating the Object.Equals symmetry contract.
+            var sparse = new ReliableStateManagerReplicatorSettings2();
+            bool sutEqualsSparse = sut.Equals(sparse);
+            bool sparseEqualsSut = sparse.Equals(sut);
+            Assert.Equal(sutEqualsSparse, sparseEqualsSut);
+        }
+    }
+
+    public new sealed class GetHashCode : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Fact]
+        public void ReturnsIdentityHash() =>
+            Assert.Equal(RuntimeHelpers.GetHashCode(sut), sut.GetHashCode());
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Equals and GetHashCode are inconsistent.
+        public void IsConsistentWithEquals()
+        {
+            // GetHashCode returns the identity hash, so two instances that Equals reports as equal
+            // produce different hash codes, violating the Object.GetHashCode contract.
+            Populate();
+            ReliableStateManagerReplicatorSettings2 other;
+            // Guarantee the assertion fails for the right reason rather than a spurious identity-hash collision.
+            do
+                other = CloneOf(sut);
+            while (RuntimeHelpers.GetHashCode(other) == RuntimeHelpers.GetHashCode(sut));
+
+            Assert.True(sut.Equals(other));
+            Assert.Equal(sut.GetHashCode(), other.GetHashCode());
+        }
+    }
+
+    public sealed class ReplicationBatchSendInterval : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            TimeSpan expected = fuzzy.TimeSpan();
+            sut.ReplicationBatchSendInterval = expected;
+            Assert.Equal(expected, sut.ReplicationBatchSendInterval);
+        }
+    }
+
+    public sealed class ReplicationBatchSize : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.ReplicationBatchSize = expected;
+            Assert.Equal(expected, sut.ReplicationBatchSize);
+        }
+    }
+
+    public sealed class ShouldAbortCopyForTruncation : ReliableStateManagerReplicatorSettings2Test
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.ShouldAbortCopyForTruncation = value;
+            Assert.Equal(value, sut.ShouldAbortCopyForTruncation);
+        }
+    }
+
+    public new sealed class ToString : ReliableStateManagerReplicatorSettings2Test
+    {
+        public ToString() => Populate();
+
+        [Fact]
+        public void StartsWithBaseToString() =>
+            Assert.StartsWith(BaseCopyOf(sut).ToString(), sut.ToString());
+
+        [Fact]
+        public void IncludesCopyBatchSizeInKBWhenSet() =>
+            Assert.Contains($"{nameof(sut.CopyBatchSizeInKB)} = {sut.CopyBatchSizeInKB}", sut.ToString());
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void IncludesEnableStableReadsWhenSet(bool value)
+        {
+            sut.EnableStableReads = value;
+            Assert.Contains($"{nameof(sut.EnableStableReads)} = {value}", sut.ToString());
+        }
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void IncludesShouldAbortCopyForTruncationWhenSet(bool value)
+        {
+            sut.ShouldAbortCopyForTruncation = value;
+            Assert.Contains($"{nameof(sut.ShouldAbortCopyForTruncation)} = {value}", sut.ToString());
+        }
+
+        [Fact]
+        public void IncludesReplicationBatchSizeWhenSet() =>
+            Assert.Contains($"{nameof(sut.ReplicationBatchSize)} = {sut.ReplicationBatchSize}", sut.ToString());
+
+        [Fact]
+        public void IncludesReplicationBatchSendIntervalWhenSet() =>
+            Assert.Contains($"{nameof(sut.ReplicationBatchSendInterval)} = {sut.ReplicationBatchSendInterval}", sut.ToString());
+
+        [Fact]
+        public void OmitsCopyBatchSizeInKBWhenNull()
+        {
+            sut.CopyBatchSizeInKB = null;
+            Assert.DoesNotContain($"{nameof(sut.CopyBatchSizeInKB)} = ", sut.ToString());
+        }
+
+        [Fact]
+        public void OmitsEnableStableReadsWhenNull()
+        {
+            sut.EnableStableReads = null;
+            Assert.DoesNotContain($"{nameof(sut.EnableStableReads)} = ", sut.ToString());
+        }
+
+        [Fact]
+        public void OmitsShouldAbortCopyForTruncationWhenNull()
+        {
+            sut.ShouldAbortCopyForTruncation = null;
+            Assert.DoesNotContain($"{nameof(sut.ShouldAbortCopyForTruncation)} = ", sut.ToString());
+        }
+
+        [Fact]
+        public void OmitsReplicationBatchSizeWhenNull()
+        {
+            sut.ReplicationBatchSize = null;
+            Assert.DoesNotContain($"{nameof(sut.ReplicationBatchSize)} = ", sut.ToString());
+        }
+
+        [Fact]
+        public void OmitsReplicationBatchSendIntervalWhenNull()
+        {
+            sut.ReplicationBatchSendInterval = null;
+            Assert.DoesNotContain($"{nameof(sut.ReplicationBatchSendInterval)} = ", sut.ToString());
+        }
+    }
+
+    void Populate()
+    {
+        sut.CopyBatchSizeInKB = fuzzy.Int64();
+        sut.EnableStableReads = fuzzy.Boolean();
+        sut.ShouldAbortCopyForTruncation = fuzzy.Boolean();
+        sut.ReplicationBatchSize = fuzzy.Int64();
+        // Cap leaves headroom for + fuzzy.TimeSpan().Seconds() in Differs tests; SUT does not cap this.
+        sut.ReplicationBatchSendInterval = fuzzy.TimeSpan().Maximum(TimeSpan.MaxValue - TimeSpan.FromMinutes(1));
+        sut.SharedLogId = fuzzy.String();
+        sut.SharedLogPath = fuzzy.String();
+        sut.MaxStreamSizeInMB = fuzzy.Int32();
+        sut.MaxRecordSizeInKB = fuzzy.Int32();
+        sut.MaxMetadataSizeInKB = fuzzy.Int32();
+        sut.OptimizeForLocalSSD = fuzzy.Boolean();
+        sut.OptimizeLogForLowerDiskUsage = fuzzy.Boolean();
+        sut.CheckpointThresholdInMB = fuzzy.Int32();
+        sut.MaxAccumulatedBackupLogSizeInMB = fuzzy.Int32();
+        sut.MinLogSizeInMB = fuzzy.Int32();
+        sut.TruncationThresholdFactor = fuzzy.Int32();
+        sut.ThrottlingThresholdFactor = fuzzy.Int32();
+        // Cap leaves headroom for + fuzzy.TimeSpan().Seconds() in Differs tests; SUT does not cap this.
+        sut.SlowApiMonitoringDuration = fuzzy.TimeSpan().Maximum(TimeSpan.MaxValue - TimeSpan.FromMinutes(1));
+#if NETFRAMEWORK
+        sut.LogTruncationIntervalSeconds = fuzzy.Int32();
+        sut.EnableIncrementalBackupsAcrossReplicas = fuzzy.Boolean();
+        sut.EnableSendWindowSizeInBytes = fuzzy.Boolean();
+        sut.MaxReplicationQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        sut.MaxCopyQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        sut.UseIndividualHeapPerReplica = fuzzy.Boolean();
+        sut.InitialReplicaHeapSizeInKB = fuzzy.UInt32();
+#endif
+    }
+
+    static ReliableStateManagerReplicatorSettings2 CloneOf(ReliableStateManagerReplicatorSettings2 source)
+    {
+        var clone = CopyBaseProperties(new ReliableStateManagerReplicatorSettings2(), source);
+        clone.CopyBatchSizeInKB = source.CopyBatchSizeInKB;
+        clone.EnableStableReads = source.EnableStableReads;
+        clone.ShouldAbortCopyForTruncation = source.ShouldAbortCopyForTruncation;
+        clone.ReplicationBatchSize = source.ReplicationBatchSize;
+        clone.ReplicationBatchSendInterval = source.ReplicationBatchSendInterval;
+        return clone;
+    }
+
+    static ReliableStateManagerReplicatorSettings BaseCopyOf(ReliableStateManagerReplicatorSettings2 source) =>
+        CopyBaseProperties(new ReliableStateManagerReplicatorSettings(), source);
+
+    static T CopyBaseProperties<T>(T target, ReliableStateManagerReplicatorSettings2 source)
+        where T : ReliableStateManagerReplicatorSettings
+    {
+        target.SharedLogId = source.SharedLogId;
+        target.SharedLogPath = source.SharedLogPath;
+        target.MaxStreamSizeInMB = source.MaxStreamSizeInMB;
+        target.MaxRecordSizeInKB = source.MaxRecordSizeInKB;
+        target.MaxMetadataSizeInKB = source.MaxMetadataSizeInKB;
+        target.OptimizeForLocalSSD = source.OptimizeForLocalSSD;
+        target.OptimizeLogForLowerDiskUsage = source.OptimizeLogForLowerDiskUsage;
+        target.CheckpointThresholdInMB = source.CheckpointThresholdInMB;
+        target.MaxAccumulatedBackupLogSizeInMB = source.MaxAccumulatedBackupLogSizeInMB;
+        target.MinLogSizeInMB = source.MinLogSizeInMB;
+        target.TruncationThresholdFactor = source.TruncationThresholdFactor;
+        target.ThrottlingThresholdFactor = source.ThrottlingThresholdFactor;
+        target.SlowApiMonitoringDuration = source.SlowApiMonitoringDuration;
+#if NETFRAMEWORK
+        target.LogTruncationIntervalSeconds = source.LogTruncationIntervalSeconds;
+        target.EnableIncrementalBackupsAcrossReplicas = source.EnableIncrementalBackupsAcrossReplicas;
+        target.EnableSendWindowSizeInBytes = source.EnableSendWindowSizeInBytes;
+        target.MaxReplicationQueueSendWindowSizeInBytes = source.MaxReplicationQueueSendWindowSizeInBytes;
+        target.MaxCopyQueueSendWindowSizeInBytes = source.MaxCopyQueueSendWindowSizeInBytes;
+        target.UseIndividualHeapPerReplica = source.UseIndividualHeapPerReplica;
+        target.InitialReplicaHeapSizeInKB = source.InitialReplicaHeapSizeInKB;
+#endif
+        return target;
+    }
+}

--- a/test/Data.Interfaces.V2/VersionedKeyTest.cs
+++ b/test/Data.Interfaces.V2/VersionedKeyTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class VersionedKeyTest
+{
+    readonly VersionedKey<string> sut;
+
+    // Constructor parameters
+    readonly string key = fuzzy.String();
+    readonly long sequenceNumber = fuzzy.Int64();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    VersionedKeyTest() => sut = new(key, sequenceNumber);
+
+    public sealed class Constructor : VersionedKeyTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(key, sut.Key);
+            Assert.Equal(sequenceNumber, sut.SequenceNumber);
+        }
+    }
+}

--- a/test/Data.Interfaces.V2/VersionedKeyValuePairTest.cs
+++ b/test/Data.Interfaces.V2/VersionedKeyValuePairTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Collections.Generic;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class VersionedKeyValuePairTest
+{
+    readonly VersionedKeyValuePair<string, Uri> sut;
+
+    // Constructor parameters
+    readonly string key = fuzzy.String();
+    readonly Uri value = fuzzy.Uri();
+    readonly long sequenceNumber = fuzzy.Int64();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    VersionedKeyValuePairTest() => sut = new(key, value, sequenceNumber);
+
+    public sealed class Constructor : VersionedKeyValuePairTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(value, sut.Value);
+            Assert.Same(key, sut.VersionedKey.Key);
+            Assert.Equal(sequenceNumber, sut.VersionedKey.SequenceNumber);
+        }
+    }
+
+    public sealed class Key : VersionedKeyValuePairTest
+    {
+        [Fact]
+        public void ReturnsKeyPassedToConstructor() => Assert.Same(key, sut.Key);
+    }
+
+    public sealed class KeyValuePair : VersionedKeyValuePairTest
+    {
+        [Fact]
+        public void ReturnsPairOfKeyAndValuePassedToConstructor()
+        {
+            KeyValuePair<string, Uri> actual = sut.KeyValuePair;
+            Assert.Same(key, actual.Key);
+            Assert.Same(value, actual.Value);
+        }
+    }
+
+    public sealed class SequenceNumber : VersionedKeyValuePairTest
+    {
+        [Fact]
+        public void ReturnsSequenceNumberPassedToConstructor() => Assert.Equal(sequenceNumber, sut.SequenceNumber);
+    }
+}

--- a/test/Data.Interfaces/BackupDescriptionTest.cs
+++ b/test/Data.Interfaces/BackupDescriptionTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class BackupDescriptionTest
+{
+    // Constructor parameters
+    readonly BackupOption option = fuzzy.Enum<BackupOption>();
+    readonly Func<BackupInfo, CancellationToken, Task<bool>> backupCallback = static (_, _) => Task.FromResult(true);
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class Constructor_BackupOption_FuncOfBackupInfoCancellationTokenTaskOfBoolean : BackupDescriptionTest
+    {
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate backupCallback; consumers invoking it throw NullReferenceException.
+        public void ThrowsArgumentNullExceptionWhenBackupCallbackIsNull()
+        {
+            // The constructor stores backupCallback without validation, so a null argument is silently accepted
+            // and surfaced via the BackupCallback property. Consumers that later invoke the callback then
+            // fail with NullReferenceException far from the original site. The fix is to throw ArgumentNullException here.
+            var e = Assert.Throws<ArgumentNullException>(() => new BackupDescription(option, null));
+            Assert.Equal(nameof(backupCallback), e.ParamName);
+        }
+    }
+
+    public sealed class Constructor_FuncOfBackupInfoCancellationTokenTaskOfBoolean : BackupDescriptionTest
+    {
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate backupCallback; consumers invoking it throw NullReferenceException.
+        public void ThrowsArgumentNullExceptionWhenBackupCallbackIsNull()
+        {
+            // The constructor stores backupCallback without validation, so a null argument is silently accepted
+            // and surfaced via the BackupCallback property. Consumers that later invoke the callback then
+            // fail with NullReferenceException far from the original site. The fix is to throw ArgumentNullException here.
+            var e = Assert.Throws<ArgumentNullException>(() => new BackupDescription(null));
+            Assert.Equal(nameof(backupCallback), e.ParamName);
+        }
+    }
+
+    public sealed class BackupCallback : BackupDescriptionTest
+    {
+        [Fact]
+        public void ReturnsValueSuppliedToConstructorWithBackupOption() =>
+            Assert.Same(backupCallback, new BackupDescription(option, backupCallback).BackupCallback);
+
+        [Fact]
+        public void ReturnsValueSuppliedToConstructorWithoutBackupOption() =>
+            Assert.Same(backupCallback, new BackupDescription(backupCallback).BackupCallback);
+    }
+
+    public sealed class Option : BackupDescriptionTest
+    {
+        [Theory, InlineData(BackupOption.Full), InlineData(BackupOption.Incremental)]
+        public void ReturnsValueSuppliedToConstructor(BackupOption option) =>
+            Assert.Equal(option, new BackupDescription(option, backupCallback).Option);
+
+        [Fact]
+        public void IsFullByDefault() =>
+            Assert.Equal(BackupOption.Full, new BackupDescription(backupCallback).Option);
+    }
+}

--- a/test/Data.Interfaces/BackupInfoTest.cs
+++ b/test/Data.Interfaces/BackupInfoTest.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Fabric;
+using Fuzzy;
+using Xunit;
+using BackupVersion = Microsoft.ServiceFabric.Data.BackupInfo.BackupVersion;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class BackupInfoTest
+{
+    // Constructor parameters
+    readonly string directory = fuzzy.String();
+    readonly BackupOption option = fuzzy.Enum<BackupOption>();
+    readonly BackupVersion version = fuzzy.BackupVersion();
+    readonly BackupVersion startBackupVersion = fuzzy.BackupVersion();
+    readonly Guid backupId = Guid.NewGuid();
+    readonly Guid parentBackupId = Guid.NewGuid();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class Constructor_String_BackupOption_BackupVersion : BackupInfoTest
+    {
+        [Theory, InlineData(BackupOption.Full), InlineData(BackupOption.Incremental)]
+        public void InitializesPropertiesAndDefaults(BackupOption option)
+        {
+            var sut = new BackupInfo(directory, option, version);
+            Assert.Same(directory, sut.Directory);
+            Assert.Equal(option, sut.Option);
+            Assert.Equal(version, sut.Version);
+            Assert.Equal(BackupVersion.InvalidBackupVersion, sut.StartBackupVersion);
+            Assert.Equal(Guid.Empty, sut.BackupId);
+            Assert.Equal(Guid.Empty, sut.ParentBackupId);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate directory; null propagates to consumers.
+        public void ThrowsArgumentNullExceptionWhenDirectoryIsNull()
+        {
+            // The constructor stores directory without validation, so a null argument is silently accepted
+            // and surfaced via the Directory auto-property. Downstream callers that dereference the returned
+            // value then fail far from the original site. The fix is to throw ArgumentNullException here.
+            var e = Assert.Throws<ArgumentNullException>(() => new BackupInfo(null, option, version));
+            Assert.Equal(nameof(directory), e.ParamName);
+        }
+    }
+
+    public sealed class Constructor_String_BackupOption_BackupVersion_BackupVersion_Guid_Guid : BackupInfoTest
+    {
+        [Theory, InlineData(BackupOption.Full), InlineData(BackupOption.Incremental)]
+        public void InitializesProperties(BackupOption option)
+        {
+            var sut = new BackupInfo(directory, option, version, startBackupVersion, backupId, parentBackupId);
+            Assert.Same(directory, sut.Directory);
+            Assert.Equal(option, sut.Option);
+            Assert.Equal(version, sut.Version);
+            Assert.Equal(startBackupVersion, sut.StartBackupVersion);
+            Assert.Equal(backupId, sut.BackupId);
+            Assert.Equal(parentBackupId, sut.ParentBackupId);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate directory; null propagates to consumers.
+        public void ThrowsArgumentNullExceptionWhenDirectoryIsNull()
+        {
+            // The constructor stores directory without validation, so a null argument is silently accepted
+            // and surfaced via the Directory auto-property. Downstream callers that dereference the returned
+            // value then fail far from the original site. The fix is to throw ArgumentNullException here.
+            var e = Assert.Throws<ArgumentNullException>(() => new BackupInfo(null, option, version, startBackupVersion, backupId, parentBackupId));
+            Assert.Equal(nameof(directory), e.ParamName);
+        }
+    }
+
+    public abstract class BackupVersionTest
+    {
+        readonly BackupVersion sut;
+
+        readonly Epoch epoch = new(SafeInt64(), SafeInt64());
+        readonly long lsn = SafeInt64(); // logical sequence number
+
+        BackupVersionTest() =>
+            sut = new BackupVersion(epoch, lsn);
+
+        public sealed class Constructor : BackupVersionTest
+        {
+            [Fact]
+            public void InitializesProperties()
+            {
+                Assert.Equal(epoch, sut.Epoch);
+                Assert.Equal(lsn, sut.Lsn);
+            }
+        }
+
+        public sealed class CompareTo : BackupVersionTest
+        {
+            [Fact]
+            public void ReturnsZeroWhenOtherEqualsThis() =>
+                Assert.Equal(0, sut.CompareTo(new BackupVersion(epoch, lsn)));
+
+            [Fact]
+            public void ReturnsNegativeWhenOtherEpochIsHigher() =>
+                Assert.True(sut.CompareTo(new BackupVersion(new Epoch(epoch.DataLossNumber + 1, epoch.ConfigurationNumber), lsn)) < 0);
+
+            [Fact]
+            public void ReturnsPositiveWhenOtherEpochIsLower() =>
+                Assert.True(sut.CompareTo(new BackupVersion(new Epoch(epoch.DataLossNumber - 1, epoch.ConfigurationNumber), lsn)) > 0);
+
+            [Fact]
+            public void ReturnsNegativeWhenOtherLsnIsHigher() =>
+                Assert.True(sut.CompareTo(new BackupVersion(epoch, lsn + 1)) < 0);
+
+            [Fact]
+            public void ReturnsPositiveWhenOtherLsnIsLower() =>
+                Assert.True(sut.CompareTo(new BackupVersion(epoch, lsn - 1)) > 0);
+
+            [Fact]
+            public void PrioritizesEpochOverLsn() =>
+                Assert.True(sut.CompareTo(new BackupVersion(new Epoch(epoch.DataLossNumber + 1, epoch.ConfigurationNumber), lsn - 1)) < 0);
+        }
+
+        public sealed class Equals_BackupVersion : BackupVersionTest
+        {
+            [Fact]
+            public void ReturnsTrueWhenOtherEqualsThis() =>
+                Assert.True(sut.Equals(new BackupVersion(epoch, lsn)));
+
+            [Fact]
+            public void ReturnsFalseWhenOtherDiffers() =>
+                Assert.False(sut.Equals(new BackupVersion(epoch, lsn + 1)));
+        }
+
+        public sealed class Equals_Object : BackupVersionTest
+        {
+            [Fact]
+            public void ReturnsTrueWhenObjEqualsThis() =>
+                Assert.True(sut.Equals((object)new BackupVersion(epoch, lsn)));
+
+            [Fact]
+            public void ReturnsFalseWhenObjIsNull() =>
+                Assert.False(sut.Equals(null));
+
+            [Fact]
+            public void ReturnsFalseWhenObjIsNotBackupVersion() =>
+                Assert.False(sut.Equals(new object()));
+        }
+
+        public new sealed class GetHashCode : BackupVersionTest
+        {
+            [Fact]
+            public void ReturnsSameValueForEqualVersions() =>
+                Assert.Equal(sut.GetHashCode(), new BackupVersion(epoch, lsn).GetHashCode());
+
+            [Fact]
+            public void VariesWithDataLossNumber() =>
+                Assert.NotEqual(
+                    sut.GetHashCode(),
+                    new BackupVersion(new Epoch(epoch.DataLossNumber + 1, epoch.ConfigurationNumber), lsn).GetHashCode());
+
+            [Fact]
+            public void VariesWithConfigurationNumber() =>
+                Assert.NotEqual(
+                    sut.GetHashCode(),
+                    new BackupVersion(new Epoch(epoch.DataLossNumber, epoch.ConfigurationNumber + 1), lsn).GetHashCode());
+
+            [Fact]
+            public void VariesWithLsn() =>
+                Assert.NotEqual(
+                    sut.GetHashCode(),
+                    new BackupVersion(epoch, lsn + 1).GetHashCode());
+        }
+
+        public sealed class InvalidBackupVersion : BackupVersionTest
+        {
+            [Fact]
+            public void RepresentsInvalidEpochAndLsn()
+            {
+                BackupVersion invalid = BackupVersion.InvalidBackupVersion;
+                Assert.Equal(-1, invalid.Epoch.DataLossNumber);
+                Assert.Equal(-1, invalid.Epoch.ConfigurationNumber);
+                Assert.Equal(-1, invalid.Lsn);
+            }
+        }
+
+        // Constrain to leave headroom for +1 arithmetic and avoid -1, whose Int64.GetHashCode() collides with 0.
+        static long SafeInt64() => fuzzy.Int64().Minimum(0).Maximum(long.MaxValue - 1);
+    }
+
+    public new sealed class ToString : BackupInfoTest
+    {
+        [Theory, InlineData(BackupOption.Full, "Backup folder: {0}, backup option: Full")]
+        [InlineData(BackupOption.Incremental, "Backup folder: {0}, backup option: Incremental")]
+        public void ReturnsFormattedString(BackupOption option, string format)
+        {
+            var sut = new BackupInfo(directory, option, version);
+            Assert.Equal(string.Format(format, directory), sut.ToString());
+        }
+    }
+}

--- a/test/Data.Interfaces/Collections/QueueFullExceptionTest.cs
+++ b/test/Data.Interfaces/Collections/QueueFullExceptionTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Collections;
+
+public abstract class QueueFullExceptionTest
+{
+    // Constructor parameters
+    readonly string msg = fuzzy.String(); // mirrors SUT parameter name
+    readonly Exception innerException = new();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class Constructor_String : QueueFullExceptionTest
+    {
+        [Fact]
+        public void SetsMessage() =>
+            Assert.Same(msg, new QueueFullException(msg).Message);
+    }
+
+    public sealed class Constructor_String_Exception : QueueFullExceptionTest
+    {
+        [Fact]
+        public void SetsMessageAndInnerException()
+        {
+            var sut = new QueueFullException(msg, innerException);
+            Assert.Same(msg, sut.Message);
+            Assert.Same(innerException, sut.InnerException);
+        }
+    }
+}

--- a/test/Data.Interfaces/ConditionalValueTest.cs
+++ b/test/Data.Interfaces/ConditionalValueTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class ConditionalValueTest
+{
+    // Constructor parameters
+    readonly string value = fuzzy.String();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class HasValue : ConditionalValueTest
+    {
+        [Theory, InlineData(true), InlineData(false)]
+        public void ReturnsHasValueConstructorArgument(bool expected) =>
+            Assert.Equal(expected, new ConditionalValue<string>(hasValue: expected, value).HasValue);
+    }
+
+    public sealed class Value : ConditionalValueTest
+    {
+        [Fact]
+        public void ReturnsValueConstructorArgumentWhenHasValueIsTrue() =>
+            Assert.Same(value, new ConditionalValue<string>(hasValue: true, value).Value);
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Value returns stored value when HasValue is false.
+        public void IsDefaultWhenHasValueIsFalse() =>
+            // XML doc on ConditionalValue<TValue>.Value says it returns default(TValue)
+            // when HasValue is false; actual impl returns the stored value.
+            Assert.Null(new ConditionalValue<string>(hasValue: false, value).Value);
+    }
+}

--- a/test/Data.Interfaces/IFuzzExtensions.cs
+++ b/test/Data.Interfaces/IFuzzExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System.Fabric;
+using Fuzzy;
+using BackupVersion = Microsoft.ServiceFabric.Data.BackupInfo.BackupVersion;
+
+namespace Microsoft.ServiceFabric.Data;
+
+static class IFuzzExtensions
+{
+    internal static Epoch Epoch(this IFuzz fuzzy) =>
+        new(fuzzy.Int64(), fuzzy.Int64());
+
+    internal static BackupVersion BackupVersion(this IFuzz fuzzy) =>
+        new(fuzzy.Epoch(), fuzzy.Int64());
+}

--- a/test/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.Tests.csproj
+++ b/test/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.ServiceFabric.Data</RootNamespace>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <Import Project="..\..\properties\service_fabric_managed_common.props" />
+  <ItemGroup>
+    <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Data.Interfaces\Microsoft.ServiceFabric.Data.Interfaces.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryChangedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryChangedEventArgsTest.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryChangedEventArgsTest
+{
+    public sealed class Action : NotifyDictionaryChangedEventArgsTest
+    {
+        [Theory]
+        [InlineData(NotifyDictionaryChangedAction.Add)]
+        [InlineData(NotifyDictionaryChangedAction.Update)]
+        [InlineData(NotifyDictionaryChangedAction.Remove)]
+        [InlineData(NotifyDictionaryChangedAction.Clear)]
+        [InlineData(NotifyDictionaryChangedAction.Rebuild)]
+        public void ReturnsActionPassedToConstructor(NotifyDictionaryChangedAction action) =>
+            Assert.Equal(action, new TestArgs(action).Action);
+
+        sealed class TestArgs(NotifyDictionaryChangedAction action) : NotifyDictionaryChangedEventArgs<string, int>(action);
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryClearEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryClearEventArgsTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryClearEventArgsTest
+{
+    readonly NotifyDictionaryClearEventArgs<string, int> sut;
+
+    // Constructor parameters
+    readonly long commitSequenceNumber = fuzzy.Int64();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyDictionaryClearEventArgsTest() =>
+        sut = new NotifyDictionaryClearEventArgs<string, int>(commitSequenceNumber);
+
+    public sealed class Constructor : NotifyDictionaryClearEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Equal(commitSequenceNumber, sut.CommitSequenceNumber);
+            Assert.Equal(NotifyDictionaryChangedAction.Clear, sut.Action);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryItemAddedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryItemAddedEventArgsTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryItemAddedEventArgsTest
+{
+    readonly NotifyDictionaryItemAddedEventArgs<string, int> sut;
+
+    // Constructor parameters
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly string key = fuzzy.String();
+    readonly int value = fuzzy.Int32();
+
+    // Test fixture
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyDictionaryItemAddedEventArgsTest() =>
+        sut = new NotifyDictionaryItemAddedEventArgs<string, int>(transaction, key, value);
+
+    public sealed class Constructor : NotifyDictionaryItemAddedEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(transaction, sut.Transaction);
+            Assert.Same(key, sut.Key);
+            Assert.Equal(value, sut.Value);
+            Assert.Equal(NotifyDictionaryChangedAction.Add, sut.Action);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryItemRemovedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryItemRemovedEventArgsTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryItemRemovedEventArgsTest
+{
+    readonly NotifyDictionaryItemRemovedEventArgs<string, int> sut;
+
+    // Constructor parameters
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly string key = fuzzy.String();
+
+    // Test fixture
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyDictionaryItemRemovedEventArgsTest() =>
+        sut = new NotifyDictionaryItemRemovedEventArgs<string, int>(transaction, key);
+
+    public sealed class Constructor : NotifyDictionaryItemRemovedEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(transaction, sut.Transaction);
+            Assert.Same(key, sut.Key);
+            Assert.Equal(NotifyDictionaryChangedAction.Remove, sut.Action);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryItemUpdatedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryItemUpdatedEventArgsTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryItemUpdatedEventArgsTest
+{
+    readonly NotifyDictionaryItemUpdatedEventArgs<string, int> sut;
+
+    // Constructor parameters
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly string key = fuzzy.String();
+    readonly int value = fuzzy.Int32();
+
+    // Test fixture
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyDictionaryItemUpdatedEventArgsTest() =>
+        sut = new NotifyDictionaryItemUpdatedEventArgs<string, int>(transaction, key, value);
+
+    public sealed class Constructor : NotifyDictionaryItemUpdatedEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(transaction, sut.Transaction);
+            Assert.Same(key, sut.Key);
+            Assert.Equal(value, sut.Value);
+            Assert.Equal(NotifyDictionaryChangedAction.Update, sut.Action);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryRebuildEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryRebuildEventArgsTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Inspector;
+using Moq;
+using Xunit;
+using IAsyncEnumerable = Microsoft.ServiceFabric.Data.IAsyncEnumerable<System.Collections.Generic.KeyValuePair<string, int>>;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryRebuildEventArgsTest
+{
+    readonly NotifyDictionaryRebuildEventArgs<string, int> sut;
+    readonly IAsyncEnumerable enumerableState = Mock.Of<IAsyncEnumerable>(); // Consistency with SUT parameter name
+
+    NotifyDictionaryRebuildEventArgsTest() =>
+        sut = new NotifyDictionaryRebuildEventArgs<string, int>(enumerableState);
+
+    public sealed class Constructor : NotifyDictionaryRebuildEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(enumerableState, sut.State);
+            Assert.Equal(NotifyDictionaryChangedAction.Rebuild, sut.Action);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers enumerating State will NRE.
+        public void ThrowsArgumentNullExceptionWhenEnumerableStateIsNull()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() => new NotifyDictionaryRebuildEventArgs<string, int>(null));
+            Assert.Equal(sut.Constructor().Parameter<IAsyncEnumerable>().Name, e.ParamName);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyDictionaryTransactionalEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyDictionaryTransactionalEventArgsTest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Inspector;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyDictionaryTransactionalEventArgsTest
+{
+    readonly NotifyDictionaryTransactionalEventArgs<string, int> sut;
+
+    // Constructor parameters
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly NotifyDictionaryChangedAction action = fuzzy.Enum<NotifyDictionaryChangedAction>();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyDictionaryTransactionalEventArgsTest() =>
+        sut = new TestArgs(transaction, action);
+
+    public sealed class Constructor : NotifyDictionaryTransactionalEventArgsTest
+    {
+        [Fact]
+        public void SetsTransaction() =>
+            Assert.Same(transaction, sut.Transaction);
+
+        [Theory]
+        [InlineData(NotifyDictionaryChangedAction.Add)]
+        [InlineData(NotifyDictionaryChangedAction.Update)]
+        [InlineData(NotifyDictionaryChangedAction.Remove)]
+        [InlineData(NotifyDictionaryChangedAction.Clear)]
+        [InlineData(NotifyDictionaryChangedAction.Rebuild)]
+        public void ForwardsActionToBaseClass(NotifyDictionaryChangedAction action) =>
+            Assert.Equal(action, new TestArgs(transaction, action).Action);
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing Transaction will NRE.
+        public void ThrowsArgumentNullExceptionWhenTransactionIsNull()
+        {
+            // The constructor stores the transaction argument verbatim without a null check, so passing null
+            // succeeds here and the NullReferenceException only surfaces later when a consumer dereferences
+            // Transaction. Validating the argument up front would fail fast at the call site that supplied null.
+            var e = Assert.Throws<ArgumentNullException>(() => new TestArgs(null, action));
+            Assert.Equal(sut.Constructor().Parameter<ITransaction>().Name, e.ParamName);
+        }
+    }
+
+    sealed class TestArgs(ITransaction transaction, NotifyDictionaryChangedAction action)
+        : NotifyDictionaryTransactionalEventArgs<string, int>(transaction, action);
+}

--- a/test/Data.Interfaces/Notifications/NotifyStateManagerChangedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyStateManagerChangedEventArgsTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyStateManagerChangedEventArgsTest
+{
+    public sealed class Action : NotifyStateManagerChangedEventArgsTest
+    {
+        [Theory]
+        [InlineData(NotifyStateManagerChangedAction.Add)]
+        [InlineData(NotifyStateManagerChangedAction.Remove)]
+        [InlineData(NotifyStateManagerChangedAction.Rebuild)]
+        public void ReturnsActionPassedToConstructor(NotifyStateManagerChangedAction action) =>
+            Assert.Equal(action, new TestArgs(action).Action);
+
+        sealed class TestArgs(NotifyStateManagerChangedAction action) : NotifyStateManagerChangedEventArgs(action);
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyStateManagerRebuildEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyStateManagerRebuildEventArgsTest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Inspector;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyStateManagerRebuildEventArgsTest
+{
+    readonly NotifyStateManagerRebuildEventArgs sut;
+    readonly IAsyncEnumerable<IReliableState> reliableStates = Mock.Of<IAsyncEnumerable<IReliableState>>();
+
+    NotifyStateManagerRebuildEventArgsTest() =>
+        sut = new NotifyStateManagerRebuildEventArgs(reliableStates);
+
+    public sealed class Constructor : NotifyStateManagerRebuildEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(reliableStates, sut.ReliableStates);
+            Assert.Equal(NotifyStateManagerChangedAction.Rebuild, sut.Action);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers enumerating ReliableStates will NRE.
+        public void ThrowsArgumentNullExceptionWhenReliableStatesIsNull()
+        {
+            // The constructor stores the reliableStates argument verbatim without a null check, so passing null
+            // succeeds here and the NullReferenceException only surfaces later when a consumer enumerates
+            // ReliableStates. Validating the argument up front would fail fast at the call site that supplied null.
+            var e = Assert.Throws<ArgumentNullException>(() => new NotifyStateManagerRebuildEventArgs(null));
+            Assert.Equal(sut.Constructor().Parameter<IAsyncEnumerable<IReliableState>>().Name, e.ParamName);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyStateManagerSingleEntityChangedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyStateManagerSingleEntityChangedEventArgsTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyStateManagerSingleEntityChangedEventArgsTest
+{
+    readonly NotifyStateManagerSingleEntityChangedEventArgs sut;
+
+    // Constructor parameters
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly IReliableState reliableState = Mock.Of<IReliableState>();
+    readonly NotifyStateManagerChangedAction action = fuzzy.Enum<NotifyStateManagerChangedAction>();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    NotifyStateManagerSingleEntityChangedEventArgsTest() =>
+        sut = new NotifyStateManagerSingleEntityChangedEventArgs(transaction, reliableState, action);
+
+    public sealed class Constructor : NotifyStateManagerSingleEntityChangedEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(transaction, sut.Transaction);
+            Assert.Same(reliableState, sut.ReliableState);
+        }
+
+        [Theory]
+        [InlineData(NotifyStateManagerChangedAction.Add)]
+        [InlineData(NotifyStateManagerChangedAction.Remove)]
+        [InlineData(NotifyStateManagerChangedAction.Rebuild)]
+        public void ForwardsActionToBase(NotifyStateManagerChangedAction action) =>
+            Assert.Equal(action, new NotifyStateManagerSingleEntityChangedEventArgs(transaction, reliableState, action).Action);
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing Transaction will NRE.
+        public void ThrowsArgumentNullExceptionWhenTransactionIsNull()
+        {
+            // The constructor stores the transaction argument verbatim without a null check, so passing null
+            // succeeds here and the NullReferenceException only surfaces later when a consumer dereferences
+            // Transaction. Validating the argument up front would fail fast at the call site that supplied null.
+            var e = Assert.Throws<ArgumentNullException>(() => new NotifyStateManagerSingleEntityChangedEventArgs(null, reliableState, action));
+            Assert.Equal(nameof(transaction), e.ParamName);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing ReliableState will NRE.
+        public void ThrowsArgumentNullExceptionWhenReliableStateIsNull()
+        {
+            // The constructor stores the reliableState argument verbatim without a null check, so passing null
+            // succeeds here and the NullReferenceException only surfaces later when a consumer dereferences
+            // ReliableState. Validating the argument up front would fail fast at the call site that supplied null.
+            var e = Assert.Throws<ArgumentNullException>(() => new NotifyStateManagerSingleEntityChangedEventArgs(transaction, null, action));
+            Assert.Equal(nameof(reliableState), e.ParamName);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyTransactionChangedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyTransactionChangedEventArgsTest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data.Notifications;
+
+public abstract class NotifyTransactionChangedEventArgsTest
+{
+    readonly NotifyTransactionChangedEventArgs sut;
+    readonly ITransaction transaction = Mock.Of<ITransaction>();
+    readonly NotifyTransactionChangedAction action = (NotifyTransactionChangedAction)1;
+
+    NotifyTransactionChangedEventArgsTest() =>
+        sut = new NotifyTransactionChangedEventArgs(transaction, action);
+
+    public sealed class Constructor : NotifyTransactionChangedEventArgsTest
+    {
+        [Fact]
+        public void InitializesProperties()
+        {
+            Assert.Same(transaction, sut.Transaction);
+            Assert.Equal(action, sut.Action);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing Transaction will NRE.
+        public void ThrowsArgumentNullExceptionWhenTransactionIsNull()
+        {
+            // The constructor stores the transaction argument verbatim without a null check, so passing null
+            // succeeds here and the NullReferenceException only surfaces later when a consumer dereferences
+            // Transaction. Validating the argument up front would fail fast at the call site that supplied null.
+            var e = Assert.Throws<ArgumentNullException>(() => new NotifyTransactionChangedEventArgs(null, action));
+            Assert.Equal(nameof(transaction), e.ParamName);
+        }
+    }
+}

--- a/test/Data.Interfaces/Notifications/NotifyTransactionChangedEventArgsTest.cs
+++ b/test/Data.Interfaces/Notifications/NotifyTransactionChangedEventArgsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 
 using System;
+using Inspector;
 using Moq;
 using Xunit;
 
@@ -9,24 +10,21 @@ namespace Microsoft.ServiceFabric.Data.Notifications;
 
 public abstract class NotifyTransactionChangedEventArgsTest
 {
-    readonly NotifyTransactionChangedEventArgs sut;
     readonly ITransaction transaction = Mock.Of<ITransaction>();
-    readonly NotifyTransactionChangedAction action = (NotifyTransactionChangedAction)1;
-
-    NotifyTransactionChangedEventArgsTest() =>
-        sut = new NotifyTransactionChangedEventArgs(transaction, action);
 
     public sealed class Constructor : NotifyTransactionChangedEventArgsTest
     {
-        [Fact]
-        public void InitializesProperties()
+        [Theory, InlineData(NotifyTransactionChangedAction.Commit)] // single-item enum
+        public void InitializesProperties(NotifyTransactionChangedAction action)
         {
+            NotifyTransactionChangedEventArgs sut = new(transaction, action);
+
             Assert.Same(transaction, sut.Transaction);
             Assert.Equal(action, sut.Action);
         }
 
-        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing Transaction will NRE.
-        public void ThrowsArgumentNullExceptionWhenTransactionIsNull()
+        [Theory(Explicit = true), InlineData(NotifyTransactionChangedAction.Commit)] // TODO: SUT bug. Constructor doesn't validate; consumers dereferencing Transaction will NRE.
+        public void ThrowsArgumentNullExceptionWhenTransactionIsNull(NotifyTransactionChangedAction action)
         {
             // The constructor stores the transaction argument verbatim without a null check, so passing null
             // succeeds here and the NullReferenceException only surfaces later when a consumer dereferences

--- a/test/Data.Interfaces/ReliableStateManagerConfigurationTest.cs
+++ b/test/Data.Interfaces/ReliableStateManagerConfigurationTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class ReliableStateManagerConfigurationTest
+{
+    readonly ReliableStateManagerConfiguration sut;
+
+    // Constructor parameters
+    readonly string configPackageName = fuzzy.String();
+    readonly string replicatorSecuritySectionName = fuzzy.String();
+    readonly string replicatorSettingsSectionName = fuzzy.String();
+    readonly Func<Task> onInitializeStateSerializersEvent = static () => Task.CompletedTask;
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    ReliableStateManagerConfigurationTest() =>
+        sut = new ReliableStateManagerConfiguration(
+            configPackageName,
+            replicatorSecuritySectionName,
+            replicatorSettingsSectionName,
+            onInitializeStateSerializersEvent);
+
+    public sealed class Constructor_ReliableStateManagerReplicatorSettings_FuncOfTask : ReliableStateManagerConfigurationTest
+    {
+        readonly ReliableStateManagerReplicatorSettings replicatorSettings = new();
+
+        [Fact]
+        public void SetsAllProperties()
+        {
+            var sut = new ReliableStateManagerConfiguration(replicatorSettings, onInitializeStateSerializersEvent);
+
+            Assert.Same(replicatorSettings, sut.ReplicatorSettings);
+            Assert.Null(sut.ConfigPackageName);
+            Assert.Null(sut.ReplicatorSecuritySectionName);
+            Assert.Null(sut.ReplicatorSettingsSectionName);
+            Assert.Same(onInitializeStateSerializersEvent, sut.OnInitializeStateSerializersEvent);
+        }
+    }
+
+    public sealed class Constructor_String_String_String_FuncOfTask : ReliableStateManagerConfigurationTest
+    {
+        [Fact]
+        public async Task SetsAllPropertiesToDefaultsWhenCalledWithoutArguments()
+        {
+            var sut = new ReliableStateManagerConfiguration();
+
+            Assert.Null(sut.ReplicatorSettings);
+            Assert.Equal("Config", sut.ConfigPackageName);
+            Assert.Equal("ReplicatorSecurityConfig", sut.ReplicatorSecuritySectionName);
+            Assert.Equal("ReplicatorConfig", sut.ReplicatorSettingsSectionName);
+            await sut.OnInitializeStateSerializersEvent();
+        }
+
+        [Fact]
+        public void SetsAllProperties()
+        {
+            Assert.Null(sut.ReplicatorSettings);
+            Assert.Same(configPackageName, sut.ConfigPackageName);
+            Assert.Same(replicatorSecuritySectionName, sut.ReplicatorSecuritySectionName);
+            Assert.Same(replicatorSettingsSectionName, sut.ReplicatorSettingsSectionName);
+            Assert.Same(onInitializeStateSerializersEvent, sut.OnInitializeStateSerializersEvent);
+        }
+    }
+}

--- a/test/Data.Interfaces/ReliableStateManagerReplicatorSettingsTest.cs
+++ b/test/Data.Interfaces/ReliableStateManagerReplicatorSettingsTest.cs
@@ -1,0 +1,789 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Fabric;
+using System.Runtime.CompilerServices;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class ReliableStateManagerReplicatorSettingsTest
+{
+    readonly ReliableStateManagerReplicatorSettings sut = new();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class BatchAcknowledgementInterval : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            TimeSpan expected = fuzzy.TimeSpan();
+            sut.BatchAcknowledgementInterval = expected;
+            Assert.Equal(expected, sut.BatchAcknowledgementInterval);
+        }
+    }
+
+    public sealed class CheckpointThresholdInMB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.CheckpointThresholdInMB = expected;
+            Assert.Equal(expected, sut.CheckpointThresholdInMB);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class EnableIncrementalBackupsAcrossReplicas : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.EnableIncrementalBackupsAcrossReplicas = value;
+            Assert.Equal(value, sut.EnableIncrementalBackupsAcrossReplicas);
+        }
+    }
+#endif
+
+#if NETFRAMEWORK
+    public sealed class EnableSendWindowSizeInBytes : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.EnableSendWindowSizeInBytes = value;
+            Assert.Equal(value, sut.EnableSendWindowSizeInBytes);
+        }
+    }
+#endif
+
+    public new sealed class Equals : ReliableStateManagerReplicatorSettingsTest
+    {
+        new readonly object sut;
+        readonly object obj;
+
+        // Typed views of sut and obj used to mutate properties during setup and in tests; the SUT's Equals override accepts object.
+        readonly ReliableStateManagerReplicatorSettings sutSettings;
+        readonly ReliableStateManagerReplicatorSettings objSettings;
+
+        readonly string sharedLogId = fuzzy.String();
+        readonly string sharedLogPath = fuzzy.String();
+        readonly int maxStreamSizeInMB = fuzzy.Int32();
+        readonly int maxRecordSizeInKB = fuzzy.Int32();
+        readonly int maxMetadataSizeInKB = fuzzy.Int32();
+        readonly int checkpointThresholdInMB = fuzzy.Int32();
+        readonly int maxAccumulatedBackupLogSizeInMB = fuzzy.Int32();
+        readonly int minLogSizeInMB = fuzzy.Int32();
+        readonly int truncationThresholdFactor = fuzzy.Int32();
+        readonly int throttlingThresholdFactor = fuzzy.Int32();
+        // Cap leaves headroom for + fuzzy.TimeSpan().Seconds() in Differs tests; SUT does not cap this.
+        readonly TimeSpan slowApiMonitoringDuration = fuzzy.TimeSpan().Maximum(TimeSpan.MaxValue - TimeSpan.FromMinutes(1));
+#if NETFRAMEWORK
+        readonly int logTruncationIntervalSeconds = fuzzy.Int32();
+        readonly uint maxReplicationQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        readonly uint maxCopyQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        readonly uint initialReplicaHeapSizeInKB = fuzzy.UInt32();
+#endif
+
+        public Equals()
+        {
+            sutSettings = Populate(new());
+            sut = sutSettings;
+
+            objSettings = Populate(new());
+            obj = objSettings;
+
+            ReliableStateManagerReplicatorSettings Populate(ReliableStateManagerReplicatorSettings s)
+            {
+                s.SharedLogId = sharedLogId;
+                s.SharedLogPath = sharedLogPath;
+                s.MaxStreamSizeInMB = maxStreamSizeInMB;
+                s.MaxRecordSizeInKB = maxRecordSizeInKB;
+                s.MaxMetadataSizeInKB = maxMetadataSizeInKB;
+                s.OptimizeForLocalSSD = true;
+                s.OptimizeLogForLowerDiskUsage = true;
+                s.CheckpointThresholdInMB = checkpointThresholdInMB;
+                s.MaxAccumulatedBackupLogSizeInMB = maxAccumulatedBackupLogSizeInMB;
+                s.MinLogSizeInMB = minLogSizeInMB;
+                s.TruncationThresholdFactor = truncationThresholdFactor;
+                s.ThrottlingThresholdFactor = throttlingThresholdFactor;
+                s.SlowApiMonitoringDuration = slowApiMonitoringDuration;
+#if NETFRAMEWORK
+                s.LogTruncationIntervalSeconds = logTruncationIntervalSeconds;
+                s.EnableIncrementalBackupsAcrossReplicas = true;
+                s.EnableSendWindowSizeInBytes = true;
+                s.MaxReplicationQueueSendWindowSizeInBytes = maxReplicationQueueSendWindowSizeInBytes;
+                s.MaxCopyQueueSendWindowSizeInBytes = maxCopyQueueSendWindowSizeInBytes;
+                s.UseIndividualHeapPerReplica = true;
+                s.InitialReplicaHeapSizeInKB = initialReplicaHeapSizeInKB;
+#endif
+                return s;
+            }
+        }
+
+        [Fact]
+        public void ReturnsTrueWhenAllPropertiesMatch() =>
+            Assert.True(sut.Equals(obj));
+
+        [Theory, InlineData(false), InlineData(null)]
+        public void ReturnsTrueWhenNullableBoolPropertiesMatch(bool? value)
+        {
+            sutSettings.OptimizeForLocalSSD = value;
+            sutSettings.OptimizeLogForLowerDiskUsage = value;
+            objSettings.OptimizeForLocalSSD = value;
+            objSettings.OptimizeLogForLowerDiskUsage = value;
+#if NETFRAMEWORK
+            sutSettings.EnableIncrementalBackupsAcrossReplicas = value;
+            sutSettings.EnableSendWindowSizeInBytes = value;
+            sutSettings.UseIndividualHeapPerReplica = value;
+            objSettings.EnableIncrementalBackupsAcrossReplicas = value;
+            objSettings.EnableSendWindowSizeInBytes = value;
+            objSettings.UseIndividualHeapPerReplica = value;
+#endif
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsNull() =>
+            Assert.False(sut.Equals(null));
+
+        [Fact]
+        public void ReturnsFalseWhenObjIsDerivedType() =>
+            Assert.False(sut.Equals(new DerivedSettings()));
+
+        [Theory, MemberData(nameof(DifferingV2PropertyMutations))]
+        public void ReturnsFalseWhenPropertyDiffers(string _, Action<ReliableStateManagerReplicatorSettings, ReliableStateManagerReplicatorSettings> differ)
+        {
+            differ(sutSettings, objSettings);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, MemberData(nameof(NullableV2Properties))]
+        public void ReturnsFalseWhenSutPropertyIsNull(string _, Action<ReliableStateManagerReplicatorSettings> setNull)
+        {
+            setNull(sutSettings);
+            Assert.False(sut.Equals(obj));
+        }
+
+        [Theory, MemberData(nameof(NullableV2Properties))]
+        public void ReturnsTrueWhenObjPropertyIsNull(string _, Action<ReliableStateManagerReplicatorSettings> setNull)
+        {
+            setNull(objSettings);
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, MemberData(nameof(EmptyV2StringProperties))]
+        public void ReturnsTrueWhenObjPropertyIsEmpty(string _, Action<ReliableStateManagerReplicatorSettings> setEmpty)
+        {
+            setEmpty(objSettings);
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Theory, MemberData(nameof(NonV2Mutations))]
+        public void IgnoresNonV2Property(string _, Action<ReliableStateManagerReplicatorSettings> mutate)
+        {
+            mutate(objSettings);
+            Assert.True(sut.Equals(obj));
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Equals is asymmetric.
+        public void IsSymmetric()
+        {
+            // InternalEquals only inspects properties set on the right-hand side, so sut.Equals(sparse) returns true
+            // while sparse.Equals(sut) returns false, violating the Object.Equals symmetry contract.
+            var sparse = new ReliableStateManagerReplicatorSettings();
+            Assert.Equal(sut.Equals(sparse), sparse.Equals(sut));
+        }
+
+        public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings>> EmptyV2StringProperties { get; } = new()
+        {
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogId), static o => o.SharedLogId = string.Empty },
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogPath), static o => o.SharedLogPath = string.Empty },
+        };
+
+        public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings, ReliableStateManagerReplicatorSettings>> DifferingV2PropertyMutations { get; } = new()
+        {
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogId), static (s, o) => o.SharedLogId = s.SharedLogId + fuzzy.String() },
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogPath), static (s, o) => o.SharedLogPath = s.SharedLogPath + fuzzy.String() },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxStreamSizeInMB), static (s, o) => o.MaxStreamSizeInMB = s.MaxStreamSizeInMB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxRecordSizeInKB), static (s, o) => o.MaxRecordSizeInKB = s.MaxRecordSizeInKB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxMetadataSizeInKB), static (s, o) => o.MaxMetadataSizeInKB = s.MaxMetadataSizeInKB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeForLocalSSD), static (s, o) => o.OptimizeForLocalSSD = false },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeLogForLowerDiskUsage), static (s, o) => o.OptimizeLogForLowerDiskUsage = false },
+            { nameof(ReliableStateManagerReplicatorSettings.CheckpointThresholdInMB), static (s, o) => o.CheckpointThresholdInMB = s.CheckpointThresholdInMB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxAccumulatedBackupLogSizeInMB), static (s, o) => o.MaxAccumulatedBackupLogSizeInMB = s.MaxAccumulatedBackupLogSizeInMB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.MinLogSizeInMB), static (s, o) => o.MinLogSizeInMB = s.MinLogSizeInMB + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.TruncationThresholdFactor), static (s, o) => o.TruncationThresholdFactor = s.TruncationThresholdFactor + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.ThrottlingThresholdFactor), static (s, o) => o.ThrottlingThresholdFactor = s.ThrottlingThresholdFactor + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.SlowApiMonitoringDuration), static (s, o) => o.SlowApiMonitoringDuration = s.SlowApiMonitoringDuration + fuzzy.TimeSpan().Seconds() },
+#if NETFRAMEWORK
+            { nameof(ReliableStateManagerReplicatorSettings.LogTruncationIntervalSeconds), static (s, o) => o.LogTruncationIntervalSeconds = s.LogTruncationIntervalSeconds + fuzzy.SByte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableIncrementalBackupsAcrossReplicas), static (s, o) => o.EnableIncrementalBackupsAcrossReplicas = false },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableSendWindowSizeInBytes), static (s, o) => o.EnableSendWindowSizeInBytes = false },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxReplicationQueueSendWindowSizeInBytes), static (s, o) => o.MaxReplicationQueueSendWindowSizeInBytes = s.MaxReplicationQueueSendWindowSizeInBytes + fuzzy.Byte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxCopyQueueSendWindowSizeInBytes), static (s, o) => o.MaxCopyQueueSendWindowSizeInBytes = s.MaxCopyQueueSendWindowSizeInBytes + fuzzy.Byte().Between(1, 5) },
+            { nameof(ReliableStateManagerReplicatorSettings.UseIndividualHeapPerReplica), static (s, o) => o.UseIndividualHeapPerReplica = false },
+            { nameof(ReliableStateManagerReplicatorSettings.InitialReplicaHeapSizeInKB), static (s, o) => o.InitialReplicaHeapSizeInKB = s.InitialReplicaHeapSizeInKB + fuzzy.Byte().Between(1, 5) },
+#endif
+        };
+
+        sealed class DerivedSettings : ReliableStateManagerReplicatorSettings { }
+    }
+
+    public new sealed class GetHashCode : ReliableStateManagerReplicatorSettingsTest
+    {
+        new readonly object sut;
+
+        public GetHashCode() => sut = base.sut;
+
+        [Fact]
+        public void ReturnsBaseImplementation() =>
+            Assert.Equal(RuntimeHelpers.GetHashCode(sut), sut.GetHashCode());
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Equals and GetHashCode are inconsistent.
+        public void IsConsistentWithEquals()
+        {
+            // GetHashCode returns the identity hash, so two instances that Equals reports as equal
+            // produce different hash codes, violating the Object.GetHashCode contract.
+            base.sut.SharedLogId = fuzzy.String();
+            object obj;
+            // Guarantee the assertion fails for the right reason rather than a spurious identity-hash collision.
+            do
+                obj = new ReliableStateManagerReplicatorSettings { SharedLogId = base.sut.SharedLogId };
+            while (RuntimeHelpers.GetHashCode(obj) == RuntimeHelpers.GetHashCode(sut));
+
+            Assert.True(sut.Equals(obj));
+            Assert.Equal(sut.GetHashCode(), obj.GetHashCode());
+        }
+    }
+
+    public sealed class InitialCopyQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.InitialCopyQueueSize = expected;
+            Assert.Equal(expected, sut.InitialCopyQueueSize);
+        }
+    }
+
+    public sealed class InitialPrimaryReplicationQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.InitialPrimaryReplicationQueueSize = expected;
+            Assert.Equal(expected, sut.InitialPrimaryReplicationQueueSize);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class InitialReplicaHeapSizeInKB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            uint expected = fuzzy.UInt32();
+            sut.InitialReplicaHeapSizeInKB = expected;
+            Assert.Equal(expected, sut.InitialReplicaHeapSizeInKB);
+        }
+    }
+#endif
+
+    public sealed class InitialSecondaryReplicationQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.InitialSecondaryReplicationQueueSize = expected;
+            Assert.Equal(expected, sut.InitialSecondaryReplicationQueueSize);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class LogTruncationIntervalSeconds : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.LogTruncationIntervalSeconds = expected;
+            Assert.Equal(expected, sut.LogTruncationIntervalSeconds);
+        }
+    }
+#endif
+
+    public sealed class MaxAccumulatedBackupLogSizeInMB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MaxAccumulatedBackupLogSizeInMB = expected;
+            Assert.Equal(expected, sut.MaxAccumulatedBackupLogSizeInMB);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class MaxCopyQueueSendWindowSizeInBytes : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            uint expected = fuzzy.UInt32();
+            sut.MaxCopyQueueSendWindowSizeInBytes = expected;
+            Assert.Equal(expected, sut.MaxCopyQueueSendWindowSizeInBytes);
+        }
+    }
+#endif
+
+    public sealed class MaxCopyQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxCopyQueueSize = expected;
+            Assert.Equal(expected, sut.MaxCopyQueueSize);
+        }
+    }
+
+    public sealed class MaxMetadataSizeInKB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MaxMetadataSizeInKB = expected;
+            Assert.Equal(expected, sut.MaxMetadataSizeInKB);
+        }
+    }
+
+    public sealed class MaxPrimaryReplicationQueueMemorySize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxPrimaryReplicationQueueMemorySize = expected;
+            Assert.Equal(expected, sut.MaxPrimaryReplicationQueueMemorySize);
+        }
+    }
+
+    public sealed class MaxPrimaryReplicationQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxPrimaryReplicationQueueSize = expected;
+            Assert.Equal(expected, sut.MaxPrimaryReplicationQueueSize);
+        }
+    }
+
+    public sealed class MaxRecordSizeInKB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MaxRecordSizeInKB = expected;
+            Assert.Equal(expected, sut.MaxRecordSizeInKB);
+        }
+    }
+
+    public sealed class MaxReplicationMessageSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxReplicationMessageSize = expected;
+            Assert.Equal(expected, sut.MaxReplicationMessageSize);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class MaxReplicationQueueSendWindowSizeInBytes : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            uint expected = fuzzy.UInt32();
+            sut.MaxReplicationQueueSendWindowSizeInBytes = expected;
+            Assert.Equal(expected, sut.MaxReplicationQueueSendWindowSizeInBytes);
+        }
+    }
+#endif
+
+    public sealed class MaxSecondaryReplicationQueueMemorySize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxSecondaryReplicationQueueMemorySize = expected;
+            Assert.Equal(expected, sut.MaxSecondaryReplicationQueueMemorySize);
+        }
+    }
+
+    public sealed class MaxSecondaryReplicationQueueSize : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            long expected = fuzzy.Int64();
+            sut.MaxSecondaryReplicationQueueSize = expected;
+            Assert.Equal(expected, sut.MaxSecondaryReplicationQueueSize);
+        }
+    }
+
+    public sealed class MaxStreamSizeInMB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MaxStreamSizeInMB = expected;
+            Assert.Equal(expected, sut.MaxStreamSizeInMB);
+        }
+    }
+
+    public sealed class MaxWriteQueueDepthInKB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MaxWriteQueueDepthInKB = expected;
+            Assert.Equal(expected, sut.MaxWriteQueueDepthInKB);
+        }
+    }
+
+    public sealed class MinLogSizeInMB : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.MinLogSizeInMB = expected;
+            Assert.Equal(expected, sut.MinLogSizeInMB);
+        }
+    }
+
+    public sealed class OptimizeForLocalSSD : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.OptimizeForLocalSSD = value;
+            Assert.Equal(value, sut.OptimizeForLocalSSD);
+        }
+    }
+
+    public sealed class OptimizeLogForLowerDiskUsage : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.OptimizeLogForLowerDiskUsage = value;
+            Assert.Equal(value, sut.OptimizeLogForLowerDiskUsage);
+        }
+    }
+
+    public sealed class ReplicatorAddress : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            string expected = fuzzy.String();
+            sut.ReplicatorAddress = expected;
+            Assert.Equal(expected, sut.ReplicatorAddress);
+        }
+    }
+
+    public sealed class ReplicatorListenAddress : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            string expected = fuzzy.String();
+            sut.ReplicatorListenAddress = expected;
+            Assert.Equal(expected, sut.ReplicatorListenAddress);
+        }
+    }
+
+    public sealed class ReplicatorPublishAddress : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            string expected = fuzzy.String();
+            sut.ReplicatorPublishAddress = expected;
+            Assert.Equal(expected, sut.ReplicatorPublishAddress);
+        }
+    }
+
+    public sealed class RetryInterval : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            TimeSpan expected = fuzzy.TimeSpan();
+            sut.RetryInterval = expected;
+            Assert.Equal(expected, sut.RetryInterval);
+        }
+    }
+
+    public sealed class SecondaryClearAcknowledgedOperations : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.SecondaryClearAcknowledgedOperations = value;
+            Assert.Equal(value, sut.SecondaryClearAcknowledgedOperations);
+        }
+    }
+
+    public sealed class SecurityCredentials : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            var expected = new NoneSecurityCredentials();
+            sut.SecurityCredentials = expected;
+            Assert.Same(expected, sut.SecurityCredentials);
+        }
+    }
+
+    public sealed class SharedLogId : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            string expected = fuzzy.String();
+            sut.SharedLogId = expected;
+            Assert.Equal(expected, sut.SharedLogId);
+        }
+    }
+
+    public sealed class SharedLogPath : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            string expected = fuzzy.String();
+            sut.SharedLogPath = expected;
+            Assert.Equal(expected, sut.SharedLogPath);
+        }
+    }
+
+    public sealed class SlowApiMonitoringDuration : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            TimeSpan expected = fuzzy.TimeSpan();
+            sut.SlowApiMonitoringDuration = expected;
+            Assert.Equal(expected, sut.SlowApiMonitoringDuration);
+        }
+    }
+
+    public sealed class ThrottlingThresholdFactor : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.ThrottlingThresholdFactor = expected;
+            Assert.Equal(expected, sut.ThrottlingThresholdFactor);
+        }
+    }
+
+    public new sealed class ToString : ReliableStateManagerReplicatorSettingsTest
+    {
+        new readonly object sut;
+        readonly ReliableStateManagerReplicatorSettings sutSettings;
+
+        readonly string sharedLogId = fuzzy.String();
+        readonly string sharedLogPath = fuzzy.String();
+        readonly int maxStreamSizeInMB = fuzzy.Int32();
+        readonly int maxMetadataSizeInKB = fuzzy.Int32();
+        readonly int maxRecordSizeInKB = fuzzy.Int32();
+        readonly int checkpointThresholdInMB = fuzzy.Int32();
+        readonly int maxAccumulatedBackupLogSizeInMB = fuzzy.Int32();
+        readonly TimeSpan slowApiMonitoringDuration = fuzzy.TimeSpan();
+        readonly int minLogSizeInMB = fuzzy.Int32();
+        readonly int truncationThresholdFactor = fuzzy.Int32();
+        readonly int throttlingThresholdFactor = fuzzy.Int32();
+#if NETFRAMEWORK
+        readonly int logTruncationIntervalSeconds = fuzzy.Int32();
+        readonly uint maxReplicationQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        readonly uint maxCopyQueueSendWindowSizeInBytes = fuzzy.UInt32();
+        readonly uint initialReplicaHeapSizeInKB = fuzzy.UInt32();
+#endif
+
+        public ToString()
+        {
+            sutSettings = new ReliableStateManagerReplicatorSettings
+            {
+                SharedLogId = sharedLogId,
+                SharedLogPath = sharedLogPath,
+                MaxStreamSizeInMB = maxStreamSizeInMB,
+                MaxMetadataSizeInKB = maxMetadataSizeInKB,
+                MaxRecordSizeInKB = maxRecordSizeInKB,
+                CheckpointThresholdInMB = checkpointThresholdInMB,
+                MaxAccumulatedBackupLogSizeInMB = maxAccumulatedBackupLogSizeInMB,
+                OptimizeForLocalSSD = true,
+                OptimizeLogForLowerDiskUsage = true,
+                SlowApiMonitoringDuration = slowApiMonitoringDuration,
+                MinLogSizeInMB = minLogSizeInMB,
+                TruncationThresholdFactor = truncationThresholdFactor,
+                ThrottlingThresholdFactor = throttlingThresholdFactor,
+#if NETFRAMEWORK
+                LogTruncationIntervalSeconds = logTruncationIntervalSeconds,
+                EnableIncrementalBackupsAcrossReplicas = true,
+                EnableSendWindowSizeInBytes = true,
+                MaxReplicationQueueSendWindowSizeInBytes = maxReplicationQueueSendWindowSizeInBytes,
+                MaxCopyQueueSendWindowSizeInBytes = maxCopyQueueSendWindowSizeInBytes,
+                UseIndividualHeapPerReplica = true,
+                InitialReplicaHeapSizeInKB = initialReplicaHeapSizeInKB,
+#endif
+            };
+            sut = sutSettings;
+        }
+
+        [Fact]
+        public void StartsWithNewLine() =>
+            Assert.StartsWith(Environment.NewLine, sut.ToString());
+
+        [Theory, MemberData(nameof(NonV2Mutations))]
+        public void ExcludesNonV2Property(string property, Action<ReliableStateManagerReplicatorSettings> mutate)
+        {
+            mutate(sutSettings);
+            Assert.DoesNotContain($"{property} = ", sut.ToString());
+        }
+
+        [Theory, MemberData(nameof(SetV2Properties))]
+        public void IncludesPropertyWhenSet(string property, Action<ReliableStateManagerReplicatorSettings> setValue, Func<ReliableStateManagerReplicatorSettings, object> getValue)
+        {
+            setValue(sutSettings);
+            Assert.Contains($"{property} = {getValue(sutSettings)}", sut.ToString());
+        }
+
+        [Theory, MemberData(nameof(NullableV2Properties))]
+        public void OmitsPropertyWhenNull(string property, Action<ReliableStateManagerReplicatorSettings> setNull)
+        {
+            setNull(sutSettings);
+            Assert.DoesNotContain($"{property} = ", sut.ToString());
+        }
+
+        public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings>, Func<ReliableStateManagerReplicatorSettings, object>> SetV2Properties { get; } = new()
+        {
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogId), static _ => { }, static o => o.SharedLogId },
+            { nameof(ReliableStateManagerReplicatorSettings.SharedLogPath), static _ => { }, static o => o.SharedLogPath },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxStreamSizeInMB), static _ => { }, static o => o.MaxStreamSizeInMB },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxRecordSizeInKB), static _ => { }, static o => o.MaxRecordSizeInKB },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxMetadataSizeInKB), static _ => { }, static o => o.MaxMetadataSizeInKB },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeForLocalSSD), static o => o.OptimizeForLocalSSD = true, static o => o.OptimizeForLocalSSD },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeForLocalSSD), static o => o.OptimizeForLocalSSD = false, static o => o.OptimizeForLocalSSD },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeLogForLowerDiskUsage), static o => o.OptimizeLogForLowerDiskUsage = true, static o => o.OptimizeLogForLowerDiskUsage },
+            { nameof(ReliableStateManagerReplicatorSettings.OptimizeLogForLowerDiskUsage), static o => o.OptimizeLogForLowerDiskUsage = false, static o => o.OptimizeLogForLowerDiskUsage },
+            { nameof(ReliableStateManagerReplicatorSettings.CheckpointThresholdInMB), static _ => { }, static o => o.CheckpointThresholdInMB },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxAccumulatedBackupLogSizeInMB), static _ => { }, static o => o.MaxAccumulatedBackupLogSizeInMB },
+            { nameof(ReliableStateManagerReplicatorSettings.MinLogSizeInMB), static _ => { }, static o => o.MinLogSizeInMB },
+            { nameof(ReliableStateManagerReplicatorSettings.TruncationThresholdFactor), static _ => { }, static o => o.TruncationThresholdFactor },
+            { nameof(ReliableStateManagerReplicatorSettings.ThrottlingThresholdFactor), static _ => { }, static o => o.ThrottlingThresholdFactor },
+            { nameof(ReliableStateManagerReplicatorSettings.SlowApiMonitoringDuration), static _ => { }, static o => o.SlowApiMonitoringDuration },
+#if NETFRAMEWORK
+            { nameof(ReliableStateManagerReplicatorSettings.LogTruncationIntervalSeconds), static _ => { }, static o => o.LogTruncationIntervalSeconds },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableIncrementalBackupsAcrossReplicas), static o => o.EnableIncrementalBackupsAcrossReplicas = true, static o => o.EnableIncrementalBackupsAcrossReplicas },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableIncrementalBackupsAcrossReplicas), static o => o.EnableIncrementalBackupsAcrossReplicas = false, static o => o.EnableIncrementalBackupsAcrossReplicas },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableSendWindowSizeInBytes), static o => o.EnableSendWindowSizeInBytes = true, static o => o.EnableSendWindowSizeInBytes },
+            { nameof(ReliableStateManagerReplicatorSettings.EnableSendWindowSizeInBytes), static o => o.EnableSendWindowSizeInBytes = false, static o => o.EnableSendWindowSizeInBytes },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxReplicationQueueSendWindowSizeInBytes), static _ => { }, static o => o.MaxReplicationQueueSendWindowSizeInBytes },
+            { nameof(ReliableStateManagerReplicatorSettings.MaxCopyQueueSendWindowSizeInBytes), static _ => { }, static o => o.MaxCopyQueueSendWindowSizeInBytes },
+            { nameof(ReliableStateManagerReplicatorSettings.UseIndividualHeapPerReplica), static o => o.UseIndividualHeapPerReplica = true, static o => o.UseIndividualHeapPerReplica },
+            { nameof(ReliableStateManagerReplicatorSettings.UseIndividualHeapPerReplica), static o => o.UseIndividualHeapPerReplica = false, static o => o.UseIndividualHeapPerReplica },
+            { nameof(ReliableStateManagerReplicatorSettings.InitialReplicaHeapSizeInKB), static _ => { }, static o => o.InitialReplicaHeapSizeInKB },
+#endif
+        };
+    }
+
+    public sealed class TruncationThresholdFactor : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Fact]
+        public void IsSetToGivenValue()
+        {
+            int expected = fuzzy.Int32();
+            sut.TruncationThresholdFactor = expected;
+            Assert.Equal(expected, sut.TruncationThresholdFactor);
+        }
+    }
+
+#if NETFRAMEWORK
+    public sealed class UseIndividualHeapPerReplica : ReliableStateManagerReplicatorSettingsTest
+    {
+        [Theory, InlineData(true), InlineData(false), InlineData(null)]
+        public void IsSetToGivenValue(bool? value)
+        {
+            sut.UseIndividualHeapPerReplica = value;
+            Assert.Equal(value, sut.UseIndividualHeapPerReplica);
+        }
+    }
+#endif
+
+    public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings>> NullableV2Properties { get; } = new()
+    {
+        { nameof(ReliableStateManagerReplicatorSettings.SharedLogId), static o => o.SharedLogId = null },
+        { nameof(ReliableStateManagerReplicatorSettings.SharedLogPath), static o => o.SharedLogPath = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxStreamSizeInMB), static o => o.MaxStreamSizeInMB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxRecordSizeInKB), static o => o.MaxRecordSizeInKB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxMetadataSizeInKB), static o => o.MaxMetadataSizeInKB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.OptimizeForLocalSSD), static o => o.OptimizeForLocalSSD = null },
+        { nameof(ReliableStateManagerReplicatorSettings.OptimizeLogForLowerDiskUsage), static o => o.OptimizeLogForLowerDiskUsage = null },
+        { nameof(ReliableStateManagerReplicatorSettings.CheckpointThresholdInMB), static o => o.CheckpointThresholdInMB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxAccumulatedBackupLogSizeInMB), static o => o.MaxAccumulatedBackupLogSizeInMB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MinLogSizeInMB), static o => o.MinLogSizeInMB = null },
+        { nameof(ReliableStateManagerReplicatorSettings.TruncationThresholdFactor), static o => o.TruncationThresholdFactor = null },
+        { nameof(ReliableStateManagerReplicatorSettings.ThrottlingThresholdFactor), static o => o.ThrottlingThresholdFactor = null },
+        { nameof(ReliableStateManagerReplicatorSettings.SlowApiMonitoringDuration), static o => o.SlowApiMonitoringDuration = null },
+#if NETFRAMEWORK
+        { nameof(ReliableStateManagerReplicatorSettings.LogTruncationIntervalSeconds), static o => o.LogTruncationIntervalSeconds = null },
+        { nameof(ReliableStateManagerReplicatorSettings.EnableIncrementalBackupsAcrossReplicas), static o => o.EnableIncrementalBackupsAcrossReplicas = null },
+        { nameof(ReliableStateManagerReplicatorSettings.EnableSendWindowSizeInBytes), static o => o.EnableSendWindowSizeInBytes = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxReplicationQueueSendWindowSizeInBytes), static o => o.MaxReplicationQueueSendWindowSizeInBytes = null },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxCopyQueueSendWindowSizeInBytes), static o => o.MaxCopyQueueSendWindowSizeInBytes = null },
+        { nameof(ReliableStateManagerReplicatorSettings.UseIndividualHeapPerReplica), static o => o.UseIndividualHeapPerReplica = null },
+        { nameof(ReliableStateManagerReplicatorSettings.InitialReplicaHeapSizeInKB), static o => o.InitialReplicaHeapSizeInKB = null },
+#endif
+    };
+
+    public static TheoryData<string, Action<ReliableStateManagerReplicatorSettings>> NonV2Mutations { get; } = new()
+    {
+        { nameof(ReliableStateManagerReplicatorSettings.RetryInterval), static o => o.RetryInterval = fuzzy.TimeSpan() },
+        { nameof(ReliableStateManagerReplicatorSettings.BatchAcknowledgementInterval), static o => o.BatchAcknowledgementInterval = fuzzy.TimeSpan() },
+        { nameof(ReliableStateManagerReplicatorSettings.ReplicatorAddress), static o => o.ReplicatorAddress = fuzzy.String() },
+        { nameof(ReliableStateManagerReplicatorSettings.ReplicatorListenAddress), static o => o.ReplicatorListenAddress = fuzzy.String() },
+        { nameof(ReliableStateManagerReplicatorSettings.ReplicatorPublishAddress), static o => o.ReplicatorPublishAddress = fuzzy.String() },
+        { nameof(ReliableStateManagerReplicatorSettings.InitialCopyQueueSize), static o => o.InitialCopyQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxCopyQueueSize), static o => o.MaxCopyQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.InitialPrimaryReplicationQueueSize), static o => o.InitialPrimaryReplicationQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxPrimaryReplicationQueueSize), static o => o.MaxPrimaryReplicationQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxPrimaryReplicationQueueMemorySize), static o => o.MaxPrimaryReplicationQueueMemorySize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.InitialSecondaryReplicationQueueSize), static o => o.InitialSecondaryReplicationQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxSecondaryReplicationQueueSize), static o => o.MaxSecondaryReplicationQueueSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxSecondaryReplicationQueueMemorySize), static o => o.MaxSecondaryReplicationQueueMemorySize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxReplicationMessageSize), static o => o.MaxReplicationMessageSize = fuzzy.Int64() },
+        { nameof(ReliableStateManagerReplicatorSettings.SecurityCredentials), static o => o.SecurityCredentials = new NoneSecurityCredentials() },
+        { nameof(ReliableStateManagerReplicatorSettings.MaxWriteQueueDepthInKB), static o => o.MaxWriteQueueDepthInKB = fuzzy.Int32() },
+        { nameof(ReliableStateManagerReplicatorSettings.SecondaryClearAcknowledgedOperations), static o => o.SecondaryClearAcknowledgedOperations = fuzzy.Boolean() },
+    };
+}

--- a/test/Data.Interfaces/RestoreContextTest.cs
+++ b/test/Data.Interfaces/RestoreContextTest.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuzzy;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class RestoreContextTest
+{
+    readonly RestoreContext sut;
+
+    // Constructor parameters
+    readonly Mock<IStateProviderReplica> stateProviderReplica = new();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+    readonly string backupFolderPath = fuzzy.String();
+
+    RestoreContextTest() =>
+        sut = new RestoreContext(stateProviderReplica.Object);
+
+    public sealed class Constructor : RestoreContextTest
+    {
+        [Fact(Explicit = true)] // TODO: SUT bug. Constructor doesn't validate stateProviderReplica; RestoreAsync throws NullReferenceException.
+        public void ThrowsArgumentNullExceptionWhenStateProviderReplicaIsNull()
+        {
+            // The constructor stores stateProviderReplica without validation, so a null argument is silently accepted.
+            // Subsequent calls to RestoreAsync then fail with NullReferenceException far from the original site.
+            // The fix is to throw ArgumentNullException here.
+            var e = Assert.Throws<ArgumentNullException>(() => new RestoreContext(null));
+            Assert.Equal(nameof(stateProviderReplica), e.ParamName);
+        }
+    }
+
+    public sealed class RestoreAsync_RestoreDescription : RestoreContextTest
+    {
+        [Theory, InlineData(RestorePolicy.Safe), InlineData(RestorePolicy.Force)]
+        public void PassesCancellationTokenNoneToReplica(RestorePolicy policy)
+        {
+            var restoreDescription = new RestoreDescription(backupFolderPath, policy);
+            Task expected = Task.FromResult(new object());
+            _ = stateProviderReplica.Setup(_ => _.RestoreAsync(backupFolderPath, policy, CancellationToken.None))
+                .Returns(expected);
+
+#pragma warning disable xUnit1051 // test verifies default overload passes CancellationToken.None
+            Task actual = sut.RestoreAsync(restoreDescription);
+#pragma warning restore xUnit1051
+
+            Assert.Same(expected, actual);
+            stateProviderReplica.Verify(_ => _.RestoreAsync(
+                It.IsAny<string>(), It.IsAny<RestorePolicy>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    public sealed class RestoreAsync_RestoreDescription_CancellationToken : RestoreContextTest
+    {
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        [Theory, InlineData(RestorePolicy.Safe), InlineData(RestorePolicy.Force)]
+        public void DelegatesToReplicaWithGivenCancellationToken(RestorePolicy policy)
+        {
+            var restoreDescription = new RestoreDescription(backupFolderPath, policy);
+            Task expected = Task.FromResult(new object());
+            _ = stateProviderReplica.Setup(_ => _.RestoreAsync(backupFolderPath, policy, cancellationToken))
+                .Returns(expected);
+
+            Task actual = sut.RestoreAsync(restoreDescription, cancellationToken);
+
+            Assert.Same(expected, actual);
+            stateProviderReplica.Verify(_ => _.RestoreAsync(
+                It.IsAny<string>(), It.IsAny<RestorePolicy>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/test/Data.Interfaces/RestoreDescriptionTest.cs
+++ b/test/Data.Interfaces/RestoreDescriptionTest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using Fuzzy;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class RestoreDescriptionTest
+{
+    // Constructor parameters
+    readonly string backupFolderPath = fuzzy.String();
+    readonly RestorePolicy restorePolicy = fuzzy.Enum<RestorePolicy>();
+
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    public sealed class Constructor_String : RestoreDescriptionTest
+    {
+        [Fact]
+        public void InitializesPropertiesWithSafePolicyByDefault()
+        {
+            var sut = new RestoreDescription(backupFolderPath);
+            Assert.Same(backupFolderPath, sut.BackupFolderPath);
+            Assert.Equal(RestorePolicy.Safe, sut.Policy);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be null, but constructor doesn't validate.
+        public void ThrowsArgumentNullExceptionWhenBackupFolderPathIsNull()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() => new RestoreDescription(null));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be empty, but constructor doesn't validate.
+        public void ThrowsArgumentExceptionWhenBackupFolderPathIsEmpty()
+        {
+            var e = Assert.Throws<ArgumentException>(() => new RestoreDescription(string.Empty));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be whitespace, but constructor doesn't validate.
+        public void ThrowsArgumentExceptionWhenBackupFolderPathIsWhitespace()
+        {
+            var e = Assert.Throws<ArgumentException>(() => new RestoreDescription(" "));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+    }
+
+    public sealed class Constructor_String_RestorePolicy : RestoreDescriptionTest
+    {
+        [Theory, InlineData(RestorePolicy.Safe), InlineData(RestorePolicy.Force)]
+        public void InitializesProperties(RestorePolicy policy)
+        {
+            var sut = new RestoreDescription(backupFolderPath, policy);
+            Assert.Same(backupFolderPath, sut.BackupFolderPath);
+            Assert.Equal(policy, sut.Policy);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be null, but constructor doesn't validate.
+        public void ThrowsArgumentNullExceptionWhenBackupFolderPathIsNull()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() => new RestoreDescription(null, restorePolicy));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be empty, but constructor doesn't validate.
+        public void ThrowsArgumentExceptionWhenBackupFolderPathIsEmpty()
+        {
+            var e = Assert.Throws<ArgumentException>(() => new RestoreDescription(string.Empty, restorePolicy));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Docs say backupFolderPath cannot be whitespace, but constructor doesn't validate.
+        public void ThrowsArgumentExceptionWhenBackupFolderPathIsWhitespace()
+        {
+            var e = Assert.Throws<ArgumentException>(() => new RestoreDescription(" ", restorePolicy));
+            Assert.Equal(nameof(backupFolderPath), e.ParamName);
+        }
+    }
+}

--- a/test/Data/Microsoft.ServiceFabric.Data.Tests.csproj
+++ b/test/Data/Microsoft.ServiceFabric.Data.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.ServiceFabric.Data</RootNamespace>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <Import Project="..\..\properties\service_fabric_managed_common.props" />
+  <ItemGroup>
+    <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Data\Microsoft.ServiceFabric.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Data/ReliableStateManagerTest.cs
+++ b/test/Data/ReliableStateManagerTest.cs
@@ -1,0 +1,1011 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+
+using System;
+using System.Fabric;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuzzy;
+using Inspector;
+using Microsoft.ServiceFabric.Data.Notifications;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ServiceFabric.Data;
+
+public abstract class ReliableStateManagerTest
+{
+    readonly ReliableStateManager sut;
+
+    // Constructor parameters
+    readonly Mock<IReliableStateManagerReplica2> impl = new() { DefaultValue = DefaultValue.Mock };
+
+    // Test fixture
+    static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
+
+    ReliableStateManagerTest() 
+    {
+        sut = Type<ReliableStateManager>.Uninitialized();
+        sut.Field<IReliableStateManagerReplica2>().Set(impl.Object);
+        sut.Field<object>().Set(new object());
+    }
+
+    public sealed class Constructor_StatefulServiceContext_ReliableStateManagerConfiguration : ReliableStateManagerTest
+    {
+        [Fact(Explicit = true)] // TODO: SUT testability limitation. Constructor's reflection-based assembly loading prevents unit testing in isolation.
+        public void DefaultsConfigurationWhenNull() =>
+            // The public constructor calls FabricRuntime.LoadAssembly("Microsoft.ServiceFabric.Data.Impl") and invokes
+            // EntryPoints.CreateReliableStateManager2 via reflection. Both the assembly resolution and the resulting
+            // IReliableStateManagerReplica2 cannot be substituted from a test, so the configuration-defaulting behavior
+            // cannot be observed in isolation without modifying the SUT to accept an injectable factory.
+            throw new NotImplementedException();
+
+        [Fact(Explicit = true)] // TODO: SUT testability limitation. Constructor's reflection-based assembly loading prevents unit testing in isolation.
+        public void ThrowsFileNotFoundExceptionWhenImplAssemblyMissing() =>
+            // Triggering the FileNotFoundException branch requires controlling FabricRuntime.LoadAssembly, which is a
+            // static method on a non-virtual type. Without an injectable assembly loader the test cannot deterministically
+            // produce a missing-assembly condition in isolation from the process's runtime environment.
+            throw new NotImplementedException();
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Public constructor does not validate serviceContext. Also a testability limitation due to reflection-based assembly loading.
+        public void ThrowsArgumentNullExceptionWhenServiceContextIsNull() =>
+            // The constructor forwards serviceContext to CreateReliableStateManager2 via reflection without a null check,
+            // so the expected ArgumentNullException is never thrown. Even after fixing the validation bug, exercising the
+            // constructor in isolation is blocked by the same reflection-based assembly loading path.
+            throw new NotImplementedException();
+    }
+
+    public sealed class Abort : ReliableStateManagerTest
+    {
+        new readonly IStateProviderReplica sut;
+
+        public Abort() => sut = base.sut;
+
+        [Fact]
+        public void CleansUpEventHandlersBeforeDelegatingToImpl() =>
+            VerifyCleansUpEventHandlersBeforeShutdown(
+                callback => _ = impl.Setup(_ => _.Abort()).Callback(callback),
+                sut.Abort);
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            sut.Abort();
+            impl.Verify(_ => _.Abort(), Times.Once);
+        }
+
+        [Fact]
+        public void UnregistersTransactionEventHandler() =>
+            VerifyUnregistersTransactionEventHandler(sut.Abort);
+
+        [Fact]
+        public void UnregistersStateManagerEventHandler() =>
+            VerifyUnregistersStateManagerEventHandler(sut.Abort);
+
+        [Fact]
+        public void DoesNotUnregisterTransactionEventHandlerWhenNoneRegistered() =>
+            VerifyDoesNotUnregisterTransactionEventHandlerWhenNoneRegistered(sut.Abort);
+
+        [Fact]
+        public void DoesNotUnregisterStateManagerEventHandlerWhenNoneRegistered() =>
+            VerifyDoesNotUnregisterStateManagerEventHandlerWhenNoneRegistered(sut.Abort);
+    }
+
+    public sealed class BackupAsync_BackupOption_TimeSpan_CancellationToken_FuncOfBackupInfoCancellationTokenTaskOfBoolean : ReliableStateManagerTest
+    {
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        readonly Func<BackupInfo, CancellationToken, Task<bool>> backupCallback = (_, _) => Task.FromResult(true);
+
+        [Theory, InlineData(BackupOption.Full), InlineData(BackupOption.Incremental)]
+        public void DelegatesToImpl(BackupOption option)
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.BackupAsync(option, timeout, cancellationToken, backupCallback)).Returns(expected);
+
+            Task actual = sut.BackupAsync(option, timeout, cancellationToken, backupCallback);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.BackupAsync(
+                It.IsAny<BackupOption>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(),
+                It.IsAny<Func<BackupInfo, CancellationToken, Task<bool>>>()), Times.Once);
+        }
+    }
+
+    public sealed class BackupAsync_FuncOfBackupInfoCancellationTokenTaskOfBoolean : ReliableStateManagerTest
+    {
+        readonly Func<BackupInfo, CancellationToken, Task<bool>> backupCallback = (_, _) => Task.FromResult(true);
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.BackupAsync(backupCallback)).Returns(expected);
+
+            Task actual = sut.BackupAsync(backupCallback);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.BackupAsync(It.IsAny<Func<BackupInfo, CancellationToken, Task<bool>>>()), Times.Once);
+        }
+    }
+
+    public sealed class ChangeRoleAsync : ReliableStateManagerTest
+    {
+        new readonly IStateProviderReplica sut;
+
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        public ChangeRoleAsync() => sut = base.sut;
+
+        [Theory]
+        [InlineData(ReplicaRole.Unknown)]
+        [InlineData(ReplicaRole.None)]
+        [InlineData(ReplicaRole.Primary)]
+        [InlineData(ReplicaRole.IdleSecondary)]
+        [InlineData(ReplicaRole.ActiveSecondary)]
+        [InlineData(ReplicaRole.IdleAuxiliary)]
+        [InlineData(ReplicaRole.ActiveAuxiliary)]
+        [InlineData(ReplicaRole.PrimaryAuxiliary)]
+        public void DelegatesToImpl(ReplicaRole newRole)
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.ChangeRoleAsync(newRole, cancellationToken)).Returns(expected);
+
+            Task actual = sut.ChangeRoleAsync(newRole, cancellationToken);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.ChangeRoleAsync(It.IsAny<ReplicaRole>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    public sealed class CloseAsync : ReliableStateManagerTest
+    {
+        new readonly IStateProviderReplica sut;
+
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        public CloseAsync() => sut = base.sut;
+
+        [Fact]
+        public void CleansUpEventHandlersBeforeDelegatingToImpl() =>
+            VerifyCleansUpEventHandlersBeforeShutdown(
+                callback => _ = impl.Setup(_ => _.CloseAsync(cancellationToken)).Callback(callback),
+                () => _ = sut.CloseAsync(cancellationToken));
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.CloseAsync(cancellationToken)).Returns(expected);
+
+            Task actual = sut.CloseAsync(cancellationToken);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public void UnregistersTransactionEventHandler() =>
+            VerifyUnregistersTransactionEventHandler(() => _ = sut.CloseAsync(cancellationToken));
+
+        [Fact]
+        public void UnregistersStateManagerEventHandler() =>
+            VerifyUnregistersStateManagerEventHandler(() => _ = sut.CloseAsync(cancellationToken));
+
+        [Fact]
+        public void DoesNotUnregisterTransactionEventHandlerWhenNoneRegistered() =>
+            VerifyDoesNotUnregisterTransactionEventHandlerWhenNoneRegistered(() => _ = sut.CloseAsync(cancellationToken));
+
+        [Fact]
+        public void DoesNotUnregisterStateManagerEventHandlerWhenNoneRegistered() =>
+            VerifyDoesNotUnregisterStateManagerEventHandlerWhenNoneRegistered(() => _ = sut.CloseAsync(cancellationToken));
+    }
+
+    public sealed class CreateTransaction : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        public CreateTransaction() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            var expected = Mock.Of<ITransaction>();
+            _ = impl.Setup(_ => _.CreateTransaction()).Returns(expected);
+
+            ITransaction actual = sut.CreateTransaction();
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.CreateTransaction(), Times.Once);
+        }
+    }
+
+    public sealed class GetAsyncEnumerator : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        public GetAsyncEnumerator() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            var expected = Mock.Of<IAsyncEnumerator<IReliableState>>();
+            _ = impl.Setup(_ => _.GetAsyncEnumerator()).Returns(expected);
+
+            IAsyncEnumerator<IReliableState> actual = sut.GetAsyncEnumerator();
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetAsyncEnumerator(), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_ITransaction_String : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly string name = fuzzy.String();
+
+        public GetOrAddAsync_ITransaction_String() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(tx, name)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(tx, name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<ITransaction>(), It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_ITransaction_String_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly string name = fuzzy.String();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public GetOrAddAsync_ITransaction_String_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(tx, name, timeout)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(tx, name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<ITransaction>(), It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_ITransaction_Uri : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly Uri name = fuzzy.Uri();
+
+        public GetOrAddAsync_ITransaction_Uri() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(tx, name)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(tx, name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<ITransaction>(), It.IsAny<Uri>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_ITransaction_Uri_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly Uri name = fuzzy.Uri();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public GetOrAddAsync_ITransaction_Uri_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(tx, name, timeout)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(tx, name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<ITransaction>(), It.IsAny<Uri>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_String : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly string name = fuzzy.String();
+
+        public GetOrAddAsync_String() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(name)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_String_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly string name = fuzzy.String();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public GetOrAddAsync_String_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(name, timeout)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_Uri : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly Uri name = fuzzy.Uri();
+
+        public GetOrAddAsync_Uri() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(name)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<Uri>()), Times.Once);
+        }
+    }
+
+    public sealed class GetOrAddAsync_Uri_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly Uri name = fuzzy.Uri();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public GetOrAddAsync_Uri_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<IReliableState> expected = Task.FromResult(Mock.Of<IReliableState>());
+            _ = impl.Setup(_ => _.GetOrAddAsync<IReliableState>(name, timeout)).Returns(expected);
+
+            Task<IReliableState> actual = sut.GetOrAddAsync<IReliableState>(name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.GetOrAddAsync<IReliableState>(It.IsAny<Uri>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class Initialize : ReliableStateManagerTest
+    {
+        new readonly IStateProviderReplica sut;
+
+        readonly StatefulServiceInitializationParameters initializationParameters = Type<StatefulServiceInitializationParameters>.Uninitialized(); // no public ctor
+
+        public Initialize() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            sut.Initialize(initializationParameters);
+
+            impl.Verify(_ => _.Initialize(initializationParameters), Times.Once);
+            impl.Verify(_ => _.Initialize(It.IsAny<StatefulServiceInitializationParameters>()), Times.Once);
+        }
+    }
+
+    public sealed class OnDataLossAsync : ReliableStateManagerTest
+    {
+        readonly Func<CancellationToken, Task<bool>> handler = _ => Task.FromResult(true);
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            sut.OnDataLossAsync = handler;
+
+            impl.VerifySet(_ => _.OnDataLossAsync = handler, Times.Once);
+            impl.VerifySet(_ => _.OnDataLossAsync = It.IsAny<Func<CancellationToken, Task<bool>>>(), Times.Once);
+        }
+    }
+
+    public sealed class OnRestoreCompletedAsync : ReliableStateManagerTest
+    {
+        readonly Func<CancellationToken, Task> handler = _ => Task.CompletedTask;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            sut.OnRestoreCompletedAsync = handler;
+
+            impl.VerifySet(_ => _.OnRestoreCompletedAsync = handler, Times.Once);
+            impl.VerifySet(_ => _.OnRestoreCompletedAsync = It.IsAny<Func<CancellationToken, Task>>(), Times.Once);
+        }
+    }
+
+    public sealed class OpenAsync : ReliableStateManagerTest
+    {
+        new readonly IStateProviderReplica sut;
+
+        readonly IStatefulServicePartition partition = Mock.Of<IStatefulServicePartition>();
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        public OpenAsync() => sut = base.sut;
+
+        [Theory]
+        [InlineData(ReplicaOpenMode.Invalid)]
+        [InlineData(ReplicaOpenMode.New)]
+        [InlineData(ReplicaOpenMode.Existing)]
+        public void DelegatesToImpl(ReplicaOpenMode openMode)
+        {
+            Task<IReplicator> expected = Task.FromResult(Mock.Of<IReplicator>());
+            _ = impl.Setup(_ => _.OpenAsync(openMode, partition, cancellationToken)).Returns(expected);
+
+            Task<IReplicator> actual = sut.OpenAsync(openMode, partition, cancellationToken);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.OpenAsync(
+                It.IsAny<ReplicaOpenMode>(), It.IsAny<IStatefulServicePartition>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_ITransaction_String : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly string name = fuzzy.String();
+
+        public RemoveAsync_ITransaction_String() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(tx, name)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(tx, name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<ITransaction>(), It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_ITransaction_String_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly string name = fuzzy.String();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public RemoveAsync_ITransaction_String_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(tx, name, timeout)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(tx, name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<ITransaction>(), It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_ITransaction_Uri : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly Uri name = fuzzy.Uri();
+
+        public RemoveAsync_ITransaction_Uri() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(tx, name)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(tx, name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<ITransaction>(), It.IsAny<Uri>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_ITransaction_Uri_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly ITransaction tx = Mock.Of<ITransaction>();
+        readonly Uri name = fuzzy.Uri();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public RemoveAsync_ITransaction_Uri_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(tx, name, timeout)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(tx, name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<ITransaction>(), It.IsAny<Uri>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_String : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly string name = fuzzy.String();
+
+        public RemoveAsync_String() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(name)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_String_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly string name = fuzzy.String();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public RemoveAsync_String_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(name, timeout)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_Uri : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly Uri name = fuzzy.Uri();
+
+        public RemoveAsync_Uri() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(name)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<Uri>()), Times.Once);
+        }
+    }
+
+    public sealed class RemoveAsync_Uri_TimeSpan : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly Uri name = fuzzy.Uri();
+        readonly TimeSpan timeout = fuzzy.TimeSpan();
+
+        public RemoveAsync_Uri_TimeSpan() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RemoveAsync(name, timeout)).Returns(expected);
+
+            Task actual = sut.RemoveAsync(name, timeout);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RemoveAsync(It.IsAny<Uri>(), It.IsAny<TimeSpan>()), Times.Once);
+        }
+    }
+
+    public sealed class Replica : ReliableStateManagerTest
+    {
+        [Fact]
+        public void ReturnsUnderlyingReplica() =>
+            Assert.Same(impl.Object, sut.Replica);
+    }
+
+    public sealed class RestoreAsync_String : ReliableStateManagerTest
+    {
+        readonly string backupFolderPath = fuzzy.String();
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RestoreAsync(backupFolderPath)).Returns(expected);
+
+            Task actual = sut.RestoreAsync(backupFolderPath);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RestoreAsync(It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class RestoreAsync_String_RestorePolicy_CancellationToken : ReliableStateManagerTest
+    {
+        readonly string backupFolderPath = fuzzy.String();
+        readonly CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        [Theory, InlineData(RestorePolicy.Safe), InlineData(RestorePolicy.Force)]
+        public void DelegatesToImpl(RestorePolicy restorePolicy)
+        {
+            Task expected = Task.FromResult(new object());
+            _ = impl.Setup(_ => _.RestoreAsync(backupFolderPath, restorePolicy, cancellationToken)).Returns(expected);
+
+            Task actual = sut.RestoreAsync(backupFolderPath, restorePolicy, cancellationToken);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.RestoreAsync(It.IsAny<string>(), It.IsAny<RestorePolicy>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    public sealed class StateManagerChanged : EventForwardingTest<NotifyStateManagerChangedEventArgs>
+    {
+        protected override void Subscribe(EventHandler<NotifyStateManagerChangedEventArgs> handler) =>
+            sut.StateManagerChanged += handler;
+
+        protected override void Unsubscribe(EventHandler<NotifyStateManagerChangedEventArgs> handler) =>
+            sut.StateManagerChanged -= handler;
+
+        protected override void SetupImplAddCapture(Action<EventHandler<NotifyStateManagerChangedEventArgs>> capture) =>
+            impl.SetupAdd(_ => _.StateManagerChanged += It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>())
+                .Callback<EventHandler<NotifyStateManagerChangedEventArgs>>(capture);
+
+        protected override void VerifyImplAdd(Func<Times> times) =>
+            impl.VerifyAdd(_ => _.StateManagerChanged += It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>(), times);
+
+        protected override void VerifyImplRemove(Func<Times> times) =>
+            impl.VerifyRemove(_ => _.StateManagerChanged -= It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>(), times);
+
+        protected override NotifyStateManagerChangedEventArgs NewArgs() =>
+            new NotifyStateManagerRebuildEventArgs(Mock.Of<IAsyncEnumerable<IReliableState>>());
+    }
+
+    public sealed class TransactionChanged : EventForwardingTest<NotifyTransactionChangedEventArgs>
+    {
+        readonly NotifyTransactionChangedAction action = fuzzy.Enum<NotifyTransactionChangedAction>();
+
+        protected override void Subscribe(EventHandler<NotifyTransactionChangedEventArgs> handler) =>
+            sut.TransactionChanged += handler;
+
+        protected override void Unsubscribe(EventHandler<NotifyTransactionChangedEventArgs> handler) =>
+            sut.TransactionChanged -= handler;
+
+        protected override void SetupImplAddCapture(Action<EventHandler<NotifyTransactionChangedEventArgs>> capture) =>
+            impl.SetupAdd(_ => _.TransactionChanged += It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>())
+                .Callback<EventHandler<NotifyTransactionChangedEventArgs>>(capture);
+
+        protected override void VerifyImplAdd(Func<Times> times) =>
+            impl.VerifyAdd(_ => _.TransactionChanged += It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>(), times);
+
+        protected override void VerifyImplRemove(Func<Times> times) =>
+            impl.VerifyRemove(_ => _.TransactionChanged -= It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>(), times);
+
+        protected override NotifyTransactionChangedEventArgs NewArgs() =>
+            new(Mock.Of<ITransaction>(), action);
+    }
+
+    public sealed class TryAddStateSerializer : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly IStateSerializer<int> stateSerializer = Mock.Of<IStateSerializer<int>>();
+
+        public TryAddStateSerializer() => sut = base.sut;
+
+        [Theory, InlineData(true), InlineData(false)]
+        public void DelegatesToImpl(bool expected)
+        {
+            _ = impl.Setup(_ => _.TryAddStateSerializer(stateSerializer)).Returns(expected);
+
+            bool actual = sut.TryAddStateSerializer(stateSerializer);
+
+            Assert.Equal(expected, actual);
+            impl.Verify(_ => _.TryAddStateSerializer(stateSerializer), Times.Once); // required when expected = default(bool)
+            impl.Verify(_ => _.TryAddStateSerializer(It.IsAny<IStateSerializer<int>>()), Times.Once);
+        }
+    }
+
+    public sealed class TryGetAsync_String : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly string name = fuzzy.String();
+
+        public TryGetAsync_String() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<ConditionalValue<IReliableState>> expected =
+                Task.FromResult(new ConditionalValue<IReliableState>(true, Mock.Of<IReliableState>()));
+            _ = impl.Setup(_ => _.TryGetAsync<IReliableState>(name)).Returns(expected);
+
+            Task<ConditionalValue<IReliableState>> actual = sut.TryGetAsync<IReliableState>(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.TryGetAsync<IReliableState>(It.IsAny<string>()), Times.Once);
+        }
+    }
+
+    public sealed class TryGetAsync_Uri : ReliableStateManagerTest
+    {
+        new readonly IReliableStateManager sut;
+
+        readonly Uri name = fuzzy.Uri();
+
+        public TryGetAsync_Uri() => sut = base.sut;
+
+        [Fact]
+        public void DelegatesToImpl()
+        {
+            Task<ConditionalValue<IReliableState>> expected =
+                Task.FromResult(new ConditionalValue<IReliableState>(true, Mock.Of<IReliableState>()));
+            _ = impl.Setup(_ => _.TryGetAsync<IReliableState>(name)).Returns(expected);
+
+            Task<ConditionalValue<IReliableState>> actual = sut.TryGetAsync<IReliableState>(name);
+
+            Assert.Same(expected, actual);
+            impl.Verify(_ => _.TryGetAsync<IReliableState>(It.IsAny<Uri>()), Times.Once);
+        }
+    }
+
+    public abstract class EventForwardingTest<TArgs> : ReliableStateManagerTest where TArgs : EventArgs
+    {
+        protected abstract void Subscribe(EventHandler<TArgs> handler);
+        protected abstract void Unsubscribe(EventHandler<TArgs> handler);
+        protected abstract void SetupImplAddCapture(Action<EventHandler<TArgs>> capture);
+        protected abstract void VerifyImplAdd(Func<Times> times);
+        protected abstract void VerifyImplRemove(Func<Times> times);
+        protected abstract TArgs NewArgs();
+
+        [Fact]
+        public void SubscribesOnlyOnceForMultipleHandlers()
+        {
+            Subscribe((_, _) => { });
+            Subscribe((_, _) => { });
+
+            VerifyImplAdd(Times.Once);
+        }
+
+        [Fact]
+        public void DoesNotSubscribeToImplWhenClosing()
+        {
+            ((IStateProviderReplica)sut).Abort();
+
+            _ = Assert.Throws<FabricObjectClosedException>(() => Subscribe((_, _) => { }));
+
+            VerifyImplAdd(Times.Never);
+        }
+
+        [Fact(Explicit = true)] // TODO: SUT bug. Subscribe throws FabricObjectClosedException after appending the user handler to the backing field, leaking it.
+        public void DoesNotRetainUserHandlerWhenSubscribeFails()
+        {
+            ((IStateProviderReplica)sut).Abort();
+
+            _ = Assert.Throws<FabricObjectClosedException>(() => Subscribe((_, _) => { }));
+
+            // The add accessor does `userHandler += value` before registering with the impl, so when registration
+            // throws FabricObjectClosedException the user handler has already been stored in the backing field and
+            // leaks. Post-fix: the accessor should append the user handler only after a successful registration,
+            // leaving the backing field null when Subscribe fails.
+            Assert.Null(sut.Field<EventHandler<TArgs>>().Value);
+        }
+
+        [Fact]
+        public void ForwardsNotificationsToUserHandler()
+        {
+            EventHandler<TArgs> actualHandler = null;
+            SetupImplAddCapture(h => actualHandler = h);
+
+            object actualSender = null;
+            TArgs actualArgs = null;
+            Subscribe((sender, args) => { actualSender = sender; actualArgs = args; });
+
+            Assert.NotNull(actualHandler);
+            TArgs expectedArgs = NewArgs();
+            actualHandler(impl.Object, expectedArgs);
+            Assert.Same(sut, actualSender);
+            Assert.Same(expectedArgs, actualArgs);
+        }
+
+        [Fact]
+        public void ForwardsNotificationRaisedDuringRegistration()
+        {
+            TArgs expectedArgs = NewArgs();
+            SetupImplAddCapture(h => h(impl.Object, expectedArgs));
+
+            object actualSender = null;
+            TArgs actualArgs = null;
+            Subscribe((sender, args) => { actualSender = sender; actualArgs = args; });
+
+            Assert.Same(sut, actualSender);
+            Assert.Same(expectedArgs, actualArgs);
+        }
+
+        [Fact]
+        public void ForwardsNotificationsToAllUserHandlers()
+        {
+            EventHandler<TArgs> actualHandler = null;
+            SetupImplAddCapture(h => actualHandler = h);
+
+            bool firstCalled = false, secondCalled = false;
+            Subscribe((_, _) => firstCalled = true);
+            Subscribe((_, _) => secondCalled = true);
+
+            Assert.NotNull(actualHandler);
+            actualHandler(impl.Object, NewArgs());
+            Assert.True(firstCalled);
+            Assert.True(secondCalled);
+        }
+
+        [Fact]
+        public void DoesNotThrowWhenAllUserHandlersUnsubscribed()
+        {
+            EventHandler<TArgs> actualHandler = null;
+            SetupImplAddCapture(h => actualHandler = h);
+
+            EventHandler<TArgs> handler = (_, _) => { };
+            Subscribe(handler);
+            Unsubscribe(handler);
+
+            Assert.NotNull(actualHandler);
+            actualHandler(impl.Object, NewArgs());
+        }
+
+        [Fact]
+        public void UnsubscribesUserHandler()
+        {
+            EventHandler<TArgs> actualHandler = null;
+            SetupImplAddCapture(h => actualHandler = h);
+
+            bool called = false;
+            EventHandler<TArgs> handler = (_, _) => called = true;
+            Subscribe(handler);
+            Unsubscribe(handler);
+
+            Assert.NotNull(actualHandler);
+            actualHandler(impl.Object, NewArgs());
+            Assert.False(called);
+        }
+
+        [Fact]
+        public void DoesNotUnregisterFromImplWhenUserUnsubscribes()
+        {
+            EventHandler<TArgs> handler = (_, _) => { };
+            Subscribe(handler);
+
+            Unsubscribe(handler);
+
+            VerifyImplRemove(Times.Never);
+        }
+    }
+
+    void VerifyCleansUpEventHandlersBeforeShutdown(Action<Action> setupShutdownCallback, Action invokeShutdown)
+    {
+        sut.TransactionChanged += (_, _) => { };
+        sut.StateManagerChanged += (_, _) => { };
+        bool txRemoved = false, smRemoved = false;
+        _ = impl.SetupRemove(_ => _.TransactionChanged -= It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>())
+            .Callback<EventHandler<NotifyTransactionChangedEventArgs>>(_ => txRemoved = true);
+        _ = impl.SetupRemove(_ => _.StateManagerChanged -= It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>())
+            .Callback<EventHandler<NotifyStateManagerChangedEventArgs>>(_ => smRemoved = true);
+        bool txRemovedBefore = false, smRemovedBefore = false;
+        setupShutdownCallback(() => { txRemovedBefore = txRemoved; smRemovedBefore = smRemoved; });
+
+        invokeShutdown();
+
+        Assert.True(txRemovedBefore);
+        Assert.True(smRemovedBefore);
+    }
+
+    void VerifyUnregistersTransactionEventHandler(Action invokeShutdown)
+    {
+        EventHandler<NotifyTransactionChangedEventArgs> actualAdded = null, actualRemoved = null;
+        _ = impl.SetupAdd(_ => _.TransactionChanged += It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>())
+            .Callback<EventHandler<NotifyTransactionChangedEventArgs>>(h => actualAdded = h);
+        _ = impl.SetupRemove(_ => _.TransactionChanged -= It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>())
+            .Callback<EventHandler<NotifyTransactionChangedEventArgs>>(h => actualRemoved = h);
+        sut.TransactionChanged += (_, _) => { };
+
+        invokeShutdown();
+
+        Assert.NotNull(actualAdded);
+        Assert.Equal(actualAdded, actualRemoved);
+        impl.VerifyRemove(_ => _.TransactionChanged -= It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>(), Times.Once);
+    }
+
+    void VerifyUnregistersStateManagerEventHandler(Action invokeShutdown)
+    {
+        EventHandler<NotifyStateManagerChangedEventArgs> actualAdded = null, actualRemoved = null;
+        _ = impl.SetupAdd(_ => _.StateManagerChanged += It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>())
+            .Callback<EventHandler<NotifyStateManagerChangedEventArgs>>(h => actualAdded = h);
+        _ = impl.SetupRemove(_ => _.StateManagerChanged -= It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>())
+            .Callback<EventHandler<NotifyStateManagerChangedEventArgs>>(h => actualRemoved = h);
+        sut.StateManagerChanged += (_, _) => { };
+
+        invokeShutdown();
+
+        Assert.NotNull(actualAdded);
+        Assert.Equal(actualAdded, actualRemoved);
+        impl.VerifyRemove(_ => _.StateManagerChanged -= It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>(), Times.Once);
+    }
+
+    void VerifyDoesNotUnregisterTransactionEventHandlerWhenNoneRegistered(Action invokeShutdown)
+    {
+        invokeShutdown();
+        impl.VerifyRemove(_ => _.TransactionChanged -= It.IsAny<EventHandler<NotifyTransactionChangedEventArgs>>(), Times.Never);
+    }
+
+    void VerifyDoesNotUnregisterStateManagerEventHandlerWhenNoneRegistered(Action invokeShutdown)
+    {
+        invokeShutdown();
+        impl.VerifyRemove(_ => _.StateManagerChanged -= It.IsAny<EventHandler<NotifyStateManagerChangedEventArgs>>(), Times.Never);
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,6 +4,15 @@
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- When building outside of VS or Code -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <!--
+      Disable detection of unused using directives. It requires generation of documentation XML files, which would force
+      redundant comments for test classes and methods. Detection still works in the IDEs.
+    -->
+    <NoWarn>$(NoWarn);IDE0005</NoWarn>
+  </PropertyGroup>
+
   <!-- On Linux -->
   <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
     <!-- Skip net472 tests, they require Mono and Service Fabric native libraries to run -->


### PR DESCRIPTION
Puts `Microsoft.ServiceFabric.Data`, `Microsoft.ServiceFabric.Data.Interfaces`, and `Microsoft.ServiceFabric.Data.Interfaces.V2` under unit test for the first time.

## Test projects

Adds three new xUnit v3 test projects mirroring the `src/` layout:

- `test/Data/Microsoft.ServiceFabric.Data.Tests.csproj`
- `test/Data.Interfaces/Microsoft.ServiceFabric.Data.Interfaces.Tests.csproj`
- `test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj`

Registered in `code.slnx` and `eng/SkipStrongName.ps1`.

## Coverage added

- `ReliableStateManager` — full behavioral coverage of `IReliableStateManagerReplica2` delegation, event subscription/unsubscription, transaction/state-manager change notifications, backup/restore, and shutdown ordering (`Abort`, `CloseAsync`).
- `ReliableStateManagerReplicatorSettings` and `ReliableStateManagerReplicatorSettings2` — property round-trip, `Equals`/`GetHashCode`, `InternalEquals`, `ToString`.
- `ReliableStateManagerConfiguration`, `BackupInfo`, `BackupDescription`, `RestoreContext`, `RestoreDescription`, `ConditionalValue`, `QueueFullException`.
- All `Notifications.Notify*EventArgs` types.
- `OrdinalString`, `VersionedKey`, `VersionedKeyValuePair`, `IReliableDictionaryExtensions` (Beta).

## Test infrastructure

- `[assembly: InternalsVisibleTo("…Tests" + PublicKey)]` added to `src/Data/AssemblyInfo.cs` and `src/Data.Interfaces/AssemblyInfo.cs` so tests can access `internal` members directly and via Inspector.
- `ReliableStateManager` SUT is constructed with Inspector's `Type<T>.Uninitialized()` plus field injection of a mocked `IReliableStateManagerReplica2`. This bypasses the public constructor's `FabricRuntime.LoadAssembly("Microsoft.ServiceFabric.Data.Impl")` + reflection-based `CreateReliableStateManager2` path, which is not substitutable from a test.

## Documented SUT defects

Tests that exercise pre-existing SUT defects are committed as `[Fact(Explicit = true)]` so they document the behavior without failing CI. SUT fixes are out of scope for this PR.

- `ReliableStateManager`
  - Public constructor does not validate `serviceContext` (forwarded to reflection without a null check).
  - Public constructor's reflection-based assembly loading prevents isolated unit testing.
  - `StateManagerChanged` / `TransactionChanged` `add` accessors append the user handler to the backing delegate field **before** calling `RegisterStateManagerEventHandlerIfNecessary` / `RegisterTransactionEventHandlerIfNecessary`. If the registration throws (for example, `FabricObjectClosedException` after `Abort`), the handler is already stored and leaks.
- `ReliableStateManagerReplicatorSettings2.InternalEquals`
  - Each `if (updated.X.HasValue)` branch unconditionally overwrites `isEqual`, so a mismatch in an earlier property is silently lost when a later property is set. Should combine via `isEqual && …` to match `BaseInternalEquals`.
  - `BaseInternalEquals` does not compare `InitialReplicaHeapSizeInKB`.
  - `Equals` is asymmetric.
- `ReliableStateManagerReplicatorSettings`
  - `Equals` is asymmetric.
  - `Equals` and `GetHashCode` are inconsistent.
- `OrdinalString`
  - `GetHashCode()` on `default(OrdinalString)` throws `NullReferenceException`, violating the `Equals`/`GetHashCode` contract. Also documented in `src/Data.Interfaces.V2/README.md`.

## README

`src/Data.Interfaces.V2/README.md` clarifies `default(OrdinalString)` semantics (defaults compare equal; member access on the underlying value throws `NullReferenceException` to match `default(string)`) and calls out the `GetHashCode` bug above.