### PR TITLE
Collect code coverage during CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
   Configuration: Release
   Artifacts: ${{ github.workspace }}/out
   Logs: ${{ github.workspace }}/out/logs
+  Tests: ${{ github.workspace }}/out/tests
 
 jobs:
   build:
@@ -35,7 +36,7 @@ jobs:
           .\eng\SkipStrongName.ps1
           .\eng\UninstallSfSdkFromGac.ps1
       - run: dotnet build -graph -bl:"${{ env.Logs }}/build.binLog" -c ${{ env.Configuration }}
-      - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }}
+      - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }} -p TestResultsPath=${{ env.Tests }}
       - run: dotnet pack --no-build -bl:"${{ env.Logs }}/pack.binLog" -c ${{ env.Configuration }}
       - uses: actions/upload-artifact@v6
         if: always()

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,6 @@
     -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)bin\</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <TestResultsDirectory>$(MSBuildThisFileDirectory)out\tests\</TestResultsDirectory>
     <PackageOutputPath>$(MSBuildThisFileDirectory)out\packages\</PackageOutputPath>
   </PropertyGroup>
 </Project>

--- a/test/Actors.Integration/Microsoft.ServiceFabric.Actors.IntegrationTests.csproj
+++ b/test/Actors.Integration/Microsoft.ServiceFabric.Actors.IntegrationTests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/Actors.Wcf/Microsoft.ServiceFabric.Actors.Wcf.Tests.csproj
+++ b/test/Actors.Wcf/Microsoft.ServiceFabric.Actors.Wcf.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/Actors/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/Actors/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Fuzzy" />
     <PackageReference Include="Inspector" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/AspNetCore/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq"/>
     <PackageReference Include="xunit.v3"/>
   </ItemGroup>

--- a/test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj
+++ b/test/Data.Interfaces.V2/Microsoft.ServiceFabric.Data.Interfaces.V2.Tests.csproj
@@ -6,6 +6,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Diagnostics/Microsoft.ServiceFabric.Diagnostics.Tests.csproj
+++ b/test/Diagnostics/Microsoft.ServiceFabric.Diagnostics.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
     <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,9 +2,25 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
-    <!-- Skip net472 tests on Linux -->
-    <IsTestingPlatformApplication Condition="'$(TargetFramework)' == 'net472' and !$([MSBuild]::IsOSPlatform('Windows'))">false</IsTestingPlatformApplication>
-    <!-- Generate test results file name based on the project name and target framework -->
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --results-directory $(TestResultsDirectory) --report-xunit-trx --report-xunit-trx-filename $(MSBuildProjectName)-$(TargetFramework).trx</TestingPlatformCommandLineArguments>
+  </PropertyGroup>
+
+  <!-- On Linux -->
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <!-- Skip net472 tests, they require Mono and Service Fabric native libraries to run -->
+    <IsTestingPlatformApplication Condition="'$(TargetFramework)' == 'net472'">false</IsTestingPlatformApplication>
+    <!-- Place build outputs of test projects in separate folders for reliable parallel execution of tests instrumented for code coverage -->
+    <BaseOutputPath Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(MSBuildThisFileDirectory)bin\$(MSBuildProjectName)</BaseOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != '' and '$(TestResultsPath)' != ''">
+    <!--
+      Generate the test results and coverage files when the TestResultsPath property is set, typically by the build.yml.
+      We use it as a workaround because the TestingPlatformCommandLineArguments property is always empty during dotnet test.
+      .trx and .coverage files can be opened by Visual Studio.
+    -->
+    <TestResultFileName>$(MSBuildProjectName)-$(TargetFramework)</TestResultFileName>
+    <TestingPlatformCommandLineArguments>--results-directory $(TestResultsPath)</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-xunit-trx --report-xunit-trx-filename $(TestResultFileName).trx</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --coverage --coverage-output $(TestResultFileName).coverage</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,6 +6,8 @@
     <PackageVersion Include="Inspector" Version="0.3.12" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" /> <!-- x.v.c->6.0.0; S.T.J->8.0.0 -->
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" /> <!-- 3.2.2 breaks SemVer: S.C.I 8.0.0->9.0.8 -->
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" /> <!-- Last version for M.T.P 1.* -->
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" /> <!-- M.T.E.C->1.8.4; x.v.c.m->1.9.1 -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
@@ -15,5 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" /> <!-- x.v.a->6.0.0; (M.D.T.TE, S.R.M)->8.0.0 -->
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" /> <!-- M.TP.OM->1.6.0; M.D.T.TE->8.0.0; M.ANC.H->8.0.1 -->
+    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" /> <!-- M.E.DM->6.0.1; (M.ANC.H.A, M.ANC.WU, S.T.J)->8.0.0 -->
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" /> <!-- M.E.DM->6.0.11; M.E.L.C->8.0.5 -->
   </ItemGroup>
 </Project>

--- a/test/FabricTransport/Microsoft.ServiceFabric.FabricTransport.Tests.csproj
+++ b/test/FabricTransport/Microsoft.ServiceFabric.FabricTransport.Tests.csproj
@@ -7,6 +7,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
+++ b/test/Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
     <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.Tests.csproj
+++ b/test/Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
     <PackageReference Include="Inspector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/test/Services/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/Services/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -6,6 +6,7 @@
   <Import Project="..\..\properties\service_fabric_managed_common.props" />
   <ItemGroup>
     <PackageReference Include="Fuzzy" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Inspector" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
- Use `Microsoft.Testing.Extensions.CodeCoverage` package rather than `coverlet` because it is the [default code coverage]( https://learn.microsoft.com/lb-lu/dotnet/core/testing/microsoft-testing-platform-code-coverage) for the `Microsoft.Testing.Platform` and `dotnet test --coverage`.
- Collect coverage information in binary `.coverage` files that can be opened in Visual Studio. At some point, we'll need to migrate to the more popular open-source formats, but for now it's consistently with the `.trx` test results we already use.
- Make generation of test result and coverage files conditional on the `TestResultsPath` variable. During regular development loop, this variable is not set to make the test runs a little faster. 
- Make test projects use separate build output directories on Linux. They frequently fail with `BadImageException` when running from shared build outputs, probably because the instrumentation logic is not as resilient as on Windows. `--max-parallel-test-modules 1` works as well, but increases the test run duration from ~3 to ~10 minutes.