### PR TITLE
UninstallSfSdkFromGac.ps1 switch from VS2022 to VS2026

### DIFF
--- a/eng/UninstallSfSdkFromGac.ps1
+++ b/eng/UninstallSfSdkFromGac.ps1
@@ -3,7 +3,7 @@ $assemblies = "Microsoft.ServiceFabric.Data.Interfaces",
 
 if (-not $env:DevEnvDir)
 {
-    & "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -SkipAutomaticLocation
+    & "${env:ProgramFiles}\Microsoft Visual Studio\18\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -SkipAutomaticLocation
 }
 
 foreach ($assembly in $assemblies)


### PR DESCRIPTION
Switch from Visual Studio 2022 to Visual Studio 2026, which is now installed on the `windows-latest` Actions runner images.