### PR TITLE
Change IFabricMeterProvider interface version

### DIFF
--- a/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
@@ -16,14 +16,19 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
 [GeneratedComInterface]
 [Guid("89462876-f11e-41c6-bd99-c933b46c5e66")]
 [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-partial interface IFabricMeterProvider
+partial interface IFabricMeterProvider2
 {
-    // Vtable slot 3: inherited from old IFabricMeterProvider (GUID 15AD37D2-F641-4188-824B-0D68CB4F6C17).
-    // Declared for vtable alignment only; not called by managed code.
+    #region IFabricMeterProvider
+
     [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
     IFabricMeter CreateMeter(IntPtr metricNamespace, IntPtr name, uint count, IntPtr dimensionNames);
 
-    // Vtable slot 4: new method on IFabricMeterProvider2.
+    #endregion
+
+    #region IFabricMeterProvider2
+
     [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
     IFabricMeter CreateMeter2(IntPtr meterDescription);
+
+    #endregion
 }

--- a/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/IFabricMeterProvider.cs
@@ -14,10 +14,16 @@ using GeneratedComInterfaceAttribute = System.Runtime.InteropServices.ComImportA
 namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation;
 
 [GeneratedComInterface]
-[Guid("15AD37D2-F641-4188-824B-0D68CB4F6C17")]
+[Guid("89462876-f11e-41c6-bd99-c933b46c5e66")]
 [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 partial interface IFabricMeterProvider
 {
+    // Vtable slot 3: inherited from old IFabricMeterProvider (GUID 15AD37D2-F641-4188-824B-0D68CB4F6C17).
+    // Declared for vtable alignment only; not called by managed code.
     [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
-    IFabricMeter CreateMeter(IntPtr meterDescription);
+    IFabricMeter CreateMeter(IntPtr metricNamespace, IntPtr name, uint count, IntPtr dimensionNames);
+
+    // Vtable slot 4: new method on IFabricMeterProvider2.
+    [return: MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeter>))]
+    IFabricMeter CreateMeter2(IntPtr meterDescription);
 }

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -15,9 +15,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
     {
         readonly IReadOnlyCollection<string> fixedDimensionNames;
         protected readonly IReadOnlyCollection<string> fixedDimensionValues;
-        IFabricMeterProvider fabricMeterProvider;
+        IFabricMeterProvider2 fabricMeterProvider;
 
-        static Func<IFabricMeterProvider> createFabricMeterProvider = NativeTelemetry.FabricCreateMeterProvider;
+        static Func<IFabricMeterProvider2> createFabricMeterProvider = NativeTelemetry.FabricCreateMeterProvider;
         static Func<object, int> finalReleaseComObject = Utility.FinalReleaseComObject;
 
         protected MeterProvider(ServiceContext serviceContext = null)

--- a/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
+++ b/src/Diagnostics/Metrics/Implementation/MeterProvider.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
                 description.FixedDimensionValues = (IntPtr)fixedValuePtrs;
                 description.Reserved = IntPtr.Zero;
 
-                return fabricMeterProvider.CreateMeter((IntPtr)(&description));
+                return fabricMeterProvider.CreateMeter2((IntPtr)(&description));
             }
             finally
             {

--- a/src/Diagnostics/Metrics/Implementation/NativeTelemetry.cs
+++ b/src/Diagnostics/Metrics/Implementation/NativeTelemetry.cs
@@ -15,9 +15,9 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 {
     static partial class NativeTelemetry
     {
-        internal static IFabricMeterProvider FabricCreateMeterProvider()
+        internal static IFabricMeterProvider2 FabricCreateMeterProvider()
         {
-            Marshal.ThrowExceptionForHR(FabricCreateMeterProvider(out IFabricMeterProvider meterProvider));
+            Marshal.ThrowExceptionForHR(FabricCreateMeterProvider(out IFabricMeterProvider2 meterProvider));
             return meterProvider;
         }
 
@@ -28,7 +28,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 #else
         extern
 #endif
-        HRESULT FabricCreateMeterProvider([MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeterProvider>))] out IFabricMeterProvider meterProvider);
+        HRESULT FabricCreateMeterProvider([MarshalUsing(typeof(UniqueComInterfaceMarshaller<IFabricMeterProvider2>))] out IFabricMeterProvider2 meterProvider);
 
     }
 }

--- a/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Implementation/MeterProviderTest.cs
@@ -21,16 +21,16 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
 
         readonly IMeterProvider<int> sut;
 
-        readonly IFabricMeterProvider fabricMeterProvider = Mock.Of<IFabricMeterProvider>();
+        readonly IFabricMeterProvider2 fabricMeterProvider = Mock.Of<IFabricMeterProvider2>();
         readonly ServiceContext serviceContext = fuzzy.ServiceContext();
 
         public MeterProviderTest()
         {
-            typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(() => fabricMeterProvider);
+            typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider2>>().Set(() => fabricMeterProvider);
             sut = new Mock<MeterProvider<int>>(serviceContext).Object;
         }
 
-        public virtual void Dispose() => typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider>>().Set(NativeTelemetry.FabricCreateMeterProvider);
+        public virtual void Dispose() => typeof(MeterProvider<int>).Field<Func<IFabricMeterProvider2>>().Set(NativeTelemetry.FabricCreateMeterProvider);
 
         public class Constructor : MeterProviderTest
         {
@@ -89,7 +89,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics.Implementation
                 sut.Dispose();
 
                 Mock.Get(finalReleaseComObject).Verify(f => f(fabricMeterProvider), Times.Once);
-                Assert.Null(sut.Private().Field<IFabricMeterProvider>().Value);
+                Assert.Null(sut.Private().Field<IFabricMeterProvider2>().Value);
             }
 
             [Fact]

--- a/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
 
                 Mock.Get(fabricMeterProvider)
-                    .Setup(x => x.CreateMeter(It.IsAny<IntPtr>()))
+                    .Setup(x => x.CreateMeter2(It.IsAny<IntPtr>()))
                     .Callback((IntPtr ptr) =>
                     {
                         var desc = Marshal.PtrToStructure<FABRIC_METER_DESCRIPTION>(ptr);

--- a/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/Int64MeterProviderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
             readonly Int64MeterProvider sut;
             readonly IReadOnlyCollection<string> systemDimensionsNames;
             readonly IReadOnlyCollection<string> systemDimensionsValues;
-            readonly IFabricMeterProvider fabricMeterProvider = new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object;
+            readonly IFabricMeterProvider2 fabricMeterProvider = new Mock<IFabricMeterProvider2>() { DefaultValue = DefaultValue.Mock }.Object;
             readonly IFabricMeter fabricMeter = Mock.Of<IFabricMeter>();
 
             // Values captured from FABRIC_METER_DESCRIPTION during CreateMeter call
@@ -46,7 +46,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 sut = new Int64MeterProvider(serviceContext);
                 systemDimensionsNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
                 systemDimensionsValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
-                sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
+                sut.Field<IFabricMeterProvider2>().Set(fabricMeterProvider);
 
                 Mock.Get(fabricMeterProvider)
                     .Setup(x => x.CreateMeter2(It.IsAny<IntPtr>()))

--- a/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
             readonly TimeSpanMeterProvider sut;
             readonly IReadOnlyCollection<string> systemDimensionsNames;
             readonly IReadOnlyCollection<string> systemDimensionsValues;
-            readonly IFabricMeterProvider fabricMeterProvider = new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object;
+            readonly IFabricMeterProvider2 fabricMeterProvider = new Mock<IFabricMeterProvider2>() { DefaultValue = DefaultValue.Mock }.Object;
             readonly IFabricMeter fabricMeter = Mock.Of<IFabricMeter>();
 
             // Values captured from FABRIC_METER_DESCRIPTION during CreateMeter call
@@ -46,7 +46,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 sut = new TimeSpanMeterProvider(serviceContext);
                 systemDimensionsNames = sut.Private().Field<IReadOnlyCollection<string>>().Value;
                 systemDimensionsValues = sut.Protected().Field<IReadOnlyCollection<string>>().Value;
-                sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
+                sut.Field<IFabricMeterProvider2>().Set(fabricMeterProvider);
 
                 Mock.Get(fabricMeterProvider)
                     .Setup(x => x.CreateMeter2(It.IsAny<IntPtr>()))

--- a/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
+++ b/test/Diagnostics/Metrics/TimeSpanMeterProviderTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Metrics
                 sut.Field<IFabricMeterProvider>().Set(fabricMeterProvider);
 
                 Mock.Get(fabricMeterProvider)
-                    .Setup(x => x.CreateMeter(It.IsAny<IntPtr>()))
+                    .Setup(x => x.CreateMeter2(It.IsAny<IntPtr>()))
                     .Callback((IntPtr ptr) =>
                     {
                         var desc = Marshal.PtrToStructure<FABRIC_METER_DESCRIPTION>(ptr);

--- a/test/TestFramework/FabricTelemetryDllFixture.cs
+++ b/test/TestFramework/FabricTelemetryDllFixture.cs
@@ -14,14 +14,14 @@ namespace Microsoft.ServiceFabric
     {
         public FabricTelemetryDllFixture()
         {
-            typeof(MeterProvider<long>).Field<Func<IFabricMeterProvider>>().Set(() => new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object);
-            typeof(MeterProvider<TimeSpan>).Field<Func<IFabricMeterProvider>>().Set(() => new Mock<IFabricMeterProvider>() { DefaultValue = DefaultValue.Mock }.Object);
+            typeof(MeterProvider<long>).Field<Func<IFabricMeterProvider2>>().Set(() => new Mock<IFabricMeterProvider2>() { DefaultValue = DefaultValue.Mock }.Object);
+            typeof(MeterProvider<TimeSpan>).Field<Func<IFabricMeterProvider2>>().Set(() => new Mock<IFabricMeterProvider2>() { DefaultValue = DefaultValue.Mock }.Object);
         }
 
         public virtual void Dispose()
         {
-            typeof(MeterProvider<long>).Field<Func<IFabricMeterProvider>>().Set(NativeTelemetry.FabricCreateMeterProvider);
-            typeof(MeterProvider<TimeSpan>).Field<Func<IFabricMeterProvider>>().Set(NativeTelemetry.FabricCreateMeterProvider);
+            typeof(MeterProvider<long>).Field<Func<IFabricMeterProvider2>>().Set(NativeTelemetry.FabricCreateMeterProvider);
+            typeof(MeterProvider<TimeSpan>).Field<Func<IFabricMeterProvider2>>().Set(NativeTelemetry.FabricCreateMeterProvider);
         }
     }
 }


### PR DESCRIPTION
This is a proposal for a solution regarding the [incident ](https://portal.microsofticm.com/imp/v5/incidents/details/802511150/summary)

Short summary of the issue:
- Customer app build with SDK 11.4 contains a old version of **IFabricMeterProvider** interface. This version passes a string as the first parameter - `CreateMeter(IntPtr metricNamespace, IntPtr name, uint count, IntPtr dimensionNames);`
- FabricTelemetry.dll implementation for the same interface has a diferent signiture of the method - `CreateMeter(IntPtr meterDescription);`
- String that is passed as the namespace gets interpreted as a struct, and dereferences pointers based on the raw binary value of the string - causing Access Violation exception, crashing the user process.

Proposed fix:
- Instead of changing the method signature, introduce a new method - `CreateMeter2(IntPtr meterDescription);`, while the implementation for the old method will throw proper exceptions, ensuring we catch them.
- This change will be coupled with an [appropriate change in FabricTelemetry.dll](https://dev.azure.com/msazure/One/_git/WindowsFabric/pullrequest/15838625)