### PR TITLE
Add InternalsVisibleTo for FabricDCA in Microsoft.ServiceFabric.Diagnostics

### DIFF
--- a/src/Diagnostics/AssemblyInfo.cs
+++ b/src/Diagnostics/AssemblyInfo.cs
@@ -83,3 +83,7 @@ using static Microsoft.ServiceFabric.Constants.AssemblyInfo;
 [assembly: InternalsVisibleTo("FabricInfrastructureManualControl" + TestKey)]
 [assembly: InternalsVisibleTo("FabricIS.parallel.Test" + PublicKey)]
 [assembly: InternalsVisibleTo("FabricIS.parallel.Test" + TestKey)]
+
+// Making internals visible for DCA using Metrics
+[assembly: InternalsVisibleTo("FabricDCA" + PublicKey)]
+[assembly: InternalsVisibleTo("FabricDCA" + TestKey)]


### PR DESCRIPTION
Adds InternalsVisibleTo for FabricDCA (prod + test keys) to the Microsoft.ServiceFabric.Diagnostics assembly (src/Diagnostics/AssemblyInfo.cs), granting FabricDCA access to the internal metrics API. Mirrors the existing entries for FabricBRS, Microsoft.ServiceFabric.Data.Impl, and FabricIS.parallel.