### PR TITLE
Tolerate user-side exceptions during stateless instance Close

### DIFF
--- a/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         /// 2) When replica is being aborted.
         ///
         /// </summary>
-        protected internal virtual async Task CancelRunAsync()
+        protected virtual async Task CancelRunAsync()
         {
             if (this.runAsynCancellationTokenSource != null &&
                 this.runAsynCancellationTokenSource.IsCancellationRequested == false)

--- a/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Fabric;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Diagnostics.Tracing;
@@ -118,20 +119,75 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
         async Task IStatelessServiceInstance.CloseAsync(CancellationToken cancellationToken)
         {
-            await this.CloseCommunicationListenersAsync(cancellationToken);
-            await this.CancelRunAsync();
+            // Tolerate exceptions from each close step so subsequent steps can complete.
+            // All collected exceptions are reported together at the end: a single one is
+            // rethrown preserving its stack, multiple are wrapped in an AggregateException
+            // so no failure is lost.
+            var exceptions = new List<Exception>();
+
+            try
+            {
+                await this.CloseCommunicationListenersAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from CloseCommunicationListenersAsync() - {0}",
+                    ex);
+
+                exceptions.Add(ex);
+            }
+
+            try
+            {
+                await this.CancelRunAsync();
+            }
+            catch (Exception ex)
+            {
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from CancelRunAsync() - {0}",
+                    ex);
+
+                exceptions.Add(ex);
+            }
 
             ServiceTrace.Source.WriteInfoWithId(
                 TraceType,
                 this.traceId,
                 "Calling userServiceInstance.OnCloseAsync()");
 
-            await this.userServiceInstance.OnCloseAsync(cancellationToken);
+            try
+            {
+                await this.userServiceInstance.OnCloseAsync(cancellationToken);
 
-            ServiceTrace.Source.WriteInfoWithId(
-                TraceType,
-                this.traceId,
-                "Completed call to userServiceInstance.OnCloseAsync().");
+                ServiceTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Completed call to userServiceInstance.OnCloseAsync().");
+            }
+            catch (Exception ex)
+            {
+                ServiceTrace.Source.WriteWarningWithId(
+                    TraceType,
+                    this.traceId,
+                    "Unhandled exception from userServiceInstance.OnCloseAsync() - {0}",
+                    ex);
+
+                exceptions.Add(ex);
+            }
+
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+            else if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
         }
 
         void IStatelessServiceInstance.Abort()
@@ -244,7 +300,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         /// 2) When replica is being aborted.
         ///
         /// </summary>
-        private async Task CancelRunAsync()
+        protected virtual async Task CancelRunAsync()
         {
             if (this.runAsynCancellationTokenSource != null &&
                 this.runAsynCancellationTokenSource.IsCancellationRequested == false)

--- a/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -125,20 +125,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             // so no failure is lost.
             var exceptions = new List<Exception>();
 
-            try
-            {
-                await this.CloseCommunicationListenersAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                ServiceTrace.Source.WriteWarningWithId(
-                    TraceType,
-                    this.traceId,
-                    "Unhandled exception from CloseCommunicationListenersAsync() - {0}",
-                    ex);
-
-                exceptions.Add(ex);
-            }
+            await this.CloseCommunicationListenersAsync(cancellationToken); // no exception is expected from this call
 
             try
             {

--- a/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         /// 2) When replica is being aborted.
         ///
         /// </summary>
-        protected virtual async Task CancelRunAsync()
+        protected internal virtual async Task CancelRunAsync()
         {
             if (this.runAsynCancellationTokenSource != null &&
                 this.runAsynCancellationTokenSource.IsCancellationRequested == false)

--- a/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
+++ b/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         // Constructor parameters
         readonly StatelessServiceContext context = fuzzy.StatelessServiceContext();
         readonly IStatelessUserServiceInstance userServiceInstance = new Mock<IStatelessUserServiceInstance> { DefaultValue = DefaultValue.Mock }.Object;
+
         readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
         // Test fixture

--- a/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
+++ b/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
@@ -13,6 +13,7 @@ using Fuzzy;
 using Inspector;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Moq;
+using Moq.Protected;
 using Xunit;
 
 namespace Microsoft.ServiceFabric.Services.Runtime
@@ -24,6 +25,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         // Constructor parameters
         readonly StatelessServiceContext context = fuzzy.StatelessServiceContext();
         readonly IStatelessUserServiceInstance userServiceInstance = new Mock<IStatelessUserServiceInstance> { DefaultValue = DefaultValue.Mock }.Object;
+        readonly CancellationToken cancellation = TestContext.Current.CancellationToken;
 
         // Test fixture
         static readonly IFuzz fuzzy = new RandomFuzz(Environment.TickCount);
@@ -57,7 +59,6 @@ namespace Microsoft.ServiceFabric.Services.Runtime
         public sealed class OpenAsync : StatelessServiceInstanceAdapterTest
         {
             readonly IStatelessServicePartition partition = Mock.Of<IStatelessServicePartition>();
-            readonly CancellationToken cancellation = new CancellationToken();
 
             [Fact]
             public async Task ToPrimaryCreatesAndOpensCommunicationListeners()
@@ -80,6 +81,82 @@ namespace Microsoft.ServiceFabric.Services.Runtime
                 IList<CommunicationListenerInfo> expected = communicationListeners.Values.ToList();
                 var actual = sut.Field<IList<CommunicationListenerInfo>>().Value;
                 Assert.Equal(expected, actual);
+            }
+        }
+
+        public sealed class Close : StatelessServiceInstanceAdapterTest
+        {
+            [Fact]
+            public async Task InvokesOnCloseAsyncOnUserServiceInstance()
+            {
+                await sut.CloseAsync(cancellation);
+
+                Mock.Get(userServiceInstance).Verify(_ => _.OnCloseAsync(cancellation), Times.Once);
+                Mock.Get(userServiceInstance).Verify(_ => _.OnCloseAsync(It.IsAny<CancellationToken>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task ClosesCommunicationListeners()
+            {
+                CommunicationListenerInfo listenerInfo = fuzzy.CommunicationListenerInfo();
+                sut.Field<IList<CommunicationListenerInfo>>().Set(new List<CommunicationListenerInfo> { listenerInfo });
+
+                await sut.CloseAsync(cancellation);
+
+                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation), Times.Once);
+                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
+                Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
+            }
+
+            [Fact]
+            public async Task PropagatesExceptionFromUserServiceInstanceOnCloseAsync()
+            {
+                var expected = new InvalidOperationException();
+                Mock.Get(userServiceInstance).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(expected);
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.CloseAsync(cancellation));
+
+                Assert.Same(expected, actual);
+            }
+
+            [Fact]
+            public async Task CancelsRunAsyncEvenWhenUserServiceInstanceOnCloseAsyncThrows()
+            {
+                var adapter = new Mock<StatelessServiceInstanceAdapter>(context, userServiceInstance) { CallBase = true };
+                Mock.Get(userServiceInstance).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
+                IStatelessServiceInstance ssInstance = adapter.Object;
+
+                await Assert.ThrowsAsync<InvalidOperationException>(() => ssInstance.CloseAsync(cancellation));
+
+                adapter.Protected().Verify("CancelRunAsync", Times.Once());
+            }
+
+            [Fact]
+            public async Task AggregatesExceptionsFromAllStepsWhenAllThrow()
+            {
+                var runEx = new InvalidOperationException();
+                var userEx = new InvalidOperationException();
+                var adapter = new Mock<StatelessServiceInstanceAdapter>(context, userServiceInstance) { CallBase = true };
+                adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
+                Mock.Get(userServiceInstance).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(userEx);
+                IStatelessServiceInstance ssInstance = adapter.Object;
+
+                var actual = await Assert.ThrowsAsync<AggregateException>(() => ssInstance.CloseAsync(cancellation));
+
+                Assert.Equal(new Exception[] { runEx, userEx }, actual.InnerExceptions);
+            }
+
+            [Fact]
+            public async Task PropagatesExceptionFromCancelRunAsync()
+            {
+                var runEx = new InvalidOperationException();
+                var adapter = new Mock<StatelessServiceInstanceAdapter>(context, userServiceInstance) { CallBase = true };
+                adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(runEx);
+                IStatelessServiceInstance ssInstance = adapter.Object;
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => ssInstance.CloseAsync(cancellation));
+
+                Assert.Same(runEx, actual);
             }
         }
     }

--- a/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
+++ b/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
@@ -96,19 +96,6 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             [Fact]
-            public async Task ClosesCommunicationListeners()
-            {
-                CommunicationListenerInfo listenerInfo = fuzzy.CommunicationListenerInfo();
-                sut.Field<IList<CommunicationListenerInfo>>().Set(new List<CommunicationListenerInfo> { listenerInfo });
-
-                await sut.CloseAsync(cancellation);
-
-                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(cancellation), Times.Once);
-                Mock.Get(listenerInfo.Listener).Verify(_ => _.CloseAsync(It.IsAny<CancellationToken>()), Times.Once);
-                Assert.Null(sut.Field<IList<CommunicationListenerInfo>>().Value);
-            }
-
-            [Fact]
             public async Task PropagatesExceptionFromUserServiceInstanceOnCloseAsync()
             {
                 var expected = new InvalidOperationException();
@@ -120,15 +107,15 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             [Fact]
-            public async Task CancelsRunAsyncEvenWhenUserServiceInstanceOnCloseAsyncThrows()
+            public async Task CallsUserServiceInstanceOnCloseEvenWhenCancelRunAsyncThrows()
             {
                 var adapter = new Mock<StatelessServiceInstanceAdapter>(context, userServiceInstance) { CallBase = true };
-                Mock.Get(userServiceInstance).Setup(_ => _.OnCloseAsync(cancellation)).ThrowsAsync(new InvalidOperationException());
+                adapter.Protected().Setup<Task>("CancelRunAsync").ThrowsAsync(new InvalidOperationException());
                 IStatelessServiceInstance ssInstance = adapter.Object;
 
                 await Assert.ThrowsAsync<InvalidOperationException>(() => ssInstance.CloseAsync(cancellation));
 
-                adapter.Protected().Verify("CancelRunAsync", Times.Once());
+                Mock.Get(userServiceInstance).Verify(_ => _.OnCloseAsync(cancellation), Times.Once);
             }
 
             [Fact]

--- a/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
+++ b/test/Services/Runtime/StatelessServiceInstanceAdapterTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
         }
 
-        public sealed class Close : StatelessServiceInstanceAdapterTest
+        public sealed class CloseAsync : StatelessServiceInstanceAdapterTest
         {
             [Fact]
             public async Task InvokesOnCloseAsyncOnUserServiceInstance()
@@ -132,7 +132,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             }
 
             [Fact]
-            public async Task AggregatesExceptionsFromAllStepsWhenAllThrow()
+            public async Task AggregatesExceptionsWhenCancelRunAsyncAndOnCloseAsyncThrow()
             {
                 var runEx = new InvalidOperationException();
                 var userEx = new InvalidOperationException();


### PR DESCRIPTION
IStatelessServiceInstance.CloseAsync previously stopped at the first
failing step. A failure in CancelRunAsync skipped the user's
OnCloseAsync.

Run each close step independently and collect any failures. Rethrow a
single failure preserving its original stack trace, or wrap multiple
failures in an AggregateException so none is lost. This matches the
behavior already used by the stateful replica adapter.

CancelRunAsync becomes protected virtual so tests can override it,
matching the stateful adapter's visibility.