### PR TITLE
Document Microsoft.ServiceFabric.FabricTransport

### DIFF
--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         protected FabricTransportSettings settings;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FabricTransportClient"/> class connected to <paramref name="connectionAddress"/>.
+        /// Initializes a new instance of the <see cref="FabricTransportClient"/> class targeting the service endpoint at <paramref name="connectionAddress"/>.
         /// </summary>
         /// <param name="transportSettings">The settings that configure the connection and its timeouts.</param>
         /// <param name="connectionAddress">The address of the service endpoint to connect to.</param>

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         private IFabricTransportClient2 nativeClient;
 
         /// <summary>
-        /// The settings that configure this client's connection and timeouts.
+        /// Stores the settings that configure this client's connection and timeouts.
         /// </summary>
         protected FabricTransportSettings settings;
 

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -72,6 +72,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// Asynchronously opens the connection to the service endpoint.
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The connection is not established within the configured connect timeout.</exception>
         public async Task OpenAsync(CancellationToken cancellationToken)
@@ -104,6 +105,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <remarks>The <paramref name="cancellationToken"/> is accepted for signature consistency but is not currently observed.</remarks>
+        /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The connection is not closed within the configured connect timeout.</exception>
         public async Task CloseAsync(CancellationToken cancellationToken)
@@ -138,6 +140,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <param name="timeout">The maximum time to wait for the reply.</param>
         /// <param name="requestId">The identifier correlating the request with its reply, or <see cref="Guid.Empty"/> to let the transport assign one.</param>
         /// <returns>The reply received from the service.</returns>
+        /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The reply is not received within <paramref name="timeout"/>.</exception>
         public async Task<FabricTransportMessage> RequestResponseAsync(FabricTransportMessage requestMessage,

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -36,6 +36,9 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <param name="eventHandler">The handler notified when the connection is established or lost.</param>
         /// <param name="contract">The handler that processes one-way callback messages pushed from the service.</param>
         /// <param name="messageMessageDisposer">The disposer that releases native resources of received messages.</param>
+        /// <exception cref="FabricInvalidAddressException">
+        /// <paramref name="connectionAddress"/> is not a valid FabricTransport endpoint address.
+        /// </exception>
         public FabricTransportClient(
             FabricTransportSettings transportSettings,
             string connectionAddress,

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -71,7 +71,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <summary>
         /// Asynchronously opens the connection to the service endpoint.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The connection is not established within the configured connect timeout.</exception>
@@ -103,7 +102,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <summary>
         /// Asynchronously closes the connection to the service endpoint.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <remarks>The <paramref name="cancellationToken"/> is accepted for signature consistency but is not currently observed.</remarks>
         /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -15,11 +15,27 @@ using static Microsoft.ServiceFabric.FabricTransport.NativeFabricTransport;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Client
 {
+    /// <summary>
+    /// Connects to a service endpoint and exchanges request-response and one-way messages with it over
+    /// Service Fabric's native transport.
+    /// </summary>
     internal class FabricTransportClient : IDisposable
     {
         private IFabricTransportClient2 nativeClient;
+
+        /// <summary>
+        /// The settings that configure this client's connection and timeouts.
+        /// </summary>
         protected FabricTransportSettings settings;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportClient"/> class connected to <paramref name="connectionAddress"/>.
+        /// </summary>
+        /// <param name="transportSettings">The settings that configure the connection and its timeouts.</param>
+        /// <param name="connectionAddress">The address of the service endpoint to connect to.</param>
+        /// <param name="eventHandler">The handler notified when the connection is established or lost.</param>
+        /// <param name="contract">The handler that processes one-way callback messages pushed from the service.</param>
+        /// <param name="messageMessageDisposer">The disposer that releases native resources of received messages.</param>
         public FabricTransportClient(
             FabricTransportSettings transportSettings,
             string connectionAddress,
@@ -34,14 +50,30 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
                 "FabricTransportClient.Create");
         }
 
+        /// <summary>
+        /// Gets the settings that configure this client's connection and timeouts.
+        /// </summary>
         public FabricTransportSettings Settings
         {
             get { return this.settings; }
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether this client is still valid for reuse.
+        /// </summary>
         public bool IsValid { get; set; }
+
+        /// <summary>
+        /// Gets the address of the service endpoint this client is connected to.
+        /// </summary>
         public string ConnectionAddress { get; private set; }
 
+        /// <summary>
+        /// Asynchronously opens the connection to the service endpoint.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
+        /// <exception cref="TimeoutException">The connection is not established within the configured connect timeout.</exception>
         public async Task OpenAsync(CancellationToken cancellationToken)
         {
             try
@@ -67,6 +99,12 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
             }
         }
 
+        /// <summary>
+        /// Asynchronously closes the connection to the service endpoint.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
+        /// <exception cref="TimeoutException">The connection is not closed within the configured connect timeout.</exception>
         public async Task CloseAsync(CancellationToken cancellationToken)
         {
             try
@@ -92,6 +130,15 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
             }
         }
 
+        /// <summary>
+        /// Asynchronously sends <paramref name="requestMessage"/> to the service and returns its reply.
+        /// </summary>
+        /// <param name="requestMessage">The message to send to the service.</param>
+        /// <param name="timeout">The maximum time to wait for the reply.</param>
+        /// <param name="requestId">The identifier correlating the request with its reply, or <see cref="Guid.Empty"/> to let the transport assign one.</param>
+        /// <returns>The reply received from the service.</returns>
+        /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
+        /// <exception cref="TimeoutException">The reply is not received within <paramref name="timeout"/>.</exception>
         public async Task<FabricTransportMessage> RequestResponseAsync(FabricTransportMessage requestMessage,
             TimeSpan timeout, Guid requestId = default(Guid))
         {
@@ -126,6 +173,10 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
             }
         }
 
+        /// <summary>
+        /// Sends <paramref name="message"/> to the service without waiting for a reply.
+        /// </summary>
+        /// <param name="message">The message to send to the service.</param>
         public virtual void SendOneWay(FabricTransportMessage message)
         {
             IFabricTransportMessage nativeMessage =
@@ -196,10 +247,15 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         }
 
         //Used for Dummy Implemmentation
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportClient"/> class without a native client,
+        /// for use by test doubles that override the transport operations.
+        /// </summary>
         protected FabricTransportClient()
         {
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (nativeClient != null)
@@ -209,6 +265,9 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
             }
         }
 
+        /// <summary>
+        /// Aborts the connection to the service endpoint without waiting for pending operations to complete.
+        /// </summary>
         public void Abort()
         {
             Utility.WrapNativeSyncInvokeInMTA(() => this.internalAbort(), "Client.Abort");

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -180,7 +180,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <summary>
         /// Sends <paramref name="message"/> to the service without waiting for a reply.
         /// </summary>
-        /// <param name="message">The message to send to the service.</param>
         public virtual void SendOneWay(FabricTransportMessage message)
         {
             IFabricTransportMessage nativeMessage =

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -103,6 +103,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// Asynchronously closes the connection to the service endpoint.
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <remarks>The <paramref name="cancellationToken"/> is accepted for signature consistency but is not currently observed.</remarks>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The connection is not closed within the configured connect timeout.</exception>
         public async Task CloseAsync(CancellationToken cancellationToken)

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -139,7 +139,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         /// <param name="requestMessage">The message to send to the service.</param>
         /// <param name="timeout">The maximum time to wait for the reply.</param>
         /// <param name="requestId">The identifier correlating the request with its reply, or <see cref="Guid.Empty"/> to let the transport assign one.</param>
-        /// <returns>The reply received from the service.</returns>
         /// <exception cref="FabricCannotConnectException">The client cannot connect to the service endpoint.</exception>
         /// <exception cref="FabricConnectionDeniedException">The client connects without security to a secured service endpoint.</exception>
         /// <exception cref="TimeoutException">The reply is not received within <paramref name="timeout"/>.</exception>

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -62,11 +62,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         }
 
         /// <summary>
-        /// Gets or sets a value that indicates whether this client is still valid for reuse.
-        /// </summary>
-        public bool IsValid { get; set; }
-
-        /// <summary>
         /// Gets the address of the service endpoint this client connects to.
         /// </summary>
         public string ConnectionAddress { get; private set; }

--- a/src/FabricTransport/Client/FabricTransportClient.cs
+++ b/src/FabricTransport/Client/FabricTransportClient.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
         public bool IsValid { get; set; }
 
         /// <summary>
-        /// Gets the address of the service endpoint this client is connected to.
+        /// Gets the address of the service endpoint this client connects to.
         /// </summary>
         public string ConnectionAddress { get; private set; }
 

--- a/src/FabricTransport/Client/IFabricTransportCallbackMessageHandler.cs
+++ b/src/FabricTransport/Client/IFabricTransportCallbackMessageHandler.cs
@@ -5,8 +5,14 @@
 
 namespace Microsoft.ServiceFabric.FabricTransport.Client
 {
+    /// <summary>
+    /// Handles one-way <see cref="FabricTransportMessage"/> callbacks pushed from a service to its client.
+    /// </summary>
     internal interface IFabricTransportCallbackMessageHandler
     {
+        /// <summary>
+        /// Handles the one-way <paramref name="message"/> received from the service.
+        /// </summary>
         void OneWayMessage(FabricTransportMessage message);
     }
 }

--- a/src/FabricTransport/Client/IFabricTransportClientEventHandler.cs
+++ b/src/FabricTransport/Client/IFabricTransportClientEventHandler.cs
@@ -5,9 +5,19 @@
 
 namespace Microsoft.ServiceFabric.FabricTransport.Client
 {
+    /// <summary>
+    /// Receives notifications about the connection state of a <see cref="FabricTransportClient"/>.
+    /// </summary>
     internal interface IFabricTransportClientEventHandler
     {
+        /// <summary>
+        /// Notifies that the client has established a connection to the service endpoint.
+        /// </summary>
         void OnConnected();
+
+        /// <summary>
+        /// Notifies that the client has lost its connection to the service endpoint.
+        /// </summary>
         void OnDisconnected();
     }
 }

--- a/src/FabricTransport/Client/IFabricTransportClientEventHandler.cs
+++ b/src/FabricTransport/Client/IFabricTransportClientEventHandler.cs
@@ -11,12 +11,12 @@ namespace Microsoft.ServiceFabric.FabricTransport.Client
     internal interface IFabricTransportClientEventHandler
     {
         /// <summary>
-        /// Notifies that the client has established a connection to the service endpoint.
+        /// Notifies the handler that the client has established a connection to the service endpoint.
         /// </summary>
         void OnConnected();
 
         /// <summary>
-        /// Notifies that the client has lost its connection to the service endpoint.
+        /// Notifies the handler that the client has lost its connection to the service endpoint.
         /// </summary>
         void OnDisconnected();
     }

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -196,7 +196,8 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Try to load the FabricTransport settings from a sectionName specified in the configuration file.
+        /// Tries to load the FabricTransport settings from a sectionName specified in the configuration file and returns
+        /// <see langword="true"/> if the settings were loaded successfully; otherwise returns <see langword="false"/>.
         /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
         /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
         /// </summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -15,7 +15,7 @@ using System.Security.Cryptography.X509Certificates;
 namespace Microsoft.ServiceFabric.FabricTransport
 {
     /// <summary>
-    /// Configures the FabricTransport communication.
+    /// Represents the settings that configure FabricTransport communication.
     /// </summary>
     internal class FabricTransportSettings
     {

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -210,20 +210,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
-        /// <remarks>
-        /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
-        ///     
-        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
-        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/> value in long.
-        ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
-        ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
-        ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
-        ///        CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.
-        ///     5. OperationTimeoutInSeconds - <see cref="OperationTimeout"/> value in seconds.
-        ///     6. KeepAliveTimeoutInSeconds - <see cref="KeepAliveTimeout"/> value in seconds.
-        ///     7. ConnectTimeoutInMilliseconds - <see cref="ConnectTimeout"/> value in milliseconds.
-        /// </remarks>
+        /// <inheritdoc cref="LoadFrom(string, string, string)" path="/remarks"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportSettings settings, string filepath = null,
             string configPackageName = null)
         {

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -115,10 +115,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
         /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
         /// </summary>
-        /// <param name="sectionName">Name of the section within the configuration file.</param>
+        /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> Name of the configuration package.If its null or empty,it will check for file in filePath</param>
+        ///  <param name="configPackageName"> The name of the configuration package.If its null or empty,it will check for file in filePath</param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
@@ -201,10 +201,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
         /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
         /// </summary>
-        /// <param name="sectionName">Name of the section within the configuration file. If not found section in configuration file, it return false</param>
+        /// <param name="sectionName">The name of the section within the configuration file. If not found section in configuration file, it return false</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> Name of the configuration package. If its null or empty,it will check for file in filePath</param>
+        ///  <param name="configPackageName"> The name of the configuration package. If its null or empty,it will check for file in filePath</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -15,7 +15,7 @@ using System.Security.Cryptography.X509Certificates;
 namespace Microsoft.ServiceFabric.FabricTransport
 {
     /// <summary>
-    /// Settings that configures the  FabricTransport communication.
+    /// Configures the FabricTransport communication.
     /// </summary>
     internal class FabricTransportSettings
     {

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
-        /// <inheritdoc cref="LoadFrom(string, string, string)" path="/remarks"/>
+        /// <inheritdoc path="/remarks" cref="LoadFrom(string, string, string)"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportSettings settings, string filepath = null,
             string configPackageName = null)
         {

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Operation Timeout  which governs the whole process of sending a message, including receiving a reply message for a request/reply service operation.
+        /// Gets or sets the operation timeout that governs the whole process of sending a message, including receiving a reply message for a request/reply service operation.
         ///  This timeout also applies when sending reply messages from a callback contract method.
         /// </summary>
         /// <value>OperationTimeout as <see cref="System.TimeSpan"/></value>
@@ -70,7 +70,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         public TimeSpan OperationTimeout { get; set; }
 
         /// <summary>
-        /// KeepAliveTimeout is provides a way to configure  Tcp keep-alive option.
+        /// Gets or sets the keep-alive timeout that configures the TCP keep-alive option.
         /// </summary>
         /// <value>KeepAliveTimeout as <see cref="System.TimeSpan"/></value>
         /// <remarks>Default Value for KeepAliveTimeout Timeout is set as TimeSpan.Zero. which indicates we disable the tcp keepalive option.
@@ -78,14 +78,14 @@ namespace Microsoft.ServiceFabric.FabricTransport
         public TimeSpan KeepAliveTimeout { get; set; }
 
         /// <summary>
-        /// Connect timeout specifies the maximum time allowed for the connection to be established successfully.
+        /// Gets or sets the connect timeout that specifies the maximum time allowed for the connection to be established successfully.
         /// </summary>
         /// <value>ConnectTimeout as <see cref="System.TimeSpan"/></value>
         /// <remarks>Default Value for ConnectTimeout Timeout is set as 5 seconds.</remarks>
         public TimeSpan ConnectTimeout { get; set; }
 
         /// <summary>
-        /// MaxMessageSize represents  the maximum size for a message that can be received on a channel configured with this setting.
+        /// Gets or sets the maximum size for a message that can be received on a channel configured with this setting.
         /// </summary>
         /// <value>Maximum size of the message in bytes.
         /// </value>
@@ -95,7 +95,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         public long MaxMessageSize { get; set; }
 
         /// <summary>
-        /// The maximum size, of a queue that stores messages while they are processed for an endpoint configured with this setting. 
+        /// Gets or sets the maximum size of a queue that stores messages while they are processed for an endpoint configured with this setting.
         /// </summary>
         /// <value> Max Size for a Queue that receives messages from the channel 
         /// </value>
@@ -104,7 +104,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         public long MaxQueueSize { get; set; }
 
         ///<summary>
-        ///MaxConcurrentCalls represents maximum number of messages actively service processes at one time.
+        /// Gets or sets the maximum number of messages actively serviced at one time.
         /// </summary>
         /// <value>
         ///MaxConcurrentCalls is the upper limit of active messages in the service.
@@ -115,7 +115,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         public long MaxConcurrentCalls { get; set; }
 
         /// <summary>
-        /// Security credentials for securing the communication 
+        /// Gets or sets the security credentials for securing the communication.
         /// </summary>
         /// <value>SecurityCredentials as  <see cref=" System.Fabric.SecurityCredentials"/>
         /// </value>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         internal FabricServiceConfigSection ConfigSection { get; private set; }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration file 
+        /// Returns the <see cref="FabricTransportSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration file.
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///  <param name="configPackageName"> The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/></param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
-        /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
+        /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
         ///     
         ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
         ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.
@@ -211,7 +211,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
-        /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
+        /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
         ///     
         ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
         ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Gets or sets the maximum size for a message that can be received on a channel configured with this setting.
         /// </summary>
-        /// <value>The default is 4194304 bytes.</value>
+        /// <value>The default is 4,194,304 bytes.</value>
         public long MaxMessageSize { get; set; }
 
         /// <summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -126,7 +126,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///     1. MaxQueueSize - <see cref="MaxQueueSize"/>value in long.
         ///     2. MaxMessageSize - <see cref="MaxMessageSize"/>value in bytes.
         ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/>value in long.
-        ///     4. SecurityCredentials - <see cref="SecurityCredentials"/> value.
+        ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
+        ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
+        ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
+        ///        CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.
         ///     5. OperationTimeoutInSeconds - <see cref="OperationTimeout"/> value in seconds.
         ///     6. KeepAliveTimeoutInSeconds - <see cref="KeepAliveTimeout"/> value in seconds.
         ///     7. ConnectTimeoutInMilliseconds - <see cref="ConnectTimeout"/> value in milliseconds.
@@ -213,7 +216,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///     1. MaxQueueSize - <see cref="MaxQueueSize"/>value in long.
         ///     2. MaxMessageSize - <see cref="MaxMessageSize"/>value in bytes.
         ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/>value in long.
-        ///     4. SecurityCredentials - <see cref="SecurityCredentials"/> value.
+        ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
+        ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
+        ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
+        ///        CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.
         ///     5. OperationTimeoutInSeconds - <see cref="OperationTimeout"/> value in seconds.
         ///     6. KeepAliveTimeoutInSeconds - <see cref="KeepAliveTimeout"/> value in seconds.
         ///     7. ConnectTimeoutInMilliseconds - <see cref="ConnectTimeout"/> value in milliseconds.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -112,14 +112,15 @@ namespace Microsoft.ServiceFabric.FabricTransport
 
         /// <summary>
         /// Returns the <see cref="FabricTransportSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration file.
-        /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
-        /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If <see langword="null"/>, the default <c>TransportSettings</c> section is used.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
         /// <remarks>
+        /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
+        /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
+        /// <para>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
         /// <list type="number">
         ///     <item><c>MaxQueueSize</c> - <see cref="MaxQueueSize"/> as a <see langword="long"/> value.</item>
@@ -133,6 +134,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///     <item><c>KeepAliveTimeoutInSeconds</c> - <see cref="KeepAliveTimeout"/> value in seconds.</item>
         ///     <item><c>ConnectTimeoutInMilliseconds</c> - <see cref="ConnectTimeout"/> value in milliseconds.</item>
         /// </list>
+        /// </para>
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// <paramref name="configPackageName"/> is specified but the configuration package is not found,
@@ -201,8 +203,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Tries to load the <see cref="FabricTransportSettings"/> from the section named <paramref name="sectionName"/> specified in the configuration file into <paramref name="settings"/> and returns
         /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
-        /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
-        /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If <see langword="null"/>, the default <c>TransportSettings</c> section is used. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -200,8 +200,8 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Tries to load the FabricTransport settings from the section named <paramref name="sectionName"/> specified in the configuration file into <paramref name="settings"/> and returns
-        /// <see langword="true"/> if the settings were loaded successfully; otherwise returns <see langword="false"/>.
+        /// Tries to load the <see cref="FabricTransportSettings"/> from the section named <paramref name="sectionName"/> specified in the configuration file into <paramref name="settings"/> and returns
+        /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> Name of the configuration package.If its null or empty,it will check for file in filePath</param>
-        /// <returns>FabricTransportSettings</returns>
+        /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
         ///     

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -217,8 +217,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> Name of the configuration package. If its null or empty,it will check for file in filePath</param>
         /// <param name="settings">When this method returns it sets the <see cref="FabricTransportSettings"/> settings if load from Config succeeded. If fails ,its sets settings to null/> </param>
-        /// <returns><see cref="bool"/> specifies whether the settings get loaded successfully from Config.
-        /// It returns true when load from Config succeeded, else return false. </returns>
+        /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
         ///     

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
-        /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
+        /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
@@ -205,7 +205,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If not found section in configuration file, it return false</param>
-        /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
+        /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -199,7 +199,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Tries to load the FabricTransport settings from the section named <paramref name="sectionName"/> specified in the configuration file and returns
+        /// Tries to load the FabricTransport settings from the section named <paramref name="sectionName"/> specified in the configuration file into <paramref name="settings"/> and returns
         /// <see langword="true"/> if the settings were loaded successfully; otherwise returns <see langword="false"/>.
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -115,7 +115,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
-        /// <param name="sectionName">The name of the section within the configuration file.</param>
+        /// <param name="sectionName">The name of the section within the configuration file. If <see langword="null"/>, the default <c>TransportSettings</c> section is used.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
@@ -204,7 +204,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
-        /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
+        /// <param name="sectionName">The name of the section within the configuration file. If <see langword="null"/>, the default <c>TransportSettings</c> section is used. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -111,14 +111,14 @@ namespace Microsoft.ServiceFabric.FabricTransport
         internal FabricServiceConfigSection ConfigSection { get; private set; }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportSettings"/> loaded from a sectionName specified in the configuration file 
-        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest.
-        /// It will first try to load config using configPackageName. If configPackageName is not specified, then try to load from filePath.
+        /// Returns the <see cref="FabricTransportSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration file 
+        /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
+        /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in filePath</param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
@@ -196,15 +196,15 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Tries to load the FabricTransport settings from a sectionName specified in the configuration file and returns
+        /// Tries to load the FabricTransport settings from the section named <paramref name="sectionName"/> specified in the configuration file and returns
         /// <see langword="true"/> if the settings were loaded successfully; otherwise returns <see langword="false"/>.
-        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest.
-        /// It will first try to load config using configPackageName. If configPackageName is not specified, then try to load from filePath.
+        /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
+        /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If not found section in configuration file, it return false</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in filePath</param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -115,7 +115,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
         /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
         /// </summary>
-        /// <param name="sectionName">Name of the section within the configuration file. If not found section in configuration file, it will throw ArgumentException</param>
+        /// <param name="sectionName">Name of the section within the configuration file.</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> Name of the configuration package.If its null or empty,it will check for file in filePath</param>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// </summary>
         /// <value>The default is <see cref="NoneSecurityCredentials"/>.</value>
         /// <remarks>
-        /// The credentials can be of type <see cref="X509Credentials"/> or <see cref="WindowsCredentials"/>.
+        /// The credentials can be of type <see cref="X509Credentials"/>, <see cref="WindowsCredentials"/>, or, to disable security, <see cref="NoneSecurityCredentials"/> (the default).
         /// </remarks>
         public SecurityCredentials SecurityCredentials { get; set; }
 

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
-        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
+        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
@@ -208,7 +208,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
-        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
+        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <inheritdoc cref="LoadFrom(string, string, string)" path="/remarks"/>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -204,7 +204,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
-        /// <param name="sectionName">The name of the section within the configuration file. If not found section in configuration file, it return false</param>
+        /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -272,11 +272,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
             }
         }
 
-        /// <summary>
-        /// FabricTransportSettings returns the default Settings .Loads the configuration file from default Config Package"Config" , if not found then try to load from  default config file "ClientExeName.Settings.xml"  from Client Exe directory.
-        ///</summary>
-        /// <param name="sectionName">Name of the section within the configuration file. If not found section in configuration file, it will return the default Settings</param>
-        /// <returns></returns>
         internal static FabricTransportSettings GetDefault(string sectionName = DefaultSectionName)
         {
             FabricTransportSettings settings = null;

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
-        /// If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory.</param>
+        /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
@@ -207,7 +207,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
-        /// If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory.</param>
+        /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -149,6 +149,11 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///     6. KeepAliveTimeoutInSeconds - <see cref="KeepAliveTimeout"/> value in seconds.
         ///     7. ConnectTimeoutInMilliseconds - <see cref="ConnectTimeout"/> value in milliseconds.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="configPackageName"/> is specified but the configuration package is not found,
+        /// <paramref name="filepath"/> is specified but the configuration file is not found, or
+        /// the section named <paramref name="sectionName"/> is not found in the configuration.
+        /// </exception>
         public static FabricTransportSettings LoadFrom(
             string sectionName,
             string filepath = null,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -123,9 +123,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
         /// <list type="number">
-        ///     <item><c>MaxQueueSize</c> - <see cref="MaxQueueSize"/> value in long.</item>
+        ///     <item><c>MaxQueueSize</c> - <see cref="MaxQueueSize"/> as a <see langword="long"/> value.</item>
         ///     <item><c>MaxMessageSize</c> - <see cref="MaxMessageSize"/> value in bytes.</item>
-        ///     <item><c>MaxConcurrentCalls</c> - <see cref="MaxConcurrentCalls"/> value in long.</item>
+        ///     <item><c>MaxConcurrentCalls</c> - <see cref="MaxConcurrentCalls"/> as a <see langword="long"/> value.</item>
         ///     <item><c>SecurityCredentialsType</c> - One of <c>None</c>, <c>X509</c>, or <c>Windows</c> that selects the <see cref="SecurityCredentials"/> type.
         ///         <c>Windows</c> credentials additionally read <c>RemoteSecurityPrincipalName</c>. <c>X509</c> credentials additionally read <c>CertificateFindType</c>,
         ///         <c>CertificateFindValue</c>, <c>CertificateProtectionLevel</c>, <c>CertificateStoreLocation</c>, <c>CertificateStoreName</c>, <c>CertificateRemoteCommonNames</c>,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -116,9 +116,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
-        /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
-        ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/></param>
+        /// <param name="filepath">The full path of the file where the settings will be loaded from.
+        /// If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory.</param>
+        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
@@ -205,9 +205,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
-        /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
-        ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/></param>
+        /// <param name="filepath">The full path of the file where the settings will be loaded from.
+        /// If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory.</param>
+        /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/>.</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Returns the <see cref="FabricTransportSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration file.
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
-        /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
+        /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
@@ -203,7 +203,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Tries to load the <see cref="FabricTransportSettings"/> from the section named <paramref name="sectionName"/> specified in the configuration file into <paramref name="settings"/> and returns
         /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
         /// The configuration file can be specified using <paramref name="filepath"/> or the name of the configuration package specified in the service manifest.
-        /// It will first try to load config using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, then try to load from <paramref name="filepath"/>.
+        /// It first tries to load the configuration using <paramref name="configPackageName"/>. If <paramref name="configPackageName"/> is not specified, it then tries to load from <paramref name="filepath"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -123,9 +123,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
         ///     
-        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/>value in long.
-        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/>value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/>value in long.
+        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
+        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.
+        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/> value in long.
         ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
         ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
         ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
@@ -213,9 +213,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
         ///     
-        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/>value in long.
-        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/>value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/>value in long.
+        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
+        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.
+        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/> value in long.
         ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
         ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
         ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         internal static readonly TimeSpan DefaultKeepAliveTimeout = TimeSpan.Zero;
 
         /// <summary>
-        /// Creates a new FabricTransportSettings with default Values.
+        /// Initializes a new instance of the <see cref="FabricTransportSettings"/> class.
         /// </summary>
         public FabricTransportSettings()
         {

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
 
         /// <summary>
         /// Gets or sets the operation timeout that governs the whole process of sending a message, including receiving a reply message for a request/reply service operation.
-        ///  This timeout also applies when sending reply messages from a callback contract method.
+        /// This timeout also applies when sending reply messages from a callback contract method.
         /// </summary>
         /// <value>The default is 5 minutes.</value>
         public TimeSpan OperationTimeout { get; set; }

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -138,8 +138,15 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// <paramref name="configPackageName"/> is specified but the configuration package is not found,
-        /// <paramref name="filepath"/> is specified but the configuration file is not found, or
-        /// the section named <paramref name="sectionName"/> is not found in the configuration.
+        /// <paramref name="filepath"/> is specified but the configuration file is not found,
+        /// the section named <paramref name="sectionName"/> is not found in the configuration, or
+        /// a configuration value cannot be parsed into its target enumeration type.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// A numeric configuration value is not in a format recognized by its target type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// A numeric configuration value is outside the range of its target type.
         /// </exception>
         public static FabricTransportSettings LoadFrom(
             string sectionName,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -112,13 +112,13 @@ namespace Microsoft.ServiceFabric.FabricTransport
 
         /// <summary>
         /// Returns the <see cref="FabricTransportSettings"/> loaded from a sectionName specified in the configuration file 
-        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
-        /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
+        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest.
+        /// It will first try to load config using configPackageName. If configPackageName is not specified, then try to load from filePath.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
-        ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package.If its null or empty,it will check for file in filePath</param>
+        ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in filePath</param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
@@ -198,13 +198,13 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Tries to load the FabricTransport settings from a sectionName specified in the configuration file and returns
         /// <see langword="true"/> if the settings were loaded successfully; otherwise returns <see langword="false"/>.
-        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
-        /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
+        /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest.
+        /// It will first try to load config using configPackageName. If configPackageName is not specified, then try to load from filePath.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If not found section in configuration file, it return false</param>
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
-        ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If its null or empty,it will check for file in filePath</param>
+        ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in filePath</param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -122,17 +122,18 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
-        ///     
-        ///     1. MaxQueueSize - <see cref="MaxQueueSize"/> value in long.
-        ///     2. MaxMessageSize - <see cref="MaxMessageSize"/> value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="MaxConcurrentCalls"/> value in long.
-        ///     4. SecurityCredentialsType - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
-        ///        Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
-        ///        CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
-        ///        CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.
-        ///     5. OperationTimeoutInSeconds - <see cref="OperationTimeout"/> value in seconds.
-        ///     6. KeepAliveTimeoutInSeconds - <see cref="KeepAliveTimeout"/> value in seconds.
-        ///     7. ConnectTimeoutInMilliseconds - <see cref="ConnectTimeout"/> value in milliseconds.
+        /// <list type="number">
+        ///     <item><c>MaxQueueSize</c> - <see cref="MaxQueueSize"/> value in long.</item>
+        ///     <item><c>MaxMessageSize</c> - <see cref="MaxMessageSize"/> value in bytes.</item>
+        ///     <item><c>MaxConcurrentCalls</c> - <see cref="MaxConcurrentCalls"/> value in long.</item>
+        ///     <item><c>SecurityCredentialsType</c> - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
+        ///         Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
+        ///         CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
+        ///         CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.</item>
+        ///     <item><c>OperationTimeoutInSeconds</c> - <see cref="OperationTimeout"/> value in seconds.</item>
+        ///     <item><c>KeepAliveTimeoutInSeconds</c> - <see cref="KeepAliveTimeout"/> value in seconds.</item>
+        ///     <item><c>ConnectTimeoutInMilliseconds</c> - <see cref="ConnectTimeout"/> value in milliseconds.</item>
+        /// </list>
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// <paramref name="configPackageName"/> is specified but the configuration package is not found,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/></param>
         /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
@@ -207,7 +207,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
         /// <param name="filepath"> The full path of the file where the settings will be loaded from. 
         ///  If not specified, it will first try to load from default Config Package "Config", if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
-        ///  <param name="configPackageName"> The name of the configuration package. If it's null or empty, it will check for file in <paramref name="filepath"/></param>
+        ///  <param name="configPackageName"> The name of the configuration package. If it's <see langword="null"/> or empty, it will check for file in <paramref name="filepath"/></param>
         /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -126,10 +126,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         ///     <item><c>MaxQueueSize</c> - <see cref="MaxQueueSize"/> value in long.</item>
         ///     <item><c>MaxMessageSize</c> - <see cref="MaxMessageSize"/> value in bytes.</item>
         ///     <item><c>MaxConcurrentCalls</c> - <see cref="MaxConcurrentCalls"/> value in long.</item>
-        ///     <item><c>SecurityCredentialsType</c> - One of None, X509, or Windows that selects the <see cref="SecurityCredentials"/> type.
-        ///         Windows credentials additionally read RemoteSecurityPrincipalName. X509 credentials additionally read CertificateFindType,
-        ///         CertificateFindValue, CertificateProtectionLevel, CertificateStoreLocation, CertificateStoreName, CertificateRemoteCommonNames,
-        ///         CertificateRemoteThumbprints, CertificateIssuerThumbprints, CertificateFindValuebySecondary, and CertificateApplicationIssuerStore/ entries.</item>
+        ///     <item><c>SecurityCredentialsType</c> - One of <c>None</c>, <c>X509</c>, or <c>Windows</c> that selects the <see cref="SecurityCredentials"/> type.
+        ///         <c>Windows</c> credentials additionally read <c>RemoteSecurityPrincipalName</c>. <c>X509</c> credentials additionally read <c>CertificateFindType</c>,
+        ///         <c>CertificateFindValue</c>, <c>CertificateProtectionLevel</c>, <c>CertificateStoreLocation</c>, <c>CertificateStoreName</c>, <c>CertificateRemoteCommonNames</c>,
+        ///         <c>CertificateRemoteThumbprints</c>, <c>CertificateIssuerThumbprints</c>, <c>CertificateFindValuebySecondary</c>, and <c>CertificateApplicationIssuerStore/</c> entries.</item>
         ///     <item><c>OperationTimeoutInSeconds</c> - <see cref="OperationTimeout"/> value in seconds.</item>
         ///     <item><c>KeepAliveTimeoutInSeconds</c> - <see cref="KeepAliveTimeout"/> value in seconds.</item>
         ///     <item><c>ConnectTimeoutInMilliseconds</c> - <see cref="ConnectTimeout"/> value in milliseconds.</item>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -119,7 +119,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
-        /// <returns>The settings loaded from the specified configuration section.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
         /// <list type="number">

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -205,10 +205,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file. If <see langword="null"/>, the default <c>TransportSettings</c> section is used. Returns <see langword="false"/> if the section is not found.</param>
+        /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <param name="filepath">The full path of the file where the settings will be loaded from.
         /// If not specified, it will first try to load from the default configuration package <c>Config</c>, and if not found, from the <c>ClientExeName.Settings.xml</c> settings file in the client executable directory.</param>
         /// <param name="configPackageName">The name of the configuration package. If it's <see langword="null"/> or empty, it will check for the file in <paramref name="filepath"/>.</param>
-        /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <inheritdoc path="/remarks" cref="LoadFrom(string, string, string)"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportSettings settings, string filepath = null,

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -63,9 +63,9 @@ namespace Microsoft.ServiceFabric.FabricTransport
 
         /// <summary>
         /// Gets or sets the operation timeout that governs the whole process of sending a message, including receiving a reply message for a request/reply service operation.
-        /// This timeout also applies when sending reply messages from a callback contract method.
         /// </summary>
         /// <value>The default is 5 minutes.</value>
+        /// <remarks>This timeout also applies when sending reply messages from a callback contract method.</remarks>
         public TimeSpan OperationTimeout { get; set; }
 
         /// <summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         internal FabricServiceConfigSection ConfigSection { get; private set; }
 
         /// <summary>
-        /// Loads the FabricTransport settings from a sectionName specified in the configuration file 
+        /// Returns the <see cref="FabricTransportSettings"/> loaded from a sectionName specified in the configuration file 
         /// Configuration File can be specified using the filePath or using the name of the configuration package specified in the service manifest .
         /// It will first try to load config using configPackageName . if configPackageName is not specified then try to load  from filePath.
         /// </summary>

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -216,7 +216,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <param name="filepath"> Full path of the file where the settings will be loaded from. 
         ///  If not specified , it will first try to load from default Config Package"Config" , if not found then load from Settings "ClientExeName.Settings.xml" present in Client Exe directory. </param>
         ///  <param name="configPackageName"> Name of the configuration package. If its null or empty,it will check for file in filePath</param>
-        /// <param name="settings">When this method returns it sets the <see cref="FabricTransportSettings"/> settings if load from Config succeeded. If fails ,its sets settings to null/> </param>
+        /// <param name="settings">When this method returns, contains the <see cref="FabricTransportSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
         /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -65,23 +65,20 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Gets or sets the operation timeout that governs the whole process of sending a message, including receiving a reply message for a request/reply service operation.
         ///  This timeout also applies when sending reply messages from a callback contract method.
         /// </summary>
-        /// <value>OperationTimeout as <see cref="System.TimeSpan"/></value>
-        /// <remarks>Default Value for Operation Timeout is set as 5 mins</remarks>
+        /// <value>The default is 5 minutes.</value>
         public TimeSpan OperationTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the keep-alive timeout that configures the TCP keep-alive option.
         /// </summary>
-        /// <value>KeepAliveTimeout as <see cref="System.TimeSpan"/></value>
-        /// <remarks>Default Value for KeepAliveTimeout Timeout is set as TimeSpan.Zero. which indicates we disable the tcp keepalive option.
-        /// If you are using loadbalancer , you may need to configure this in order to avoid  the loadbalancer to close the connection after certain time </remarks>
+        /// <value>The default is <see cref="TimeSpan.Zero"/>, which disables the TCP keep-alive option.</value>
+        /// <remarks>When using a load balancer, you may need to configure this to prevent the load balancer from closing the connection after a period of inactivity.</remarks>
         public TimeSpan KeepAliveTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the connect timeout that specifies the maximum time allowed for the connection to be established successfully.
         /// </summary>
-        /// <value>ConnectTimeout as <see cref="System.TimeSpan"/></value>
-        /// <remarks>Default Value for ConnectTimeout Timeout is set as 5 seconds.</remarks>
+        /// <value>The default is 5 seconds.</value>
         public TimeSpan ConnectTimeout { get; set; }
 
         /// <summary>
@@ -117,13 +114,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Gets or sets the security credentials for securing the communication.
         /// </summary>
-        /// <value>SecurityCredentials as  <see cref=" System.Fabric.SecurityCredentials"/>
-        /// </value>
+        /// <value>The default is <see cref="NoneSecurityCredentials"/>.</value>
         /// <remarks>
-        /// Default Value for SecurityCredentials is None
-        /// SecurityCredential can be of type x509SecurityCredentail <seealso cref="System.Fabric.X509Credentials"/>or
-        ///  WindowsCredentials <seealso cref="System.Fabric.WindowsCredentials"/>
-        ///</remarks>
+        /// The credentials can be of type <see cref="X509Credentials"/> or <see cref="WindowsCredentials"/>.
+        /// </remarks>
         public SecurityCredentials SecurityCredentials { get; set; }
 
         internal FabricServiceConfigSection ConfigSection { get; private set; }

--- a/src/FabricTransport/Common/FabricTransportSettings.cs
+++ b/src/FabricTransport/Common/FabricTransportSettings.cs
@@ -84,31 +84,19 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Gets or sets the maximum size for a message that can be received on a channel configured with this setting.
         /// </summary>
-        /// <value>Maximum size of the message in bytes.
-        /// </value>
-        /// <remarks>
-        /// Default Value for MaxMessageSize used is 4194304 bytes
-        /// </remarks>
+        /// <value>The default is 4194304 bytes.</value>
         public long MaxMessageSize { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum size of a queue that stores messages while they are processed for an endpoint configured with this setting.
         /// </summary>
-        /// <value> Max Size for a Queue that receives messages from the channel 
-        /// </value>
-        /// <remarks>
-        /// Default value is 10,000 messages</remarks>
+        /// <value>The default is 10,000 messages.</value>
         public long MaxQueueSize { get; set; }
 
-        ///<summary>
+        /// <summary>
         /// Gets or sets the maximum number of messages actively serviced at one time.
         /// </summary>
-        /// <value>
-        ///MaxConcurrentCalls is the upper limit of active messages in the service.
-        /// </value>
-        /// <remarks>
-        ///Default value for the MaxConcurrentCalls is 0 which indicates that the setting is not enabled. This implies that all the messages are active and are processed simultaneously.
-        /// </remarks>
+        /// <value>The default is 0, which processes all messages simultaneously.</value>
         public long MaxConcurrentCalls { get; set; }
 
         /// <summary>

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the stream containing the received header bytes.
+        /// Returns the <see cref="Stream"/> containing the received header bytes.
         /// </summary>
         public Stream GetRecievedStream()
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -121,27 +121,44 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly Action disposeAction;
         private readonly Stream recievedStream;
 
+        /// <summary>
+        /// Returns the serialized body buffers to send.
+        /// </summary>
         public IEnumerable<ArraySegment<byte>> GetBodyBuffers()
         {
             return this.sendBuffers;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportRequestBody"/> class for an outgoing body.
+        /// </summary>
+        /// <param name="sendBuffers">The serialized body buffers to send.</param>
+        /// <param name="disposeAction">A callback that releases <paramref name="sendBuffers"/> when the body is disposed.</param>
         public FabricTransportRequestBody(IEnumerable<ArraySegment<byte>> sendBuffers, Action disposeAction)
         {
             this.sendBuffers = sendBuffers;
             this.disposeAction = disposeAction;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportRequestBody"/> class for a received body.
+        /// </summary>
         public FabricTransportRequestBody(Stream recievedStream)
         {
             this.recievedStream = recievedStream;
         }
 
+        /// <summary>
+        /// Returns the <see cref="Stream"/> containing the received body bytes.
+        /// </summary>
         public Stream GetRecievedStream()
         {
             return this.recievedStream;
         }
 
+        /// <summary>
+        /// Releases the resources held by the outgoing body buffers.
+        /// </summary>
         public void Dispose()
         {
             if (this.disposeAction != null)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly IFabricTransportMessage nativeInterfaceRoot;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class.
+        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class for an outgoing message.
         /// </summary>
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader, FabricTransportRequestBody requestBody)
         {
@@ -28,7 +28,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class backed by a native message.
+        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class for a received message backed by a native message.
         /// </summary>
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader,
             FabricTransportRequestBody requestBody,

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -30,9 +30,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class backed by a native message.
         /// </summary>
-        /// <param name="requestHeader">The header of the message.</param>
-        /// <param name="requestBody">The body of the message.</param>
-        /// <param name="nativeInterfaceRoot">The native message whose COM object is released when this message is disposed.</param>
+        // Disposing this message releases the COM object of nativeInterfaceRoot.
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader,
             FabricTransportRequestBody requestBody,
             IFabricTransportMessage nativeInterfaceRoot)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// Initializes a new instance of the <see cref="FabricTransportRequestHeader"/> class for an outgoing header.
         /// </summary>
         /// <param name="requestHeaderBuffer">The serialized header bytes to send.</param>
-        /// <param name="disposeAction">The action that releases <paramref name="requestHeaderBuffer"/> when the header is disposed.</param>
+        /// <param name="disposeAction">A callback that releases <paramref name="requestHeaderBuffer"/> when the header is disposed.</param>
         public FabricTransportRequestHeader(ArraySegment<byte> requestHeaderBuffer, Action disposeAction)
         {
             this.requestHeaderBuffer = requestHeaderBuffer;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportRequestBody"/> of the message.
+        /// Returns the <see cref="FabricTransportRequestBody"/> of the message, or <see langword="null"/> if the message has no body.
         /// </summary>
         public FabricTransportRequestBody GetBody()
         {
@@ -49,7 +49,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportRequestHeader"/> of the message.
+        /// Returns the <see cref="FabricTransportRequestHeader"/> of the message, or <see langword="null"/> if the message has no header.
         /// </summary>
         public FabricTransportRequestHeader GetHeader()
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly Stream recievedStream;
 
         /// <summary>
-        /// Returns the serialized body buffers to send.
+        /// Returns the serialized body buffers to send for an outgoing body, or <see langword="null"/> for a received body.
         /// </summary>
         public IEnumerable<ArraySegment<byte>> GetBodyBuffers()
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -56,9 +56,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
             return this.requestHeader;
         }
 
-        /// <summary>
-        /// Releases the native message and the resources held by the message header and body.
-        /// </summary>
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (this.nativeInterfaceRoot != null)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly Action disposeAction;
 
         /// <summary>
-        /// Returns the serialized header bytes to send for an outgoing header, or the default <see cref="ArraySegment{T}"/> for a received header.
+        /// Returns the serialized header bytes to send for an outgoing header, or the default <see cref="ArraySegment{T}"/> when there are no outgoing bytes or for a received header.
         /// </summary>
         public ArraySegment<byte> GetSendBuffer()
         {
@@ -92,7 +92,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportRequestHeader"/> class for an outgoing header.
         /// </summary>
-        /// <param name="requestHeaderBuffer">The serialized header bytes to send.</param>
+        /// <param name="requestHeaderBuffer">The serialized header bytes to send, or the default <see cref="ArraySegment{T}"/> when there are no header bytes.</param>
         /// <param name="disposeAction">A callback that releases <paramref name="requestHeaderBuffer"/> when the header is disposed.</param>
         public FabricTransportRequestHeader(ArraySegment<byte> requestHeaderBuffer, Action disposeAction)
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
 
     /// <summary>
     /// Represents the header of a <see cref="FabricTransportMessage"/>, carried either as serialized bytes to send for an
-    /// outgoing message or as a stream of received bytes for an incoming message.
+    /// outgoing message or as a stream of received bytes for a received message.
     /// </summary>
     internal class FabricTransportRequestHeader
     {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -30,7 +30,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class backed by a native message.
         /// </summary>
-        // Disposing this message releases the COM object of nativeInterfaceRoot.
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader,
             FabricTransportRequestBody requestBody,
             IFabricTransportMessage nativeInterfaceRoot)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -75,6 +75,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
     }
 
+    /// <summary>
+    /// Represents the header of a <see cref="FabricTransportMessage"/>, carried either as serialized bytes to send for an
+    /// outgoing message or as a stream of received bytes for an incoming message.
+    /// </summary>
     internal class FabricTransportRequestHeader
     {
         private readonly Stream recievedHeaderStream;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -132,6 +132,10 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
     }
 
+    /// <summary>
+    /// Represents the body of a <see cref="FabricTransportMessage"/>, carried either as serialized buffers to send for an
+    /// outgoing message or as a stream of received bytes for a received message.
+    /// </summary>
     internal class FabricTransportRequestBody
     {
         private readonly IEnumerable<ArraySegment<byte>> sendBuffers;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="Stream"/> containing the received body bytes.
+        /// Returns the <see cref="Stream"/> containing the received body bytes for a received body, or <see langword="null"/> for an outgoing body.
         /// </summary>
         public Stream GetRecievedStream()
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -17,6 +17,11 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly FabricTransportRequestBody requestBody;
         private readonly IFabricTransportMessage nativeInterfaceRoot;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class.
+        /// </summary>
+        /// <param name="requestHeader">The header of the message.</param>
+        /// <param name="requestBody">The body of the message.</param>
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader, FabricTransportRequestBody requestBody)
         {
             this.requestHeader = requestHeader;
@@ -24,6 +29,12 @@ namespace Microsoft.ServiceFabric.FabricTransport
             this.nativeInterfaceRoot = null;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class backed by a native message.
+        /// </summary>
+        /// <param name="requestHeader">The header of the message.</param>
+        /// <param name="requestBody">The body of the message.</param>
+        /// <param name="nativeInterfaceRoot">The native message whose COM object is released when this message is disposed.</param>
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader,
             FabricTransportRequestBody requestBody,
             IFabricTransportMessage nativeInterfaceRoot)
@@ -33,16 +44,25 @@ namespace Microsoft.ServiceFabric.FabricTransport
             this.nativeInterfaceRoot = nativeInterfaceRoot;
         }
 
+        /// <summary>
+        /// Returns the <see cref="FabricTransportRequestBody"/> of the message.
+        /// </summary>
         public FabricTransportRequestBody GetBody()
         {
             return this.requestBody;
         }
 
+        /// <summary>
+        /// Returns the <see cref="FabricTransportRequestHeader"/> of the message.
+        /// </summary>
         public FabricTransportRequestHeader GetHeader()
         {
             return this.requestHeader;
         }
 
+        /// <summary>
+        /// Releases the native message and the resources held by the message header and body.
+        /// </summary>
         public void Dispose()
         {
             if (this.nativeInterfaceRoot != null)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -90,7 +90,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportRequestHeader"/> class for a received header.
         /// </summary>
-        /// <param name="recievedHeaderStream">The stream containing the received header bytes.</param>
         public FabricTransportRequestHeader(Stream recievedHeaderStream)
         {
             this.recievedHeaderStream = recievedHeaderStream;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportRequestBody"/> class for an outgoing body.
         /// </summary>
-        /// <param name="sendBuffers">The serialized body buffers to send.</param>
+        /// <param name="sendBuffers">The serialized body buffers to send, or an empty collection when there are no body bytes.</param>
         /// <param name="disposeAction">A callback that releases <paramref name="sendBuffers"/> when the body is disposed.</param>
         public FabricTransportRequestBody(IEnumerable<ArraySegment<byte>> sendBuffers, Action disposeAction)
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly Action disposeAction;
 
         /// <summary>
-        /// Returns the serialized header bytes to send.
+        /// Returns the serialized header bytes to send for an outgoing header, or the default <see cref="ArraySegment{T}"/> for a received header.
         /// </summary>
         public ArraySegment<byte> GetSendBuffer()
         {
@@ -109,7 +109,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="Stream"/> containing the received header bytes.
+        /// Returns the <see cref="Stream"/> containing the received header bytes for a received header, or <see langword="null"/> for an outgoing header.
         /// </summary>
         public Stream GetRecievedStream()
         {

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -11,6 +11,10 @@ using static Microsoft.ServiceFabric.FabricTransport.NativeFabricTransport;
 
 namespace Microsoft.ServiceFabric.FabricTransport
 {
+    /// <summary>
+    /// Represents a Service Fabric transport message composed of an optional <see cref="FabricTransportRequestHeader"/> and
+    /// <see cref="FabricTransportRequestBody"/>, either built to send for an outgoing message or received and backed by a native message.
+    /// </summary>
     internal class FabricTransportMessage : IDisposable
     {
         private readonly FabricTransportRequestHeader requestHeader;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -68,27 +68,45 @@ namespace Microsoft.ServiceFabric.FabricTransport
         private readonly ArraySegment<byte> requestHeaderBuffer;
         private readonly Action disposeAction;
 
+        /// <summary>
+        /// Returns the serialized header bytes to send.
+        /// </summary>
         public ArraySegment<byte> GetSendBuffer()
         {
             return this.requestHeaderBuffer;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportRequestHeader"/> class for an outgoing header.
+        /// </summary>
+        /// <param name="requestHeaderBuffer">The serialized header bytes to send.</param>
+        /// <param name="disposeAction">The action that releases <paramref name="requestHeaderBuffer"/> when the header is disposed.</param>
         public FabricTransportRequestHeader(ArraySegment<byte> requestHeaderBuffer, Action disposeAction)
         {
             this.requestHeaderBuffer = requestHeaderBuffer;
             this.disposeAction = disposeAction;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportRequestHeader"/> class for a received header.
+        /// </summary>
+        /// <param name="recievedHeaderStream">The stream containing the received header bytes.</param>
         public FabricTransportRequestHeader(Stream recievedHeaderStream)
         {
             this.recievedHeaderStream = recievedHeaderStream;
         }
 
+        /// <summary>
+        /// Returns the stream containing the received header bytes.
+        /// </summary>
         public Stream GetRecievedStream()
         {
             return this.recievedHeaderStream;
         }
 
+        /// <summary>
+        /// Releases the resources held by the outgoing header buffer.
+        /// </summary>
         public void Dispose()
         {
             if (this.disposeAction != null)

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -20,8 +20,6 @@ namespace Microsoft.ServiceFabric.FabricTransport
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportMessage"/> class.
         /// </summary>
-        /// <param name="requestHeader">The header of the message.</param>
-        /// <param name="requestBody">The body of the message.</param>
         public FabricTransportMessage(FabricTransportRequestHeader requestHeader, FabricTransportRequestBody requestBody)
         {
             this.requestHeader = requestHeader;

--- a/src/FabricTransport/FabricTransportMessage.cs
+++ b/src/FabricTransport/FabricTransportMessage.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportRequestBody"/> of the message, or <see langword="null"/> if the message has no body.
+        /// Returns the <see cref="FabricTransportRequestBody"/>, or <see langword="null"/> if the message has no body.
         /// </summary>
         public FabricTransportRequestBody GetBody()
         {
@@ -49,7 +49,7 @@ namespace Microsoft.ServiceFabric.FabricTransport
         }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportRequestHeader"/> of the message, or <see langword="null"/> if the message has no header.
+        /// Returns the <see cref="FabricTransportRequestHeader"/>, or <see langword="null"/> if the message has no header.
         /// </summary>
         public FabricTransportRequestHeader GetHeader()
         {

--- a/src/FabricTransport/NativeFabricTransportMessageDisposer.cs
+++ b/src/FabricTransport/NativeFabricTransportMessageDisposer.cs
@@ -11,11 +11,21 @@ using static Microsoft.ServiceFabric.FabricTransport.NativeFabricTransport;
 
 namespace Microsoft.ServiceFabric.FabricTransport
 {
+    /// <summary>
+    /// Disposes native <see cref="IFabricTransportMessage"/> instances handed back across the COM boundary by the
+    /// Service Fabric runtime.
+    /// </summary>
     [GeneratedComClass]
     sealed partial class NativeFabricTransportMessageDisposer : IFabricTransportMessageDisposer
     {
         readonly int sizeOfPtr = Marshal.SizeOf(typeof(IntPtr));
 
+        /// <summary>
+        /// Disposes the <see cref="IFabricTransportMessage"/> instances in the native array referenced by
+        /// <paramref name="messages"/>.
+        /// </summary>
+        /// <param name="count">The number of message pointers in the array referenced by <paramref name="messages"/>.</param>
+        /// <param name="messages">A pointer to a contiguous array of <see cref="IFabricTransportMessage"/> COM interface pointers to dispose.</param>
         public void Dispose(UInt32 count, IntPtr messages)
         {
             for (var i = 0; i < count; i++)

--- a/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
+++ b/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
@@ -42,7 +42,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <summary>
         /// Sends <paramref name="requestBody"/> to the client without waiting for a reply.
         /// </summary>
-        /// <param name="requestBody">The message to send to the client.</param>
         public void OneWayMessage(FabricTransportMessage requestBody)
         {
             NativeFabricTransport.IFabricTransportMessage message = new NativeFabricTransportMessage(requestBody);

--- a/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
+++ b/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
@@ -8,6 +8,9 @@ using System.Fabric.Interop;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
+    /// <summary>
+    /// Sends messages back to a connected client over its callback channel on the service side.
+    /// </summary>
     internal class FabricTransportCallbackClient : IDisposable
     {
         private readonly TimeSpan defaultTimeout = TimeSpan.FromMinutes(2);
@@ -16,6 +19,10 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 
         bool disposed;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportCallbackClient"/> class wrapping the native callback channel of a connected client.
+        /// </summary>
+        /// <param name="nativeClientConnection">The native connection that identifies the client and carries messages back to it.</param>
         public FabricTransportCallbackClient(
             NativeFabricTransport.IFabricTransportClientConnection nativeClientConnection)
         {
@@ -24,11 +31,18 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
             this.clientId = NativeTypes.FromNativeString(clientId);
         }
 
+        /// <summary>
+        /// Returns the identifier of the client this callback channel sends messages to.
+        /// </summary>
         public string GetClientId()
         {
             return this.clientId;
         }
 
+        /// <summary>
+        /// Sends <paramref name="requestBody"/> to the client without waiting for a reply.
+        /// </summary>
+        /// <param name="requestBody">The message to send to the client.</param>
         public void OneWayMessage(FabricTransportMessage requestBody)
         {
             NativeFabricTransport.IFabricTransportMessage message = new NativeFabricTransportMessage(requestBody);
@@ -36,6 +50,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
                 "NativeFabricClientConnection.SendMessage");
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (!disposed)

--- a/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
+++ b/src/FabricTransport/Runtime/FabricTransportCallbackClient.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         bool disposed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FabricTransportCallbackClient"/> class wrapping the native callback channel of a connected client.
+        /// Initializes a new instance of the <see cref="FabricTransportCallbackClient"/> class.
         /// </summary>
         /// <param name="nativeClientConnection">The native connection that identifies the client and carries messages back to it.</param>
         public FabricTransportCallbackClient(

--- a/src/FabricTransport/Runtime/FabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListener.cs
@@ -12,10 +12,20 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
+    /// <summary>
+    /// Implements <see cref="IFabricTransportListener"/> over Service Fabric's native transport.
+    /// </summary>
     internal class FabricTransportListener : IFabricTransportListener
     {
         private NativeFabricTransport.IFabricTransportListener nativeListner;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportListener"/> class listening at <paramref name="listenerAddress"/>.
+        /// </summary>
+        /// <param name="transportSettings">The settings that configure the listener and its timeouts.</param>
+        /// <param name="listenerAddress">The address on which the listener accepts client connections.</param>
+        /// <param name="serviceImplementation">The handler that processes incoming request messages.</param>
+        /// <param name="remotingConnectionHandler">The handler that tracks client callback channels for pushing one-way messages back to clients.</param>
         public FabricTransportListener(
             FabricTransportSettings transportSettings,
             FabricTransportListenerAddress listenerAddress,
@@ -73,6 +83,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 
         #region API
 
+        /// <inheritdoc/>
         public Task<string> OpenAsync(CancellationToken cancellationToken)
         {
             return Utility.WrapNativeAsyncInvokeInMTA<string>(
@@ -82,6 +93,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
                 "FabricTransportListener.Open");
         }
 
+        /// <inheritdoc/>
         public Task CloseAsync(CancellationToken cancellationToken)
         {
             return Utility.WrapNativeAsyncInvokeInMTA(
@@ -91,6 +103,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
                 "FabricTransportListener.Close");
         }
 
+        /// <inheritdoc/>
         public void Abort()
         {
             if (this.nativeListner != null)
@@ -101,6 +114,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 
         #endregion
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (nativeListner != null)

--- a/src/FabricTransport/Runtime/FabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListener.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportListener"/> class.
         /// </summary>
-        /// <param name="transportSettings">The settings that configure the listener and its timeouts.</param>
+        /// <param name="transportSettings">The settings that configure the listener.</param>
         /// <param name="listenerAddress">The address on which the listener accepts client connections.</param>
         /// <param name="serviceImplementation">The handler that processes incoming request-response and one-way messages.</param>
         /// <param name="remotingConnectionHandler">The handler that tracks client callback channels for pushing one-way messages back to clients.</param>

--- a/src/FabricTransport/Runtime/FabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// </summary>
         /// <param name="transportSettings">The settings that configure the listener and its timeouts.</param>
         /// <param name="listenerAddress">The address on which the listener accepts client connections.</param>
-        /// <param name="serviceImplementation">The handler that processes incoming request messages.</param>
+        /// <param name="serviceImplementation">The handler that processes incoming request-response and one-way messages.</param>
         /// <param name="remotingConnectionHandler">The handler that tracks client callback channels for pushing one-way messages back to clients.</param>
         public FabricTransportListener(
             FabricTransportSettings transportSettings,

--- a/src/FabricTransport/Runtime/FabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         private NativeFabricTransport.IFabricTransportListener nativeListner;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FabricTransportListener"/> class listening at <paramref name="listenerAddress"/>.
+        /// Initializes a new instance of the <see cref="FabricTransportListener"/> class.
         /// </summary>
         /// <param name="transportSettings">The settings that configure the listener and its timeouts.</param>
         /// <param name="listenerAddress">The address on which the listener accepts client connections.</param>

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -11,7 +11,7 @@ using System.Globalization;
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
     /// <summary>
-    ///Settings that configures the  FabricTransport Listener.
+    /// Configures the FabricTransport listener.
     /// </summary>
     internal class FabricTransportListenerSettings : FabricTransportSettings
     {

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// Tries to load the <see cref="FabricTransportListenerSettings"/> from the section named <paramref name="sectionName"/> specified in the configuration package into <paramref name="listenerSettings"/> and returns
         /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
         /// </summary>
-        /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
+        /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="listenerSettings">When this method returns, contains the <see cref="FabricTransportListenerSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -145,10 +145,9 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         }
 
         /// <summary>
-        /// FabricTransportListenerSettings returns the default Settings .Loads the configuration file from default Config Package"Config" .
-        ///</summary>
-        /// <param name="sectionName">Name of the section within the configuration file. If not found section in configuration file, it will return the default Settings</param>
-        /// <returns></returns>
+        /// Returns the <see cref="FabricTransportListenerSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration package, or the default settings if the section cannot be loaded.
+        /// </summary>
+        /// <param name="sectionName">The name of the section within the configuration file.</param>
         internal new static FabricTransportListenerSettings GetDefault(string sectionName = DefaultSectionName)
         {
             FabricTransportListenerSettings listenerSettings = null;

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <summary>
         /// Returns the <see cref="FabricTransportListenerSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration package, or the default settings if the section cannot be loaded.
         /// </summary>
-        /// <param name="sectionName">The name of the section within the configuration file.</param>
+        /// <param name="sectionName">The name of the section within the configuration file. If not specified, the default <c>TransportSettings</c> section is used.</param>
         internal new static FabricTransportListenerSettings GetDefault(string sectionName = DefaultSectionName)
         {
             FabricTransportListenerSettings listenerSettings = null;

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -168,6 +168,11 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
             return listenerSettings;
         }
 
+        /// <summary>
+        /// Returns the <see cref="FabricTransportListenerAddress"/> for the listener of the service replica or instance described by <paramref name="serviceContext"/>.
+        /// </summary>
+        /// <param name="serviceContext">The context of the service replica or instance that hosts the listener.</param>
+        /// <returns>A <see cref="FabricTransportListenerAddress"/> unique to the replica or instance, combining its listen address with the port of the configured endpoint resource.</returns>
         internal FabricTransportListenerAddress GetListenerAddress(ServiceContext serviceContext)
         {
             var replicaId = serviceContext.ReplicaOrInstanceId;

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -181,7 +181,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// Returns the <see cref="FabricTransportListenerAddress"/> for the listener of the service replica or instance described by <paramref name="serviceContext"/>.
         /// </summary>
         /// <param name="serviceContext">The context of the service replica or instance that hosts the listener.</param>
-        /// <returns>A <see cref="FabricTransportListenerAddress"/> unique to the replica or instance, combining its listen address with the port of the configured endpoint resource.</returns>
+        /// <returns>An address unique to the replica or instance, combining its listen address with the port of the configured endpoint resource.</returns>
         internal FabricTransportListenerAddress GetListenerAddress(ServiceContext serviceContext)
         {
             var replicaId = serviceContext.ReplicaOrInstanceId;

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -38,7 +38,21 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// </summary>
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
-        /// <inheritdoc cref="FabricTransportSettings.LoadFrom(string, string, string)" path="/remarks"/>
+        /// <remarks>
+        /// The following are the parameter names that should be provided in the configuration file, to be recognizable by Service Fabric to load the transport settings.
+        /// <list type="number">
+        ///     <item><c>MaxQueueSize</c> - <see cref="FabricTransportSettings.MaxQueueSize"/> as a <see langword="long"/> value.</item>
+        ///     <item><c>MaxMessageSize</c> - <see cref="FabricTransportSettings.MaxMessageSize"/> value in bytes.</item>
+        ///     <item><c>MaxConcurrentCalls</c> - <see cref="FabricTransportSettings.MaxConcurrentCalls"/> as a <see langword="long"/> value.</item>
+        ///     <item><c>SecurityCredentialsType</c> - One of <c>None</c>, <c>X509</c>, or <c>Windows</c> that selects the <see cref="SecurityCredentials"/> type.
+        ///         <c>Windows</c> credentials additionally read <c>RemoteSecurityPrincipalName</c>. <c>X509</c> credentials additionally read <c>CertificateFindType</c>,
+        ///         <c>CertificateFindValue</c>, <c>CertificateProtectionLevel</c>, <c>CertificateStoreLocation</c>, <c>CertificateStoreName</c>, <c>CertificateRemoteCommonNames</c>,
+        ///         <c>CertificateRemoteThumbprints</c>, <c>CertificateIssuerThumbprints</c>, <c>CertificateFindValuebySecondary</c>, and <c>CertificateApplicationIssuerStore/</c> entries.</item>
+        ///     <item><c>OperationTimeoutInSeconds</c> - <see cref="FabricTransportSettings.OperationTimeout"/> value in seconds.</item>
+        ///     <item><c>KeepAliveTimeoutInSeconds</c> - <see cref="FabricTransportSettings.KeepAliveTimeout"/> value in seconds.</item>
+        ///     <item><c>ConnectTimeoutInMilliseconds</c> - <see cref="FabricTransportSettings.ConnectTimeout"/> value in milliseconds.</item>
+        /// </list>
+        /// </remarks>
         /// <exception cref="ArgumentException">
         /// The configuration package is not found, or the section named <paramref name="sectionName"/> is not found in the configuration.
         /// </exception>
@@ -84,7 +98,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <param name="listenerSettings">When this method returns, contains the <see cref="FabricTransportListenerSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
         /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
-        /// <inheritdoc cref="FabricTransportSettings.LoadFrom(string, string, string)" path="/remarks"/>
+        /// <inheritdoc path="/remarks" cref="LoadFrom(string, string)"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportListenerSettings listenerSettings,
             string configPackageName = null)
         {

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
     internal class FabricTransportListenerSettings : FabricTransportSettings
     {
         /// <summary>
-        /// The default name of the endpoint resource, used when <see cref="EndpointResourceName"/> is not specified.
+        /// Specifies the default name of the endpoint resource, used when <see cref="EndpointResourceName"/> is not specified.
         /// </summary>
         internal const string DefaultEndpointResourceName = "ServiceEndpoint";
         private static readonly string Tracetype = "FabricTransportListenerSettings";

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -15,6 +15,9 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
     /// </summary>
     internal class FabricTransportListenerSettings : FabricTransportSettings
     {
+        /// <summary>
+        /// The default name of the endpoint resource, used when <see cref="EndpointResourceName"/> is not specified.
+        /// </summary>
         internal const string DefaultEndpointResourceName = "ServiceEndpoint";
         private static readonly string Tracetype = "FabricTransportListenerSettings";
         private static readonly string DefaultPackageName = "Config";

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -100,7 +100,6 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <param name="sectionName">The name of the section within the configuration file.</param>
         /// <param name="listenerSettings">When this method returns, contains the <see cref="FabricTransportListenerSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
         /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
-        /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
         /// <inheritdoc path="/remarks" cref="LoadFrom(string, string)"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportListenerSettings listenerSettings,
             string configPackageName = null)

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         private static readonly string DefaultPackageName = "Config";
 
         /// <summary>
-        /// Creates a new instance of FabricTransportListenerSettings and initializes properties with default Values.
+        /// Initializes a new instance of the <see cref="FabricTransportListenerSettings"/> class.
         /// </summary>
         public FabricTransportListenerSettings()
         {
@@ -28,33 +28,20 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         }
 
         /// <summary>
-        /// EndpointResourceName is name of the endpoint resource specified in ServiceManifest .This is used to obtain the port number on which to
-        /// service will listen. 
+        /// Gets or sets the name of the endpoint resource specified in the service manifest, used to obtain the port on which the service listens.
         /// </summary>
-        /// <value>
-        /// EndpointResourceName is  name of the  endpoint resource defined in the service manifest.
-        /// </value>
-        /// <remarks>
-        /// Default value of EndpointResourceName  is "ServiceEndpoint" </remarks>
+        /// <value>The default is <c>ServiceEndpoint</c>.</value>
         public string EndpointResourceName { get; set; }
 
         /// <summary>
-        /// Loads the FabricTransport settings from a section specified in the service settings configuration file - settings.xml 
+        /// Returns the <see cref="FabricTransportListenerSettings"/> loaded from the section named <paramref name="sectionName"/> specified in the configuration package.
         /// </summary>
-        /// <param name="sectionName">Name of the section within the configuration file. if not found , it throws ArgumentException.</param>
-        /// <param name="configPackageName"> Name of the configuration package. if not found Settings.xml in the configuration package path, it throws ArgumentException. 
-        /// If not specified, default name is "Config"</param>
-        /// <returns>FabricTransportListenerSettings</returns>
-        /// <remarks>
-        /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
-        ///     
-        ///     1. MaxQueueSize - <see cref="FabricTransportSettings.MaxQueueSize"/>value in long.
-        ///     2. MaxMessageSize - <see cref="FabricTransportSettings.MaxMessageSize"/>value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="FabricTransportSettings.MaxConcurrentCalls"/>value in long.
-        ///     4. SecurityCredentials - <see cref="FabricTransportSettings.SecurityCredentials"/> value.
-        ///     5. OperationTimeoutInSeconds - <see cref="FabricTransportSettings.OperationTimeout"/> value in seconds.
-        ///     6. KeepAliveTimeoutInSeconds - <see cref="FabricTransportSettings.KeepAliveTimeout"/> value in seconds.
-        /// </remarks>
+        /// <param name="sectionName">The name of the section within the configuration file.</param>
+        /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
+        /// <inheritdoc cref="FabricTransportSettings.LoadFrom(string, string, string)" path="/remarks"/>
+        /// <exception cref="ArgumentException">
+        /// The configuration package is not found, or the section named <paramref name="sectionName"/> is not found in the configuration.
+        /// </exception>
         public static FabricTransportListenerSettings LoadFrom(string sectionName, string configPackageName = null)
         {
             var settings = new FabricTransportListenerSettings();
@@ -90,24 +77,14 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 
 
         /// <summary>
-        /// Try to load the FabricTransport settings from a section specified in the service settings configuration file - settings.xml 
+        /// Tries to load the <see cref="FabricTransportListenerSettings"/> from the section named <paramref name="sectionName"/> specified in the configuration package into <paramref name="listenerSettings"/> and returns
+        /// <see langword="true"/> if it was successfully loaded; otherwise returns <see langword="false"/>.
         /// </summary>
-        /// <param name="sectionName">Name of the section within the configuration file. if not found , it return false</param>
-        /// <param name="configPackageName"> Name of the configuration package. if not found Settings.xml in the configuration package path, it return false. 
-        /// If not specified, default name is "Config"</param>
-        /// <param name="listenerSettings">When this method returns it sets the <see cref="FabricTransportListenerSettings"/> listenersettings if load from Config succeeded. If fails ,its sets listenerSettings to null/> </param>
-        /// <returns> <see cref="bool"/> specifies whether the settings get loaded successfully from Config.
-        /// It returns true when load from Config succeeded, else return false.</returns>
-        /// <remarks>
-        /// The following are the parameter names that should be provided in the configuration file,to be recognizable by service fabric to load the transport settings.
-        ///     
-        ///     1. MaxQueueSize - <see cref="FabricTransportSettings.MaxQueueSize"/>value in long.
-        ///     2. MaxMessageSize - <see cref="FabricTransportSettings.MaxMessageSize"/>value in bytes.
-        ///     3. MaxConcurrentCalls - <see cref="FabricTransportSettings.MaxConcurrentCalls"/>value in long.
-        ///     4. SecurityCredentials - <see cref="FabricTransportSettings.SecurityCredentials"/> value.
-        ///     5. OperationTimeoutInSeconds - <see cref="FabricTransportSettings.OperationTimeout"/> value in seconds.
-        ///     6. KeepAliveTimeoutInSeconds - <see cref="FabricTransportSettings.KeepAliveTimeout"/> value in seconds.
-        /// </remarks>
+        /// <param name="sectionName">The name of the section within the configuration file. Returns <see langword="false"/> if the section is not found.</param>
+        /// <param name="listenerSettings">When this method returns, contains the <see cref="FabricTransportListenerSettings"/> loaded from configuration if the load succeeded, or <see langword="null"/> if it failed. This parameter is treated as uninitialized.</param>
+        /// <param name="configPackageName">The name of the configuration package. If not specified, the default name <c>Config</c> is used.</param>
+        /// <returns><see langword="true"/> if the settings were loaded successfully from configuration; otherwise, <see langword="false"/>.</returns>
+        /// <inheritdoc cref="FabricTransportSettings.LoadFrom(string, string, string)" path="/remarks"/>
         public static bool TryLoadFrom(string sectionName, out FabricTransportListenerSettings listenerSettings,
             string configPackageName = null)
         {

--- a/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
+++ b/src/FabricTransport/Runtime/FabricTransportListenerSettings.cs
@@ -57,7 +57,14 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// </list>
         /// </remarks>
         /// <exception cref="ArgumentException">
-        /// The configuration package is not found, or the section named <paramref name="sectionName"/> is not found in the configuration.
+        /// The configuration package is not found, the section named <paramref name="sectionName"/> is not found in the configuration, or
+        /// a configuration value cannot be parsed into its target enumeration type.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// A numeric configuration value is not in a format recognized by its target type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// A numeric configuration value is outside the range of its target type.
         /// </exception>
         public static FabricTransportListenerSettings LoadFrom(string sectionName, string configPackageName = null)
         {

--- a/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
+++ b/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
@@ -20,6 +20,8 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricTransportRequestContext"/> class.
         /// </summary>
+        /// <param name="clientId">The identifier of the client that sent the request.</param>
+        /// <param name="getCallBack">A factory invoked with <paramref name="clientId"/> to resolve the client's <see cref="FabricTransportCallbackClient"/>.</param>
         public FabricTransportRequestContext(string clientId, Func<string, FabricTransportCallbackClient> getCallBack)
         {
             this.clientId = clientId;

--- a/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
+++ b/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
@@ -7,23 +7,36 @@ using System;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
+    /// <summary>
+    /// Captures the per-request context on the service side, exposing the requesting client's identity and its
+    /// callback channel.
+    /// </summary>
     internal class FabricTransportRequestContext
     {
         private readonly string clientId;
         private readonly Func<string, FabricTransportCallbackClient> callback;
         private FabricTransportCallbackClient callbackClient;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FabricTransportRequestContext"/> class.
+        /// </summary>
         public FabricTransportRequestContext(string clientId, Func<string, FabricTransportCallbackClient> getCallBack)
         {
             this.clientId = clientId;
             this.callback = getCallBack;
         }
 
+        /// <summary>
+        /// Gets the identifier of the client that sent the request.
+        /// </summary>
         public string ClientId
         {
             get { return this.clientId; }
         }
 
+        /// <summary>
+        /// Returns the <see cref="FabricTransportCallbackClient"/> used to send messages back to the client that sent the request.
+        /// </summary>
         public FabricTransportCallbackClient GetCallbackClient()
 
         {

--- a/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
+++ b/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
@@ -8,8 +8,8 @@ using System;
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
     /// <summary>
-    /// Captures the per-request context on the service side, exposing the requesting client's identity and its
-    /// callback channel.
+    /// Represents the per-request, service-side context that exposes the requesting client's identity and its callback
+    /// channel.
     /// </summary>
     internal class FabricTransportRequestContext
     {

--- a/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
+++ b/src/FabricTransport/Runtime/FabricTransportRequestContext.cs
@@ -37,7 +37,8 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         }
 
         /// <summary>
-        /// Returns the <see cref="FabricTransportCallbackClient"/> used to send messages back to the client that sent the request.
+        /// Returns the <see cref="FabricTransportCallbackClient"/> used to send messages back to the client that sent the request,
+        /// or <see langword="null"/> if no callback channel is registered for the client.
         /// </summary>
         public FabricTransportCallbackClient GetCallbackClient()
 

--- a/src/FabricTransport/Runtime/IFabricTransportConnectionHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportConnectionHandler.cs
@@ -8,12 +8,27 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
+    /// <summary>
+    /// Tracks the per-client callback channels that let a service push one-way messages back to its connected clients.
+    /// </summary>
     internal interface IFabricTransportConnectionHandler
     {
+        /// <summary>
+        /// Asynchronously registers the <paramref name="fabricTransportServiceRemotingCallback"/> channel for a newly
+        /// connected client so the service can later push one-way messages back to it.
+        /// </summary>
         Task ConnectAsync(FabricTransportCallbackClient fabricTransportServiceRemotingCallback, TimeSpan timeout);
 
+        /// <summary>
+        /// Asynchronously removes and disposes the callback channel registered for the client identified by
+        /// <paramref name="clientId"/>.
+        /// </summary>
         Task DisconnectAsync(string clientId, TimeSpan timeout);
 
+        /// <summary>
+        /// Returns the <see cref="FabricTransportCallbackClient"/> registered for the client identified by
+        /// <paramref name="clientId"/>, or <see langword="null"/> if no such client is connected.
+        /// </summary>
         FabricTransportCallbackClient GetCallBack(string clientId);
     }
 }

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         Task CloseAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Aborts the listener immediately, releasing its resources without gracefully closing open connections.
+        /// Aborts the listener immediately without gracefully closing open connections.
         /// </summary>
         void Abort();
     }

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         Task CloseAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Aborts the listener immediately without gracefully closing open connections.
+        /// Aborts the listener immediately without gracefully closing open connections, unlike <see cref="CloseAsync"/>.
         /// </summary>
         void Abort();
     }

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
     /// <summary>
-    /// Defines the transport listener that accepts incoming remoting connections from clients and routes their messages
+    /// Defines a transport listener that accepts incoming remoting connections from clients and routes their messages
     /// to an <see cref="IFabricTransportMessageHandler"/>.
     /// </summary>
     interface IFabricTransportListener : IDisposable

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -22,7 +22,8 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
         Task<string> OpenAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Asynchronously closes the listener, stopping it from accepting new connections.
+        /// Asynchronously closes the listener, stopping it from accepting new connections and gracefully closing open
+        /// connections.
         /// </summary>
         Task CloseAsync(CancellationToken cancellationToken);
 

--- a/src/FabricTransport/Runtime/IFabricTransportListener.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportListener.cs
@@ -9,12 +9,26 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
+    /// <summary>
+    /// Defines the transport listener that accepts incoming remoting connections from clients and routes their messages
+    /// to an <see cref="IFabricTransportMessageHandler"/>.
+    /// </summary>
     interface IFabricTransportListener : IDisposable
     {
+        /// <summary>
+        /// Asynchronously opens the listener to start accepting client connections and returns the address on which it
+        /// listens for requests.
+        /// </summary>
         Task<string> OpenAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Asynchronously closes the listener, stopping it from accepting new connections.
+        /// </summary>
         Task CloseAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Aborts the listener immediately, releasing its resources without gracefully closing open connections.
+        /// </summary>
         void Abort();
     }
 }

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -14,9 +14,17 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
     /// </summary>
     interface IFabricTransportMessageHandler : IDisposable
     {
+        /// <summary>
+        /// Asynchronously processes the request in <paramref name="fabricTransportMessage"/> received on the connection
+        /// described by <paramref name="requestContext"/> and returns the reply to send back to the client.
+        /// </summary>
         Task<FabricTransportMessage> RequestResponseAsync(FabricTransportRequestContext requestContext,
             FabricTransportMessage fabricTransportMessage);
 
+        /// <summary>
+        /// Processes the one-way message in <paramref name="requesTransportMessage"/> received on the connection
+        /// described by <paramref name="requestContext"/>. No reply is sent back to the client.
+        /// </summary>
         void HandleOneWay(FabricTransportRequestContext requestContext, FabricTransportMessage requesTransportMessage);
     }
 }

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
             FabricTransportMessage fabricTransportMessage);
 
         /// <summary>
-        /// Processes the one-way message in <paramref name="requesTransportMessage"/> received on the connection
+        /// Processes the received one-way message on the connection
         /// described by <paramref name="requestContext"/>. No reply is sent back to the client.
         /// </summary>
         void HandleOneWay(FabricTransportRequestContext requestContext, FabricTransportMessage requesTransportMessage);

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -14,15 +14,15 @@ namespace Microsoft.ServiceFabric.FabricTransport.Runtime
     interface IFabricTransportMessageHandler : IDisposable
     {
         /// <summary>
-        /// Asynchronously processes the request in <paramref name="fabricTransportMessage"/> received on the connection
-        /// described by <paramref name="requestContext"/> and returns the reply to send back to the client.
+        /// Asynchronously processes the request in <paramref name="fabricTransportMessage"/> received from the client
+        /// identified by <paramref name="requestContext"/> and returns the reply to send back to the client.
         /// </summary>
         Task<FabricTransportMessage> RequestResponseAsync(FabricTransportRequestContext requestContext,
             FabricTransportMessage fabricTransportMessage);
 
         /// <summary>
-        /// Processes the received one-way message on the connection
-        /// described by <paramref name="requestContext"/>. No reply is sent back to the client.
+        /// Processes the received one-way message in the context described by <paramref name="requestContext"/>.
+        /// No reply is sent back to the client.
         /// </summary>
         void HandleOneWay(FabricTransportRequestContext requestContext, FabricTransportMessage requesTransportMessage);
     }

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
     /// <summary>
-    /// Processes messages received from the native fabric transport and produces the replies to send back.
+    /// Processes messages received from the native fabric transport.
     /// </summary>
     interface IFabricTransportMessageHandler : IDisposable
     {

--- a/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
+++ b/src/FabricTransport/Runtime/IFabricTransportMessageHandler.cs
@@ -9,8 +9,7 @@ using System.Threading.Tasks;
 namespace Microsoft.ServiceFabric.FabricTransport.Runtime
 {
     /// <summary>
-    /// Defines the interface that must be implemented by the ServiceRemotingListener to receive messages from the
-    /// remoting transport.
+    /// Processes messages received from the native fabric transport and produces the replies to send back.
     /// </summary>
     interface IFabricTransportMessageHandler : IDisposable
     {


### PR DESCRIPTION
Add XML documentation comments to the `Microsoft.ServiceFabric.FabricTransport` library, which was previously undocumented or carried stale, typo-laden comments. This assembly contains only internal types and only used by the `Microsoft.ServiceFabric.Services.Remoting`, so only the types used by Remoting were documented.

Changes:
- Add missing docs.
- Rewrite `FabricTransportSettings` and `FabricTransportListenerSettings` docs into the repo house style (`Gets or sets…`, `<value>The default is…</value>`, structured `<list>` remarks, and `<inheritdoc … path="/remarks"/>` to avoid duplication), and correct the configuration-key documentation to match the actual settings parsed from config.
- Add clarifying remarks where behavior is non-obvious (e.g. the COM pointer-array layout in the native message disposer, `null`-return contracts on body/header accessors).