### PR TITLE
Enable execution of .sh scripts in WSL on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Let Git detect text files, store LF line endings, check out LF endings on Linux and CRLF endings on Windows
 * text=auto
+
+# Shell scripts must keep LF endings on Windows to be executable in WSL
+*.sh text eol=lf


### PR DESCRIPTION
They must be checked out with LF line endings whereas the previous default on Windows was CRLF for all files.