### PR TITLE
Tolerate user-side exceptions during Close

### DIFF
--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -194,17 +194,33 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             await this.CloseCommunicationListenersAsync(cancellationToken);
 
+            ServiceTrace.Source.WriteInfoWithId(
+                TraceType,
+                this.traceId,
+                "Calling userServiceReplica.OnCloseAsync()");
+
             // Tolerate user-side exceptions so subsequent close steps can complete.
             // The exception is logged immediately and rethrown at the end of CloseAsync
             // unless a more severe exception occurs first.
-            Exception userServiceReplicaOnCloseException = null;
+            Exception userReplicaEx = null;
             try
             {
-                await UserServiceReplicaOnCloseAsync(cancellationToken);
+                await this.userServiceReplica.OnCloseAsync(cancellationToken);
+
+                ServiceTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Completed call to userServiceReplica.OnCloseAsync().");
             }
             catch (Exception ex)
             {
-                userServiceReplicaOnCloseException = ex;
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from userServiceReplica.OnCloseAsync() - {0}",
+                    ex);
+
+                userReplicaEx = ex;
             }
 
             if (this.stateProviderReplica != null)
@@ -226,37 +242,9 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             await this.CancelRunAsync();
 
-            if (userServiceReplicaOnCloseException != null)
+            if (userReplicaEx != null)
             {
-                throw userServiceReplicaOnCloseException;
-            }
-        }
-
-        async Task UserServiceReplicaOnCloseAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                ServiceTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.traceId,
-                    "Calling userServiceReplica.OnCloseAsync()");
-
-                await this.userServiceReplica.OnCloseAsync(cancellationToken);
-
-                ServiceTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.traceId,
-                    "Completed call to userServiceReplica.OnCloseAsync().");
-            }
-            catch (Exception ex)
-            {
-                ServiceTrace.Source.WriteWarningWithId(
-                    TraceType,
-                    this.traceId,
-                    "Unhandled exception from userServiceReplica.OnCloseAsync() - {0}",
-                    ex);
-
-                throw;
+                throw userReplicaEx;
             }
         }
 

--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -194,9 +194,18 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             await this.CloseCommunicationListenersAsync(cancellationToken);
 
-            var userServiceReplica_OnCloseAsync = Task.Run(() => UserServiceReplicaOnCloseAsync(cancellationToken), cancellationToken); // we want to tolerate user-side exceptions to perform closing properly
-                                                                                                                                        // so these are propagated in the very end of the method unless a more severe exception has occured
-                                                                                                                                        // in any case, the user-side exception is logged
+            // Tolerate user-side exceptions so subsequent close steps can complete.
+            // The exception is logged immediately and rethrown at the end of CloseAsync
+            // unless a more severe exception occurs first.
+            Exception userServiceReplicaOnCloseException = null;
+            try
+            {
+                await UserServiceReplicaOnCloseAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                userServiceReplicaOnCloseException = ex;
+            }
 
             if (this.stateProviderReplica != null)
             {
@@ -216,7 +225,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             await this.CancelRunAsync();
-            await userServiceReplica_OnCloseAsync;
+
+            if (userServiceReplicaOnCloseException != null)
+            {
+                throw userServiceReplicaOnCloseException;
+            }
         }
 
         async Task UserServiceReplicaOnCloseAsync(CancellationToken cancellationToken)
@@ -226,9 +239,9 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 ServiceTrace.Source.WriteInfoWithId(
                     TraceType,
                     this.traceId,
-                    "Calling to userServiceReplica.OnCloseAsync()");
+                    "Calling userServiceReplica.OnCloseAsync()");
 
-                await userServiceReplica.OnCloseAsync(cancellationToken);
+                await this.userServiceReplica.OnCloseAsync(cancellationToken);
 
                 ServiceTrace.Source.WriteInfoWithId(
                     TraceType,
@@ -237,10 +250,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
             catch (Exception ex)
             {
-                ServiceTrace.Source.WriteErrorWithId(TraceType + ServiceHelper.ApiErrorTraceTypeSuffix,
-                    traceId,
-                    "userServiceReplica.OnCloseAsync threw: {0}",
-                    ex.ToString());
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from userServiceReplica.OnCloseAsync() - {0}",
+                    ex);
 
                 throw;
             }

--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -193,17 +193,10 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 "CloseAsync");
 
             await this.CloseCommunicationListenersAsync(cancellationToken);
-            ServiceTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.traceId,
-                "Calling userServiceReplica.OnCloseAsync()");
 
-            await this.userServiceReplica.OnCloseAsync(cancellationToken);
-
-            ServiceTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.traceId,
-                "Completed call to userServiceReplica.OnCloseAsync().");
+            var userServiceReplica_OnCloseAsync = Task.Run(() => UserServiceReplicaOnCloseAsync(cancellationToken), cancellationToken); // we want to tolerate user-side exceptions to perform closing properly
+                                                                                                                                        // so these are propagated in the very end of the method unless a more severe exception has occured
+                                                                                                                                        // in any case, the user-side exception is logged
 
             if (this.stateProviderReplica != null)
             {
@@ -223,6 +216,34 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             await this.CancelRunAsync();
+            await userServiceReplica_OnCloseAsync;
+        }
+
+        async Task UserServiceReplicaOnCloseAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                ServiceTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Calling to userServiceReplica.OnCloseAsync()");
+
+                await userServiceReplica.OnCloseAsync(cancellationToken);
+
+                ServiceTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Completed call to userServiceReplica.OnCloseAsync().");
+            }
+            catch (Exception ex)
+            {
+                ServiceTrace.Source.WriteErrorWithId(TraceType + ServiceHelper.ApiErrorTraceTypeSuffix,
+                    traceId,
+                    "userServiceReplica.OnCloseAsync threw: {0}",
+                    ex.ToString());
+
+                throw;
+            }
         }
 
         void IStatefulServiceReplica.Abort()

--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -410,7 +410,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         /// 3) When replica is being aborted.
         ///
         /// </summary>
-        private async Task CancelRunAsync()
+        protected virtual async Task CancelRunAsync()
         {
             if (this.runAsynCancellationTokenSource != null &&
                 this.runAsynCancellationTokenSource.IsCancellationRequested == false)

--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Fabric;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Data;
@@ -98,14 +99,14 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             var replicator = await this.stateProviderReplica.OpenAsync(openMode, partition, cancellationToken);
 
-            Exception userReplicaEx = null;
+            ExceptionDispatchInfo userReplicaEx = null;
             try
             {
                 await this.userServiceReplica.OnOpenAsync(openMode, cancellationToken);
             }
             catch (Exception ex)
             {
-                userReplicaEx = ex;
+                userReplicaEx = ExceptionDispatchInfo.Capture(ex);
 
                 ServiceTrace.Source.WriteWarningWithId(
                     TraceType,
@@ -117,7 +118,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             if (userReplicaEx != null)
             {
                 await this.stateProviderReplica.CloseAsync(cancellationToken);
-                throw userReplicaEx;
+                userReplicaEx.Throw();
             }
 
             return replicator;
@@ -202,7 +203,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             // Tolerate user-side exceptions so subsequent close steps can complete.
             // The exception is logged immediately and rethrown at the end of CloseAsync
             // unless a more severe exception occurs first.
-            Exception userReplicaEx = null;
+            ExceptionDispatchInfo userReplicaEx = null;
             try
             {
                 await this.userServiceReplica.OnCloseAsync(cancellationToken);
@@ -220,7 +221,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                     "Unhandled exception from userServiceReplica.OnCloseAsync() - {0}",
                     ex);
 
-                userReplicaEx = ex;
+                userReplicaEx = ExceptionDispatchInfo.Capture(ex);
             }
 
             if (this.stateProviderReplica != null)
@@ -242,10 +243,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             await this.CancelRunAsync();
 
-            if (userReplicaEx != null)
-            {
-                throw userReplicaEx;
-            }
+            userReplicaEx?.Throw();
         }
 
         void IStatefulServiceReplica.Abort()

--- a/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
+++ b/src/Services/Runtime/StatefulServiceReplicaAdapter.cs
@@ -200,10 +200,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 this.traceId,
                 "Calling userServiceReplica.OnCloseAsync()");
 
-            // Tolerate user-side exceptions so subsequent close steps can complete.
-            // The exception is logged immediately and rethrown at the end of CloseAsync
-            // unless a more severe exception occurs first.
-            ExceptionDispatchInfo userReplicaEx = null;
+            // Tolerate exceptions from each close step so subsequent steps can complete.
+            // All collected exceptions are reported together at the end: a single one is
+            // rethrown preserving its stack, multiple are wrapped in an AggregateException
+            // so no failure is lost.
+            var exceptions = new List<Exception>();
             try
             {
                 await this.userServiceReplica.OnCloseAsync(cancellationToken);
@@ -221,7 +222,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                     "Unhandled exception from userServiceReplica.OnCloseAsync() - {0}",
                     ex);
 
-                userReplicaEx = ExceptionDispatchInfo.Capture(ex);
+                exceptions.Add(ex);
             }
 
             if (this.stateProviderReplica != null)
@@ -231,19 +232,52 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 this.traceId,
                 "Calling IStateProviderReplica.CloseAsync()");
 
-                await this.stateProviderReplica.CloseAsync(cancellationToken);
+                try
+                {
+                    await this.stateProviderReplica.CloseAsync(cancellationToken);
 
-                ServiceTrace.Source.WriteInfoWithId(
-                    TraceType,
-                    this.traceId,
-                    "Completed call to IStateProviderReplica.CloseAsync.");
+                    ServiceTrace.Source.WriteInfoWithId(
+                        TraceType,
+                        this.traceId,
+                        "Completed call to IStateProviderReplica.CloseAsync.");
 
-                this.stateProviderReplica = null;
+                    this.stateProviderReplica = null;
+                }
+                catch (Exception ex)
+                {
+                    ServiceTrace.Source.WriteWarningWithId(
+                        TraceType,
+                        this.traceId,
+                        "Unhandled exception from IStateProviderReplica.CloseAsync() - {0}",
+                        ex);
+
+                    exceptions.Add(ex);
+                }
             }
 
-            await this.CancelRunAsync();
+            try
+            {
+                await this.CancelRunAsync();
+            }
+            catch (Exception ex)
+            {
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from CancelRunAsync() - {0}",
+                    ex);
 
-            userReplicaEx?.Throw();
+                exceptions.Add(ex);
+            }
+
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+            else if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
         }
 
         void IStatefulServiceReplica.Abort()

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
         }
 
-        public sealed class CloseAsync : StatefulServiceReplicaAdapterTest
+        public sealed class Close : StatefulServiceReplicaAdapterTest
         {
             readonly CancellationToken cancellation = new CancellationToken();
 
@@ -108,7 +108,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await sut.CloseAsync(cancellation);
 
                 // Assert
-                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(It.IsAny<CancellationToken>()));
+                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(cancellation));
             }
 
             [Fact]
@@ -131,7 +131,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             {
                 // Arrange
                 var expected = new InvalidOperationException();
-                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(It.IsAny<CancellationToken>())).ThrowsAsync(expected);
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(expected);
 
                 // Act
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
@@ -145,7 +145,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             {
                 // Arrange
                 IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
-                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException());
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
 
                 // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
@@ -153,6 +153,20 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
+            }
+
+            [Fact]
+            public async Task CancelsRunAsyncEvenWhenUserServiceReplicaOnCloseAsyncThrows()
+            {
+                // Arrange
+                sut.Field<CancellationTokenSource>().Set(new CancellationTokenSource());
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
+
+                // Act
+                await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
+
+                // Assert
+                Assert.Null(sut.Field<CancellationTokenSource>().Value);
             }
         }
     }

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fuzzy;
 using Inspector;
+using Microsoft.ServiceFabric.Data;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Moq;
 using Xunit;
@@ -79,6 +80,79 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 IList<CommunicationListenerInfo> expected = communicationListeners.Values.ToList();
                 var actual = sut.Field<IList<CommunicationListenerInfo>>().Value;
                 Assert.Equal(expected, actual);
+            }
+        }
+
+        public sealed class CloseAsync : StatefulServiceReplicaAdapterTest
+        {
+            readonly CancellationToken cancellation = new CancellationToken();
+
+            [Fact]
+            public async Task ClosesStateProviderReplica()
+            {
+                // Arrange
+                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+
+                // Act
+                await sut.CloseAsync(cancellation);
+
+                // Assert
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
+                Assert.Null(sut.Field<IStateProviderReplica>().Value);
+            }
+
+            [Fact]
+            public async Task InvokesOnCloseAsyncOnUserServiceReplica()
+            {
+                // Act
+                await sut.CloseAsync(cancellation);
+
+                // Assert
+                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(It.IsAny<CancellationToken>()));
+            }
+
+            [Fact]
+            public async Task ClosesCommunicationListeners()
+            {
+                // Arrange
+                CommunicationListenerInfo listenerInfo = fuzzy.CommunicationListenerInfo();
+                sut.Field<IList<CommunicationListenerInfo>>().Set(new List<CommunicationListenerInfo> { listenerInfo });
+
+                // Act
+                await sut.CloseAsync(cancellation);
+
+                // Assert
+                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation));
+                Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
+            }
+
+            [Fact]
+            public async Task PropagatesExceptionFromUserServiceReplicaOnCloseAsync()
+            {
+                // Arrange
+                var expected = new InvalidOperationException();
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(It.IsAny<CancellationToken>())).ThrowsAsync(expected);
+
+                // Act
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
+
+                // Assert
+                Assert.Same(expected, actual);
+            }
+
+            [Fact]
+            public async Task ClosesStateProviderReplicaEvenWhenUserServiceReplicaOnCloseAsyncThrows()
+            {
+                // Arrange
+                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException());
+
+                // Act
+                await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
+
+                // Assert
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
+                Assert.Null(sut.Field<IStateProviderReplica>().Value);
             }
         }
     }

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -22,6 +22,8 @@ namespace Microsoft.ServiceFabric.Services.Runtime
     public abstract class StatefulServiceReplicaAdapterTest
     {
         readonly IStatefulServiceReplica sut;
+        readonly IStateProviderReplica stateProviderReplica;
+        readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
         // Constructor parameters
         readonly StatefulServiceContext context = fuzzy.StatefulServiceContext();
@@ -30,8 +32,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         // Test fixture
         static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
 
-        protected StatefulServiceReplicaAdapterTest() =>
+        protected StatefulServiceReplicaAdapterTest()
+        {
             sut = new StatefulServiceReplicaAdapter(context, userServiceReplica);
+            stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+        }
 
         public sealed class Constructor : StatefulServiceReplicaAdapterTest
         {
@@ -60,30 +65,23 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         {
             readonly ReplicaOpenMode openMode = fuzzy.Enum<ReplicaOpenMode>();
             readonly IStatefulServicePartition partition = new Mock<IStatefulServicePartition> { DefaultValue = DefaultValue.Mock }.Object;
-            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
             [Fact]
             public async Task ReturnsReplicatorFromStateProviderReplica()
             {
-                // Arrange
-                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
                 IReplicator expected = Mock.Of<IReplicator>();
                 Mock.Get(stateProviderReplica).Setup(_ => _.OpenAsync(openMode, partition, cancellation)).ReturnsAsync(expected);
 
-                // Act
                 IReplicator actual = await sut.OpenAsync(openMode, partition, cancellation);
 
-                // Assert
                 Assert.Same(expected, actual);
             }
 
             [Fact]
             public async Task InvokesOnOpenAsyncOnUserServiceReplica()
             {
-                // Act
                 await sut.OpenAsync(openMode, partition, cancellation);
 
-                // Assert
                 Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(openMode, cancellation), Times.Once);
                 Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(It.IsAny<ReplicaOpenMode>(), It.IsAny<CancellationToken>()), Times.Once);
             }
@@ -91,28 +89,21 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             [Fact]
             public async Task PropagatesExceptionFromUserServiceReplicaOnOpenAsync()
             {
-                // Arrange
                 var expected = new InvalidOperationException();
                 Mock.Get(userServiceReplica).Setup(_ => _.OnOpenAsync(openMode, cancellation)).ThrowsAsync(expected);
 
-                // Act
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.OpenAsync(openMode, partition, cancellation));
 
-                // Assert
                 Assert.Same(expected, actual);
             }
 
             [Fact]
             public async Task ClosesStateProviderReplicaWhenUserServiceReplicaOnOpenAsyncThrows()
             {
-                // Arrange
-                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
                 Mock.Get(userServiceReplica).Setup(_ => _.OnOpenAsync(openMode, cancellation)).ThrowsAsync(new InvalidOperationException());
 
-                // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.OpenAsync(openMode, partition, cancellation));
 
-                // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
             }
@@ -120,12 +111,9 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
         public sealed class ChangeRole : StatefulServiceReplicaAdapterTest
         {
-            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
-
             [Fact]
             public async Task ToPrimaryCreatesAndOpensCommunicationListeners()
             {
-                // Arrange
                 IEnumerable<ServiceReplicaListener> replicaListeners = fuzzy.Array(fuzzy.ServiceReplicaListener);
                 Mock.Get(userServiceReplica).Setup(_ => _.CreateServiceReplicaListeners()).Returns(replicaListeners);
 
@@ -136,10 +124,8 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 sut.Field<Func<ServiceReplicaListener, StatefulServiceContext, CommunicationListenerInfo>>().Set(createCommunicationListener.Object);
 
-                // Act
                 await sut.ChangeRoleAsync(ReplicaRole.Primary, cancellation);
 
-                // Assert
                 IList<CommunicationListenerInfo> expected = communicationListeners.Values.ToList();
                 var actual = sut.Field<IList<CommunicationListenerInfo>>().Value;
                 Assert.Equal(expected, actual);
@@ -148,18 +134,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
         public sealed class Close : StatefulServiceReplicaAdapterTest
         {
-            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
-
             [Fact]
             public async Task ClosesStateProviderReplica()
             {
-                // Arrange
-                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
-
-                // Act
                 await sut.CloseAsync(cancellation);
 
-                // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
@@ -168,10 +147,8 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             [Fact]
             public async Task InvokesOnCloseAsyncOnUserServiceReplica()
             {
-                // Act
                 await sut.CloseAsync(cancellation);
 
-                // Assert
                 Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(cancellation), Times.Once);
                 Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(It.IsAny<CancellationToken>()), Times.Once);
             }
@@ -179,14 +156,11 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             [Fact]
             public async Task ClosesCommunicationListeners()
             {
-                // Arrange
                 CommunicationListenerInfo listenerInfo = fuzzy.CommunicationListenerInfo();
                 sut.Field<IList<CommunicationListenerInfo>>().Set(new List<CommunicationListenerInfo> { listenerInfo });
 
-                // Act
                 await sut.CloseAsync(cancellation);
 
-                // Assert
                 Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
@@ -195,28 +169,21 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             [Fact]
             public async Task PropagatesExceptionFromUserServiceReplicaOnCloseAsync()
             {
-                // Arrange
                 var expected = new InvalidOperationException();
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(expected);
 
-                // Act
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
 
-                // Assert
                 Assert.Same(expected, actual);
             }
 
             [Fact]
             public async Task ClosesStateProviderReplicaEvenWhenUserServiceReplicaOnCloseAsyncThrows()
             {
-                // Arrange
-                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
 
-                // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
 
-                // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
@@ -225,52 +192,42 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             [Fact]
             public async Task CancelsRunAsyncEvenWhenUserServiceReplicaOnCloseAsyncThrows()
             {
-                // Arrange
                 var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
                 IStatefulServiceReplica ssReplica = adapter.Object;
 
-                // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() => ssReplica.CloseAsync(cancellation));
 
-                // Assert
                 adapter.Protected().Verify("CancelRunAsync", Times.Once());
             }
 
             [Fact]
             public async Task AggregatesExceptionsFromAllStepsWhenAllThrow()
             {
-                // Arrange
                 var userEx = new InvalidOperationException();
                 var stateEx = new InvalidOperationException();
                 var runEx = new InvalidOperationException();
                 var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
-                IStateProviderReplica stateProviderReplica = adapter.Object.Field<IStateProviderReplica>().Value;
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(userEx);
                 Mock.Get(stateProviderReplica).Setup(_ => _.CloseAsync(cancellation)).ThrowsAsync(stateEx);
                 adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
                 IStatefulServiceReplica ssReplica = adapter.Object;
 
-                // Act
                 var actual = await Assert.ThrowsAsync<AggregateException>(() => ssReplica.CloseAsync(cancellation));
 
-                // Assert
                 Assert.Equal(new Exception[] { userEx, stateEx, runEx }, actual.InnerExceptions);
             }
 
             [Fact]
             public async Task PropagatesExceptionFromCancelRunAsync()
             {
-                // Arrange
                 var runEx = new InvalidOperationException();
                 var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
                 adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
                 IStatefulServiceReplica ssReplica = adapter.Object;
 
-                // Act
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => ssReplica.CloseAsync(cancellation));
 
-                // Assert
                 Assert.Same(runEx, actual);
             }
         }

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Services.Runtime
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public abstract class StatefulServiceReplicaAdapterTest
     {
         readonly IStatefulServiceReplica sut;
@@ -52,6 +53,64 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             public void UsesServiceReplicaListenerInstantiateToCreateCommunicationListeners()
             {
                 Assert.Equal(ServiceReplicaListener.Instantiate, sut.Field<Func<ServiceReplicaListener, StatefulServiceContext, CommunicationListenerInfo>>().Value);
+            }
+        }
+
+        public sealed class Open : StatefulServiceReplicaAdapterTest
+        {
+            readonly ReplicaOpenMode openMode = fuzzy.Enum<ReplicaOpenMode>();
+            readonly IStatefulServicePartition partition = new Mock<IStatefulServicePartition> { DefaultValue = DefaultValue.Mock }.Object;
+            readonly CancellationToken cancellation = new CancellationToken();
+
+            [Fact]
+            public async Task OpensStateProviderReplica()
+            {
+                // Arrange
+                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+
+                // Act
+                await sut.OpenAsync(openMode, partition, cancellation);
+
+                // Assert
+                Mock.Get(stateProviderReplica).Verify(_ => _.OpenAsync(openMode, partition, cancellation));
+            }
+
+            [Fact]
+            public async Task InvokesOnOpenAsyncOnUserServiceReplica()
+            {
+                // Act
+                await sut.OpenAsync(openMode, partition, cancellation);
+
+                // Assert
+                Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(openMode, cancellation));
+            }
+
+            [Fact]
+            public async Task PropagatesExceptionFromUserServiceReplicaOnOpenAsync()
+            {
+                // Arrange
+                var expected = new InvalidOperationException();
+                Mock.Get(userServiceReplica).Setup(_ => _.OnOpenAsync(openMode, cancellation)).ThrowsAsync(expected);
+
+                // Act
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.OpenAsync(openMode, partition, cancellation));
+
+                // Assert
+                Assert.Same(expected, actual);
+            }
+
+            [Fact]
+            public async Task ClosesStateProviderReplicaWhenUserServiceReplicaOnOpenAsyncThrows()
+            {
+                // Arrange
+                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+                Mock.Get(userServiceReplica).Setup(_ => _.OnOpenAsync(openMode, cancellation)).ThrowsAsync(new InvalidOperationException());
+
+                // Act
+                await Assert.ThrowsAsync<InvalidOperationException>(() => sut.OpenAsync(openMode, partition, cancellation));
+
+                // Assert
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
             }
         }
 

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -14,6 +14,7 @@ using Inspector;
 using Microsoft.ServiceFabric.Data;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Moq;
+using Moq.Protected;
 using Xunit;
 
 namespace Microsoft.ServiceFabric.Services.Runtime
@@ -59,7 +60,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         {
             readonly ReplicaOpenMode openMode = fuzzy.Enum<ReplicaOpenMode>();
             readonly IStatefulServicePartition partition = new Mock<IStatefulServicePartition> { DefaultValue = DefaultValue.Mock }.Object;
-            readonly CancellationToken cancellation = new CancellationToken();
+            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
             [Fact]
             public async Task ReturnsReplicatorFromStateProviderReplica()
@@ -84,6 +85,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(openMode, cancellation), Times.Once);
+                Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(It.IsAny<ReplicaOpenMode>(), It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]
@@ -112,12 +114,13 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
         public sealed class ChangeRole : StatefulServiceReplicaAdapterTest
         {
-            readonly CancellationToken cancellation = new CancellationToken();
+            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
             [Fact]
             public async Task ToPrimaryCreatesAndOpensCommunicationListeners()
@@ -145,7 +148,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
         public sealed class Close : StatefulServiceReplicaAdapterTest
         {
-            readonly CancellationToken cancellation = new CancellationToken();
+            readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
             [Fact]
             public async Task ClosesStateProviderReplica()
@@ -158,6 +161,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
             }
 
@@ -169,6 +173,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(cancellation), Times.Once);
+                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]
@@ -183,6 +188,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation), Times.Once);
+                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
             }
 
@@ -212,6 +218,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 // Assert
                 Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
             }
 
@@ -219,33 +226,52 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             public async Task CancelsRunAsyncEvenWhenUserServiceReplicaOnCloseAsyncThrows()
             {
                 // Arrange
-                var source = new CancellationTokenSource();
-                sut.Field<CancellationTokenSource>().Set(source);
+                var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
+                IStatefulServiceReplica ssReplica = adapter.Object;
 
                 // Act
-                await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
+                await Assert.ThrowsAsync<InvalidOperationException>(() => ssReplica.CloseAsync(cancellation));
 
                 // Assert
-                Assert.True(source.IsCancellationRequested);
-                Assert.Null(sut.Field<CancellationTokenSource>().Value);
+                adapter.Protected().Verify("CancelRunAsync", Times.Once());
             }
 
             [Fact]
-            public async Task AggregatesExceptionsFromUserServiceReplicaAndStateProviderReplicaWhenBothThrow()
+            public async Task AggregatesExceptionsFromAllStepsWhenAllThrow()
             {
                 // Arrange
                 var userEx = new InvalidOperationException();
                 var stateEx = new InvalidOperationException();
-                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+                var runEx = new InvalidOperationException();
+                var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
+                IStateProviderReplica stateProviderReplica = adapter.Object.Field<IStateProviderReplica>().Value;
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(userEx);
                 Mock.Get(stateProviderReplica).Setup(_ => _.CloseAsync(cancellation)).ThrowsAsync(stateEx);
+                adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
+                IStatefulServiceReplica ssReplica = adapter.Object;
 
                 // Act
-                var actual = await Assert.ThrowsAsync<AggregateException>(() => sut.CloseAsync(cancellation));
+                var actual = await Assert.ThrowsAsync<AggregateException>(() => ssReplica.CloseAsync(cancellation));
 
                 // Assert
-                Assert.Equal(new Exception[] { userEx, stateEx }, actual.InnerExceptions);
+                Assert.Equal(new Exception[] { userEx, stateEx, runEx }, actual.InnerExceptions);
+            }
+
+            [Fact]
+            public async Task PropagatesExceptionFromCancelRunAsync()
+            {
+                // Arrange
+                var runEx = new InvalidOperationException();
+                var adapter = new Mock<StatefulServiceReplicaAdapter>(context, userServiceReplica) { CallBase = true };
+                adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
+                IStatefulServiceReplica ssReplica = adapter.Object;
+
+                // Act
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => ssReplica.CloseAsync(cancellation));
+
+                // Assert
+                Assert.Same(runEx, actual);
             }
         }
     }

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Microsoft.ServiceFabric.Services.Runtime
 {
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public abstract class StatefulServiceReplicaAdapterTest
     {
         readonly IStatefulServiceReplica sut;

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -230,6 +230,23 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 Assert.True(source.IsCancellationRequested);
                 Assert.Null(sut.Field<CancellationTokenSource>().Value);
             }
+
+            [Fact]
+            public async Task AggregatesExceptionsFromUserServiceReplicaAndStateProviderReplicaWhenBothThrow()
+            {
+                // Arrange
+                var userEx = new InvalidOperationException();
+                var stateEx = new InvalidOperationException();
+                IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+                Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(userEx);
+                Mock.Get(stateProviderReplica).Setup(_ => _.CloseAsync(cancellation)).ThrowsAsync(stateEx);
+
+                // Act
+                var actual = await Assert.ThrowsAsync<AggregateException>(() => sut.CloseAsync(cancellation));
+
+                // Assert
+                Assert.Equal(new Exception[] { userEx, stateEx }, actual.InnerExceptions);
+            }
         }
     }
 }

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -62,16 +62,18 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             readonly CancellationToken cancellation = new CancellationToken();
 
             [Fact]
-            public async Task OpensStateProviderReplica()
+            public async Task ReturnsReplicatorFromStateProviderReplica()
             {
                 // Arrange
                 IStateProviderReplica stateProviderReplica = sut.Field<IStateProviderReplica>().Value;
+                IReplicator expected = Mock.Of<IReplicator>();
+                Mock.Get(stateProviderReplica).Setup(_ => _.OpenAsync(openMode, partition, cancellation)).ReturnsAsync(expected);
 
                 // Act
-                await sut.OpenAsync(openMode, partition, cancellation);
+                IReplicator actual = await sut.OpenAsync(openMode, partition, cancellation);
 
                 // Assert
-                Mock.Get(stateProviderReplica).Verify(_ => _.OpenAsync(openMode, partition, cancellation));
+                Assert.Same(expected, actual);
             }
 
             [Fact]
@@ -81,7 +83,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await sut.OpenAsync(openMode, partition, cancellation);
 
                 // Assert
-                Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(openMode, cancellation));
+                Mock.Get(userServiceReplica).Verify(_ => _.OnOpenAsync(openMode, cancellation), Times.Once);
             }
 
             [Fact]
@@ -109,7 +111,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.OpenAsync(openMode, partition, cancellation));
 
                 // Assert
-                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
             }
         }
 
@@ -155,7 +157,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await sut.CloseAsync(cancellation);
 
                 // Assert
-                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
             }
 
@@ -166,7 +168,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await sut.CloseAsync(cancellation);
 
                 // Assert
-                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(cancellation));
+                Mock.Get(userServiceReplica).Verify(_ => _.OnCloseAsync(cancellation), Times.Once);
             }
 
             [Fact]
@@ -180,7 +182,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await sut.CloseAsync(cancellation);
 
                 // Assert
-                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation));
+                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
             }
 
@@ -209,7 +211,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
 
                 // Assert
-                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation));
+                Mock.Get(stateProviderReplica).Verify(_ => _.CloseAsync(cancellation), Times.Once);
                 Assert.Null(sut.Field<IStateProviderReplica>().Value);
             }
 

--- a/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
+++ b/test/Services/Runtime/StatefulServiceReplicaAdapterTest.cs
@@ -219,13 +219,15 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             public async Task CancelsRunAsyncEvenWhenUserServiceReplicaOnCloseAsyncThrows()
             {
                 // Arrange
-                sut.Field<CancellationTokenSource>().Set(new CancellationTokenSource());
+                var source = new CancellationTokenSource();
+                sut.Field<CancellationTokenSource>().Set(source);
                 Mock.Get(userServiceReplica).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
 
                 // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
 
                 // Assert
+                Assert.True(source.IsCancellationRequested);
                 Assert.Null(sut.Field<CancellationTokenSource>().Value);
             }
         }


### PR DESCRIPTION
Tolerate exceptions thrown by `await userServiceReplica.OnCloseAsync(cancellationToken);` enabling appropriate Closing

fixes internal work items 37306548, 38096923