### PR TITLE
Publish test and coverage results to CodeCov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,20 +38,31 @@ jobs:
       - run: dotnet build -graph -bl:"${{ env.Logs }}/build.binLog" -c ${{ env.Configuration }}
       - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }} -p TestResultsPath=${{ env.Tests }}
       - run: dotnet pack --no-build -bl:"${{ env.Logs }}/pack.binLog" -c ${{ env.Configuration }}
-      - name: Upload coverage to Codecov
+      - name: Locate Codecov input files (workaround for files glob not working on Windows)
         if: always()
+        id: test
+        shell: pwsh
+        run: |
+          $coverage = (Get-ChildItem '${{ env.Tests }}/*.cobertura.xml' | ForEach-Object FullName) -join ','
+          $results  = (Get-ChildItem '${{ env.Tests }}/*.junit.xml'     | ForEach-Object FullName) -join ','
+          "coverage=$coverage" >> $env:GITHUB_OUTPUT
+          "results=$results"   >> $env:GITHUB_OUTPUT
+      - name: Upload coverage to Codecov
+        if: always() && steps.test.outputs.coverage != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: "\"${{ env.Tests }}/*.cobertura.xml\""
+          files: ${{ steps.test.outputs.coverage }}
+          disable_search: true
           flags: ${{ matrix.os }}
           fail_ci_if_error: false
       - name: Upload test results to Codecov
-        if: always()
+        if: always() && steps.test.outputs.results != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: "\"${{ env.Tests }}/*.junit.xml\""
+          files: ${{ steps.test.outputs.results }}
+          disable_search: true
           flags: ${{ matrix.os }}
           report_type: test_results
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ env.Tests }}/*.cobertura.xml
+          files: "\"${{ env.Tests }}/*.cobertura.xml\""
           flags: ${{ matrix.os }}
           fail_ci_if_error: false
       - name: Upload test results to Codecov
@@ -51,7 +51,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ env.Tests }}/*.junit.xml
+          files: "\"${{ env.Tests }}/*.junit.xml\""
           flags: ${{ matrix.os }}
           report_type: test_results
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           .\eng\SkipStrongName.ps1
           .\eng\UninstallSfSdkFromGac.ps1
       - run: dotnet build -graph -bl:"${{ env.Logs }}/build.binLog" -c ${{ env.Configuration }}
-      - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }} -p TestResultsPath=${{ env.Tests }}
+      - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }} -p TestResultsFormat=CI
       - run: dotnet pack --no-build -bl:"${{ env.Logs }}/pack.binLog" -c ${{ env.Configuration }}
       - name: Locate Codecov input files (workaround for files glob not working on Windows)
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,22 @@ jobs:
       - run: dotnet build -graph -bl:"${{ env.Logs }}/build.binLog" -c ${{ env.Configuration }}
       - run: dotnet test --no-build -bl:"${{ env.Logs }}/test.binLog" -c ${{ env.Configuration }} -p TestResultsPath=${{ env.Tests }}
       - run: dotnet pack --no-build -bl:"${{ env.Logs }}/pack.binLog" -c ${{ env.Configuration }}
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.Tests }}/*.cobertura.xml
+          flags: ${{ matrix.os }}
+          fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.Tests }}/*.junit.xml
+          flags: ${{ matrix.os }}
+          report_type: test_results
       - uses: actions/upload-artifact@v6
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 .NET libraries for building and managing [Service Fabric](https://learn.microsoft.com/azure/service-fabric) services.
 
+[![build](https://github.com/microsoft/service-fabric-dotnet/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/service-fabric-dotnet/actions/workflows/build.yml)
+[![codecov](https://codecov.io/github/microsoft/service-fabric-dotnet/graph/badge.svg?token=qJxLx7IJcq)](https://codecov.io/github/microsoft/service-fabric-dotnet)
+
 NuGet packages:
  - [Microsoft.ServiceFabric.Actors](https://www.nuget.org/packages/Microsoft.ServiceFabric.Actors)
  - [Microsoft.ServiceFabric.Actors.Wcf](https://www.nuget.org/packages/Microsoft.ServiceFabric.Actors.Wcf)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -16,11 +16,11 @@
     <!--
       Generate the test results and coverage files when the TestResultsPath property is set, typically by the build.yml.
       We use it as a workaround because the TestingPlatformCommandLineArguments property is always empty during dotnet test.
-      .trx and .coverage files can be opened by Visual Studio.
+      JUnit XML is consumed by Codecov; .cobertura.xml is the coverage format Codecov ingests.
     -->
     <TestResultFileName>$(MSBuildProjectName)-$(TargetFramework)</TestResultFileName>
     <TestingPlatformCommandLineArguments>--results-directory $(TestResultsPath)</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-xunit-trx --report-xunit-trx-filename $(TestResultFileName).trx</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --coverage --coverage-output $(TestResultFileName).coverage</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-junit --report-junit-filename $(TestResultFileName).junit.xml</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --coverage --coverage-output-format cobertura --coverage-output $(TestResultFileName).cobertura.xml</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,15 +12,22 @@
     <BaseOutputPath Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(MSBuildThisFileDirectory)bin\$(MSBuildProjectName)</BaseOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != '' and '$(TestResultsPath)' != ''">
-    <!--
-      Generate the test results and coverage files when the TestResultsPath property is set, typically by the build.yml.
-      We use it as a workaround because the TestingPlatformCommandLineArguments property is always empty during dotnet test.
-      JUnit XML is consumed by Codecov; .cobertura.xml is the coverage format Codecov ingests.
-    -->
+  <PropertyGroup Condition="'$(TargetFramework)' != '' and '$(TestResultsFormat)' != ''">
+    <TestResultsPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\out\tests'))</TestResultsPath>
     <TestResultFileName>$(MSBuildProjectName)-$(TargetFramework)</TestResultFileName>
-    <TestingPlatformCommandLineArguments>--results-directory $(TestResultsPath)</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-junit --report-junit-filename $(TestResultFileName).junit.xml</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --coverage --coverage-output-format cobertura --coverage-output $(TestResultFileName).cobertura.xml</TestingPlatformCommandLineArguments>
+
+    <!-- Prepare command line arguments for the test runner -->
+    <TestArguments>--results-directory $(TestResultsPath)</TestArguments>
+
+    <!-- .trx and .coverage files can be opened by Visual Studio -->
+    <TestArguments Condition="'$(TestResultsFormat)' == 'VS'">$(TestArguments) --report-xunit-trx --report-xunit-trx-filename $(TestResultFileName).trx</TestArguments>
+    <TestArguments Condition="'$(TestResultsFormat)' == 'VS'">$(TestArguments) --coverage --coverage-output $(TestResultFileName).coverage</TestArguments>
+
+    <!-- .junit.xml .cobertura.xml are published by CI builds -->
+    <TestArguments Condition="'$(TestResultsFormat)' == 'CI'">$(TestArguments) --report-junit --report-junit-filename $(TestResultFileName).junit.xml</TestArguments>
+    <TestArguments Condition="'$(TestResultsFormat)' == 'CI'">$(TestArguments) --coverage --coverage-output-format cobertura --coverage-output $(TestResultFileName).cobertura.xml</TestArguments>
+
+    <!-- Provide test arguments to Microsoft.Testing.Platform -->
+    <TestingPlatformCommandLineArguments>$(TestArguments)</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Switch generation of test and coverage results from the `TestResultsPath` property to the `TestResultsFormat` property. It accepts values 
  - `VS`, meant to be used for local analysis of `.coverage` and `.trx` files with Visual Studio, and 
  - `CI`, meant for uploading ``.cobertura.xml` and `.junit.xml` files to both Azure DevOps and Codecov.io.
  - When empty, no coverage or test result files will be generated; it is meant for local development.
- The `TestResultsPath` property is now initialized by the `test/Directory.Build.props` and doesn't need to be specified explicitly.
- Added build and coverage badges to the `README.md`.