### PR TITLE
[Application Recycle] HTTP code generation for ResetApplication

### DIFF
--- a/src/Client.Http/Client.Http/Generated/ApplicationClient.cs
+++ b/src/Client.Http/Client.Http/Generated/ApplicationClient.cs
@@ -104,6 +104,47 @@ namespace Microsoft.ServiceFabric.Client.Http
         }
 
         /// <inheritdoc />
+        public Task ResetApplicationAsync(
+            string applicationId,
+            ResetApplicationDescription resetApplicationDescription,
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            applicationId.ThrowIfNull(nameof(applicationId));
+            resetApplicationDescription.ThrowIfNull(nameof(resetApplicationDescription));
+            serverTimeout?.ThrowIfOutOfInclusiveRange("serverTimeout", 1, 4294967295);
+            var requestId = Guid.NewGuid().ToString();
+            var url = "Applications/{applicationId}/$/Reset";
+            url = url.Replace("{applicationId}", applicationId);
+            var queryParams = new List<string>();
+            
+            // Append to queryParams if not null.
+            serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
+            queryParams.Add("api-version=12.0");
+            url += "?" + string.Join("&", queryParams);
+            
+            string content;
+            using (var sw = new StringWriter())
+            {
+                ResetApplicationDescriptionConverter.Serialize(new JsonTextWriter(sw), resetApplicationDescription);
+                content = sw.ToString();
+            }
+
+            HttpRequestMessage RequestFunc()
+            {
+                var request = new HttpRequestMessage()
+                {
+                    Method = HttpMethod.Post,
+                    Content = new StringContent(content, Encoding.UTF8),
+                };
+                request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                return request;
+            }
+
+            return this.httpClient.SendAsync(RequestFunc, url, requestId, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public Task<ApplicationLoadInfo> GetApplicationLoadInfoAsync(
             string applicationId,
             long? serverTimeout = 60,

--- a/src/Client.Http/Client.Http/Generated/Serialization/ApplicationDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/ApplicationDescriptionConverter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var parameters = default(IReadOnlyDictionary<string, string>);
             var applicationCapacity = default(ApplicationCapacityDescription);
             var managedApplicationIdentity = default(ManagedApplicationIdentityDescription);
+            var options = default(int?);
 
             do
             {
@@ -67,6 +68,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     managedApplicationIdentity = ManagedApplicationIdentityDescriptionConverter.Deserialize(reader);
                 }
+                else if (string.Compare("Options", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    options = reader.ReadValueAsInt();
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -80,7 +85,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 typeVersion: typeVersion,
                 parameters: parameters,
                 applicationCapacity: applicationCapacity,
-                managedApplicationIdentity: managedApplicationIdentity);
+                managedApplicationIdentity: managedApplicationIdentity,
+                options: options);
         }
 
         /// <summary>
@@ -108,6 +114,11 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             if (obj.ManagedApplicationIdentity != null)
             {
                 writer.WriteProperty(obj.ManagedApplicationIdentity, "ManagedApplicationIdentity", ManagedApplicationIdentityDescriptionConverter.Serialize);
+            }
+
+            if (obj.Options != null)
+            {
+                writer.WriteProperty(obj.Options, "Options", JsonWriterExtensions.WriteIntValue);
             }
 
             writer.WriteEndObject();

--- a/src/Client.Http/Client.Http/Generated/Serialization/ApplicationResetModeConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/ApplicationResetModeConverter.cs
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="ApplicationResetMode" />.
+    /// </summary>
+    internal class ApplicationResetModeConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static ApplicationResetMode? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(ApplicationResetMode);
+
+            if (string.Compare(value, "Graceful", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = ApplicationResetMode.Graceful;
+            }
+            else if (string.Compare(value, "Immediate", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = ApplicationResetMode.Immediate;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, ApplicationResetMode? value)
+        {
+            switch (value)
+            {
+                case ApplicationResetMode.Graceful:
+                    writer.WriteStringValue("Graceful");
+                    break;
+                case ApplicationResetMode.Immediate:
+                    writer.WriteStringValue("Immediate");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type ApplicationResetMode");
+            }
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/ResetApplicationDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/ResetApplicationDescriptionConverter.cs
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="ResetApplicationDescription" />.
+    /// </summary>
+    internal class ResetApplicationDescriptionConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static ResetApplicationDescription Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static ResetApplicationDescription GetFromJsonProperties(JsonReader reader)
+        {
+            var resetMode = default(ApplicationResetMode?);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("ResetMode", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    resetMode = ApplicationResetModeConverter.Deserialize(reader);
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new ResetApplicationDescription(
+                resetMode: resetMode);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, ResetApplicationDescription obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            writer.WriteProperty(obj.ResetMode, "ResetMode", ApplicationResetModeConverter.Serialize);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client/Generated/IApplicationClient.cs
+++ b/src/Client.Http/Client/Generated/IApplicationClient.cs
@@ -78,6 +78,46 @@ namespace Microsoft.ServiceFabric.Client
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Resets a Service Fabric application.
+        /// </summary>
+        /// <remarks>
+        /// Resets a Service Fabric application. An application must have been created with the resettable capability enabled
+        /// (for example, via New-ServiceFabricApplication -Options Resettable) before it can be reset. Resetting an
+        /// application recreates the replicas of each of its services with a clean, isolated working directory per reset
+        /// cycle, without deleting the application itself. Applications that were not created as resettable cannot be reset.
+        /// 
+        /// By default Service Fabric closes the existing replicas through the normal graceful shutdown sequence before
+        /// recreating them. If a replica is having issues closing gracefully, the reset operation may take a long time or get
+        /// stuck. Use the Immediate reset mode to skip the graceful close sequence.
+        /// 
+        /// Only one reset can be in progress for an application at a time. While a reset is in progress the application
+        /// reports the Resetting status and further reset requests fail with FABRIC_E_APPLICATION_RESET_IN_PROGRESS.
+        /// </remarks>
+        /// <param name ="applicationId">The identity of the application. This is typically the full name of the application
+        /// without the 'fabric:' URI scheme.
+        /// Starting from version 6.0, hierarchical names are delimited with the "~" character.
+        /// For example, if the application name is "fabric:/myapp/app1", the application identity would be "myapp~app1" in
+        /// 6.0+ and "myapp/app1" in previous versions.
+        /// </param>
+        /// <param name ="resetApplicationDescription">Parameters for resetting an existing application instance.</param>
+        /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.</param>
+        /// <param name ="cancellationToken">Cancels the client-side operation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation.
+        /// </returns>
+        /// <exception cref="InvalidCredentialsException">Thrown when invalid credentials are used while making request to cluster.</exception>
+        /// <exception cref="ServiceFabricRequestException">Thrown when request to Service Fabric cluster failed due to an underlying issue such as network connectivity, DNS failure or timeout.</exception>
+        /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
+        Task ResetApplicationAsync(
+            string applicationId,
+            ResetApplicationDescription resetApplicationDescription,
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Gets load information about a Service Fabric application.
         /// </summary>
         /// <remarks>

--- a/src/Client.Http/Common/Generated/ApplicationDescription.cs
+++ b/src/Client.Http/Common/Generated/ApplicationDescription.cs
@@ -29,13 +29,20 @@ namespace Microsoft.ServiceFabric.Common
         /// application
         /// </param>
         /// <param name="managedApplicationIdentity">Managed application identity description.</param>
+        /// <param name="options">Specifies optional capabilities requested for the application. This is a bitwise combination
+        /// of the following flags.
+        /// - None (0): No optional capabilities are requested. This is the default.
+        /// - Resettable (1): The application opts in to the Reset-ServiceFabricApplication operation. Each application
+        /// instance is given an isolated working directory per reset cycle.
+        /// </param>
         public ApplicationDescription(
             ApplicationName name,
             string typeName,
             string typeVersion,
             IReadOnlyDictionary<string, string> parameters = default(IReadOnlyDictionary<string, string>),
             ApplicationCapacityDescription applicationCapacity = default(ApplicationCapacityDescription),
-            ManagedApplicationIdentityDescription managedApplicationIdentity = default(ManagedApplicationIdentityDescription))
+            ManagedApplicationIdentityDescription managedApplicationIdentity = default(ManagedApplicationIdentityDescription),
+            int? options = default(int?))
         {
             name.ThrowIfNull(nameof(name));
             typeName.ThrowIfNull(nameof(typeName));
@@ -46,6 +53,7 @@ namespace Microsoft.ServiceFabric.Common
             this.Parameters = parameters;
             this.ApplicationCapacity = applicationCapacity;
             this.ManagedApplicationIdentity = managedApplicationIdentity;
+            this.Options = options;
         }
 
         /// <summary>
@@ -83,5 +91,14 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets managed application identity description.
         /// </summary>
         public ManagedApplicationIdentityDescription ManagedApplicationIdentity { get; }
+
+        /// <summary>
+        /// Gets specifies optional capabilities requested for the application. This is a bitwise combination of the following
+        /// flags.
+        /// - None (0): No optional capabilities are requested. This is the default.
+        /// - Resettable (1): The application opts in to the Reset-ServiceFabricApplication operation. Each application
+        /// instance is given an isolated working directory per reset cycle.
+        /// </summary>
+        public int? Options { get; }
     }
 }

--- a/src/Client.Http/Common/Generated/ApplicationResetMode.cs
+++ b/src/Client.Http/Common/Generated/ApplicationResetMode.cs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for ApplicationResetMode.
+    /// </summary>
+    public enum ApplicationResetMode
+    {
+        /// <summary>
+        /// Closes the existing replicas through the normal graceful shutdown sequence before recreating them. This is the
+        /// default behavior.
+        /// </summary>
+        Graceful,
+
+        /// <summary>
+        /// Recreates the replicas immediately, without waiting for the graceful shutdown sequence. Use this when a replica is
+        /// unable to close gracefully.
+        /// </summary>
+        Immediate,
+    }
+}

--- a/src/Client.Http/Common/Generated/ResetApplicationDescription.cs
+++ b/src/Client.Http/Common/Generated/ResetApplicationDescription.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes the parameters for resetting a Service Fabric application.
+    /// </summary>
+    public partial class ResetApplicationDescription
+    {
+        /// <summary>
+        /// Initializes a new instance of the ResetApplicationDescription class.
+        /// </summary>
+        /// <param name="resetMode">Specifies how the application replicas are reset. The default value is 'Graceful'. Possible
+        /// values include: 'Graceful', 'Immediate'</param>
+        public ResetApplicationDescription(
+            ApplicationResetMode? resetMode = Common.ApplicationResetMode.Graceful)
+        {
+            this.ResetMode = resetMode;
+        }
+
+        /// <summary>
+        /// Gets specifies how the application replicas are reset. The default value is 'Graceful'. Possible values include:
+        /// 'Graceful', 'Immediate'
+        /// </summary>
+        public ApplicationResetMode? ResetMode { get; }
+    }
+}

--- a/src/Powershell.Http/Generated/NewApplicationCmdlet.cs
+++ b/src/Powershell.Http/Generated/NewApplicationCmdlet.cs
@@ -77,11 +77,21 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public IEnumerable<ManagedApplicationIdentity> ManagedIdentities { get; set; }
 
         /// <summary>
+        /// Gets or sets Options. Specifies optional capabilities requested for the application. This is a bitwise combination
+        /// of the following flags.
+        /// - None (0): No optional capabilities are requested. This is the default.
+        /// - Resettable (1): The application opts in to the Reset-ServiceFabricApplication operation. Each application
+        /// instance is given an isolated working directory per reset cycle.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 9)]
+        public int? Options { get; set; }
+
+        /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 9)]
+        [Parameter(Mandatory = false, Position = 10)]
         public long? ServerTimeout { get; set; }
 
         /// <inheritdoc/>
@@ -102,7 +112,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
             typeVersion: this.TypeVersion,
             parameters: this.Parameters?.ToDictionary<string, string>(),
             applicationCapacity: applicationCapacityDescription,
-            managedApplicationIdentity: managedApplicationIdentityDescription);
+            managedApplicationIdentity: managedApplicationIdentityDescription,
+            options: this.Options);
 
             this.ServiceFabricClient.Applications.CreateApplicationAsync(
                 applicationDescription: applicationDescription,

--- a/src/Powershell.Http/Generated/ResetApplicationCmdlet.cs
+++ b/src/Powershell.Http/Generated/ResetApplicationCmdlet.cs
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Powershell.Http
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Management.Automation;
+    using Microsoft.ServiceFabric.Common;
+
+    /// <summary>
+    /// Resets a Service Fabric application.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Reset, "SFApplication")]
+    public partial class ResetApplicationCmdlet : CommonCmdletBase
+    {
+        /// <summary>
+        /// Gets or sets ApplicationId. The identity of the application. This is typically the full name of the application
+        /// without the 'fabric:' URI scheme.
+        /// Starting from version 6.0, hierarchical names are delimited with the "~" character.
+        /// For example, if the application name is "fabric:/myapp/app1", the application identity would be "myapp~app1" in
+        /// 6.0+ and "myapp/app1" in previous versions.
+        /// </summary>
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]
+        public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets ResetMode. Specifies how the application replicas are reset. The default value is 'Graceful'. Possible
+        /// values include: 'Graceful', 'Immediate'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 1)]
+        public ApplicationResetMode? ResetMode { get; set; } = Common.ApplicationResetMode.Graceful;
+
+        /// <summary>
+        /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 2)]
+        public long? ServerTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the force flag. If provided, then the destructive action will be performed without asking for
+        /// confirmation prompt.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 3)]
+        public SwitchParameter Force { get; set; } // Hand-coded: the generator only emits Force for its own list of destructive verbs
+
+        /// <inheritdoc/>
+        protected override void ProcessRecordInternal()
+        {
+            var resetApplicationDescription = new ResetApplicationDescription(
+            resetMode: this.ResetMode);
+
+            // Hand-coded to keep the confirmation prompt for this destructive operation
+            if (((this.Force != null) && this.Force) || this.ShouldContinue(string.Empty, string.Empty))
+            {
+                this.ServiceFabricClient.Applications.ResetApplicationAsync(
+                    applicationId: this.ApplicationId,
+                    resetApplicationDescription: resetApplicationDescription,
+                    serverTimeout: this.ServerTimeout,
+                    cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
+
+                Console.WriteLine("Success!");
+            }
+        }
+    }
+}

--- a/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -4602,6 +4602,21 @@
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="9">
+                <maml:name>Options</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies optional capabilities requested for the application. This is a bitwise combination of the following flags.
+                    - None (0): No optional capabilities are requested. This is the default.
+                    - Resettable (1): The application opts in to the Reset-ServiceFabricApplication operation. Each application instance is given an isolated working directory per reset cycle.
+                    
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">int?</command:parameterValue>
+                <dev:type>
+                    <maml:name>int?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="10">
                 <maml:name>ServerTimeout</maml:name>
                 <maml:Description>
                     <maml:para>
@@ -4655,6 +4670,67 @@
             <command:parameterValue required="false">bool?</command:parameterValue>
                 <dev:type>
                     <maml:name>bool?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="2">
+                <maml:name>ServerTimeout</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            </command:parameters>
+    </command:command>
+    <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+            <command:details>
+                <command:name>Reset-SFApplication</command:name>
+                <command:verb>Reset</command:verb>
+                <command:noun>Application</command:noun>
+                <maml:description>
+                    <maml:para>Resets a Service Fabric application.</maml:para>
+                </maml:description>
+            </command:details>
+            <command:syntax>
+            </command:syntax>
+            <maml:description>
+                <maml:para>Resets a Service Fabric application. An application must have been created with the resettable capability enabled (for example, via New-ServiceFabricApplication -Options Resettable) before it can be reset. Resetting an application recreates the replicas of each of its services with a clean, isolated working directory per reset cycle, without deleting the application itself. Applications that were not created as resettable cannot be reset.
+                
+                By default Service Fabric closes the existing replicas through the normal graceful shutdown sequence before recreating them. If a replica is having issues closing gracefully, the reset operation may take a long time or get stuck. Use the Immediate reset mode to skip the graceful close sequence.
+                
+                Only one reset can be in progress for an application at a time. While a reset is in progress the application reports the Resetting status and further reset requests fail with FABRIC_E_APPLICATION_RESET_IN_PROGRESS.
+                </maml:para>
+            </maml:description>
+            <command:parameters>
+            <command:parameter required="true" pipelineInput="True(ByPropertyName)" position="0">
+                <maml:name>ApplicationId</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The identity of the application. This is typically the full name of the application without the 'fabric:' URI scheme.
+                    Starting from version 6.0, hierarchical names are delimited with the "~" character.
+                    For example, if the application name is "fabric:/myapp/app1", the application identity would be "myapp~app1" in 6.0+ and "myapp/app1" in previous versions.
+                    
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="true">string</command:parameterValue>
+                <dev:type>
+                    <maml:name>string</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="1">
+                <maml:name>ResetMode</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    Specifies how the application replicas are reset. The default value is 'Graceful'. Possible values include: 'Graceful', 'Immediate'
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">ApplicationResetMode?</command:parameterValue>
+                <dev:type>
+                    <maml:name>ApplicationResetMode?</maml:name>
                 </dev:type>
             </command:parameter>
             <command:parameter required="false" position="2">


### PR DESCRIPTION
- **Summary**
  - Regenerates the Service Fabric HTTP client and generated HTTP PowerShell surface for the new Application Reset (Recycle) operation.
  - This picks up the Swagger change that adds the `POST /Applications/{applicationId}/$/Reset` REST operation, modeled with a `ResetApplicationDescription` request body.

- **Changes**
  - Added `ResetApplicationAsync` to the generated application client (`IApplicationClient` / `ApplicationClient`), taking a `ResetApplicationDescription` body.
  - Added the `ResetApplicationDescription` model and its JSON converter.
  - Added the `ApplicationResetMode` enum (`Graceful`, `Immediate`) and its JSON converter.
  - Added the generated `Reset-SFApplication` HTTP PowerShell cmdlet and updated the generated HTTP PowerShell help XML.
  - Added `Options` to `ApplicationDescription` (and its converter) plus the `-Options` parameter on `New-SFApplication`, so an application can opt in to the `Resettable` capability that `Reset-SFApplication` requires.
  - Uses REST `api-version=12.0` (11.5 is frozen, 12.0 is the next REST version for this operation).

- **Notes**
  - Generated code, with one deliberate exception: the `Force` switch and `ShouldContinue` confirmation in `ResetApplicationCmdlet.cs` are hand-coded, since the generator only emits them for its built-in destructive verbs and `Reset` is not one of them. They must be re-applied after any regeneration and are marked with `// Hand-coded` comments.
  - Regenerating from the current Swagger also produces unrelated `ServiceTags` / notification-tags changes (Swagger PR 15737018). Those are excluded here and belong to that feature's own propagation.
  - The runtime behavior and Swagger source are handled in the corresponding Service Fabric runtime and Swagger PRs.
  - `ResetMode` defaults to `Graceful` when omitted.

- **SF and Swagger**
  - WindowsFabric: https://msazure.visualstudio.com/One/_git/WindowsFabric/pullrequest/15792663
  - Swagger: https://msazure.visualstudio.com/One/_git/SF-Swagger/pullrequest/16280303