### PR TITLE
Make EventSource tests verify Event.Message

### DIFF
--- a/src/Actors/ActorEventSource.cs
+++ b/src/Actors/ActorEventSource.cs
@@ -23,15 +23,15 @@ namespace Microsoft.ServiceFabric.Actors
         private const int CustomActorServiceUsageEventId = 6;
         private const int ActorReminderRegistrationEventId = 7;
 
-        private const string ActorStateProviderUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
+        internal const string ActorStateProviderUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
             "runtimePlatform = {2}, partitionId = {3}, replicaId = {4}, serviceName = {5}, " +
             "serviceTypeName = {6}, applicationName = {7}, applicationTypeName = {8}, " +
             "stateProviderName = {9}";
 
-        private const string CustomActorServiceUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
+        internal const string CustomActorServiceUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
             "runtimePlatform = {2}, actorType = {3}, actorServiceType = {4}";
 
-        private const string ActorReminderRegistrationEventTraceFormat = "{0} : clusterOsType = {1}, " +
+        internal const string ActorReminderRegistrationEventTraceFormat = "{0} : clusterOsType = {1}, " +
             "runtimePlatform = {2}, partitionId = {3}, replicaId = {4}, serviceName = {5}, " +
             "serviceTypeName = {6}, applicationName = {7}, applicationTypeName = {8}, " +
             "ownerActorId = {9}, reminderPeriod = {10}, reminderName = {11}";

--- a/src/Services/ServiceEventSource.cs
+++ b/src/Services/ServiceEventSource.cs
@@ -23,17 +23,17 @@ namespace Microsoft.ServiceFabric.Services
         private const int CommunicationListenerUsageEventId = 6;
         private const int ServiceRemotingUsageEventId = 7;
 
-        private const string ServiceLifecycleEventTraceFormat = "{0} : clusterOsType = {1}, " +
+        internal const string ServiceLifecycleEventTraceFormat = "{0} : clusterOsType = {1}, " +
             "runtimePlatform = {2}, partitionId = {3}, replicaOrInstanceId = {4}, " +
             "serviceName = {5}, serviceTypeName = {6}, applicationName = {7}, " +
             "applicationTypeName = {8}, lifecycleEvent = {9}, serviceKind = {10}";
 
-        private const string CommunicationListenerUsageEventTraceFormat = "{0} : " +
+        internal const string CommunicationListenerUsageEventTraceFormat = "{0} : " +
             "clusterOsType = {1}, runtimePlatform = {2}, partitionId = {3}, replicaId = {4}, " +
             "serviceName = {5}, serviceTypeName = {6}, applicationName = {7}, " +
             "applicationTypeName = {8}, communicationListenerType = {9}";
 
-        private const string ServiceRemotingUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
+        internal const string ServiceRemotingUsageEventTraceFormat = "{0} : clusterOsType = {1}, " +
             "runtimePlatform = {2}, partitionId = {3}, replicaId = {4}, serviceName = {5}, " +
             "serviceTypeName = {6}, applicationName = {7}, applicationTypeName = {8}, " +
             "isSecure = {9}, remotingVersion = {10}, communicationListenerType = {11}";

--- a/test/Actors/ActorEventSourceTest.cs
+++ b/test/Actors/ActorEventSourceTest.cs
@@ -82,6 +82,7 @@ namespace Microsoft.ServiceFabric.Actors
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorEventSource.Keywords.Default);
             Assert.Equal("ActorStateProviderUsageEvent", test.Event.EventName);
+            Assert.Equal(ActorEventSource.ActorStateProviderUsageEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);
@@ -111,6 +112,7 @@ namespace Microsoft.ServiceFabric.Actors
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorEventSource.Keywords.Default);
             Assert.Equal("CustomActorServiceUsageEvent", test.Event.EventName);
+            Assert.Equal(ActorEventSource.CustomActorServiceUsageEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);
@@ -142,6 +144,7 @@ namespace Microsoft.ServiceFabric.Actors
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorEventSource.Keywords.Default);
             Assert.Equal("ActorReminderRegistrationEvent", test.Event.EventName);
+            Assert.Equal(ActorEventSource.ActorReminderRegistrationEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);

--- a/test/Actors/Diagnostics/ActorFrameworkEventSourceTest.cs
+++ b/test/Actors/Diagnostics/ActorFrameworkEventSourceTest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ActorActivated", test.Event.EventName);
+            Assert.Equal(SR.event_ActorActivated, test.Event.Message);
             test.EventPayload(0, "actorType", actorType);
             test.EventPayload(1, "actorId", actorId.ToString());
             test.EventPayload(2, "actorIdKind", (int)actorId.Kind);
@@ -65,6 +66,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ActorDeactivated", test.Event.EventName);
+            Assert.Equal(SR.event_ActorDeactivated, test.Event.Message);
             test.EventPayload(0, "actorType", actorType);
             test.EventPayload(1, "actorId", actorId.ToString());
             test.EventPayload(2, "actorIdKind", (int)actorId.Kind);
@@ -89,6 +91,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Verbose, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.MetricActorMethodCallsWaitingForLock);
             Assert.Equal("ActorMethodCallsWaitingForLock", test.Event.EventName);
+            Assert.Equal(SR.event_ActorMethodCallsWaitingForLock, test.Event.Message);
             test.EventPayload(0, "countOfWaitingMethodCalls", countOfWaitingMethodCalls);
             test.EventPayload(1, "actorType", actorType);
             test.EventPayload(2, "actorId", actorId.ToString());
@@ -114,6 +117,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Verbose, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.ActorMethod);
             Assert.Equal("ActorMethodStart", test.Event.EventName);
+            Assert.Equal(SR.event_ActorMethodStart, test.Event.Message);
             test.EventPayload(0, "methodName", methodName);
             test.EventPayload(1, "methodSignature", methodSignature);
             test.EventPayload(2, "actorType", actorType);
@@ -140,6 +144,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Verbose, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.ActorMethod);
             Assert.Equal("ActorMethodStop", test.Event.EventName);
+            Assert.Equal(SR.event_ActorMethodStop, test.Event.Message);
             test.EventPayload(0, "methodExecutionTimeTicks", executionTime.Ticks);
             test.EventPayload(1, "methodName", methodName);
             test.EventPayload(2, "methodSignature", methodSignature);
@@ -167,6 +172,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Warning, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default | ActorFrameworkKeywords.ActorMethod);
             Assert.Equal("ActorMethodThrewException", test.Event.EventName);
+            Assert.Equal(SR.event_ActorMethodThrewException, test.Event.Message);
             test.EventPayload(0, "exception", exception);
             test.EventPayload(1, "methodExecutionTimeTicks", executionTime.Ticks);
             test.EventPayload(2, "methodName", methodName);
@@ -195,6 +201,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Verbose, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.ActorState);
             Assert.Equal("ActorSaveStateStart", test.Event.EventName);
+            Assert.Equal(SR.event_ActorSaveStateStart, test.Event.Message);
             test.EventPayload(0, "actorType", actorType);
             test.EventPayload(1, "actorId", actorId.ToString());
             test.EventPayload(2, "actorIdKind", (int)actorId.Kind);
@@ -219,6 +226,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Verbose, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.ActorState);
             Assert.Equal("ActorSaveStateStop", test.Event.EventName);
+            Assert.Equal(SR.event_ActorSaveStateStop, test.Event.Message);
             test.EventPayload(0, "saveStateExecutionTimeTicks", executionTime.Ticks);
             test.EventPayload(1, "actorType", actorType);
             test.EventPayload(2, "actorId", actorId.ToString());
@@ -244,6 +252,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ReplicaChangeRoleFromPrimary", test.Event.EventName);
+            Assert.Equal(SR.event_ReplicaChangeRoleFromPrimary, test.Event.Message);
             test.EventPayload(0, "replicaId", service.ReplicaOrInstanceId);
             test.EventPayload(1, "partitionId", service.PartitionId);
             test.EventPayload(2, "serviceName", service.ServiceName);
@@ -265,6 +274,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ReplicaChangeRoleToPrimary", test.Event.EventName);
+            Assert.Equal(SR.event_ReplicaChangeRoleToPrimary, test.Event.Message);
             test.EventPayload(0, "replicaId", service.ReplicaOrInstanceId);
             test.EventPayload(1, "partitionId", service.PartitionId);
             test.EventPayload(2, "serviceName", service.ServiceName);
@@ -286,6 +296,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ServiceInstanceClose", test.Event.EventName);
+            Assert.Null(test.Event.Message); // TODO: Event definition bug, but event is unused.
             test.EventPayload(0, "instanceId", service.ReplicaOrInstanceId);
             test.EventPayload(1, "partitionId", service.PartitionId);
             test.EventPayload(2, "serviceName", service.ServiceName);
@@ -307,6 +318,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ActorFrameworkKeywords.Default);
             Assert.Equal("ServiceInstanceOpen", test.Event.EventName);
+            Assert.Null(test.Event.Message); // TODO: Event definition bug, but event is unused.
             test.EventPayload(0, "instanceId", service.ReplicaOrInstanceId);
             test.EventPayload(1, "partitionId", service.PartitionId);
             test.EventPayload(2, "serviceName", service.ServiceName);

--- a/test/Services/Runtime/ServiceFrameworkEventSourceTest.cs
+++ b/test/Services/Runtime/ServiceFrameworkEventSourceTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatefulRunAsyncInvocation", test.Event.EventName);
+            Assert.Equal(SR.event_StatefulRunAsyncInvocation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statefulService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statefulService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statefulService.ServiceTypeName);
@@ -60,6 +61,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatefulRunAsyncCancellation", test.Event.EventName);
+            Assert.Equal(SR.event_StatefulRunAsyncCancellation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statefulService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statefulService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statefulService.ServiceTypeName);
@@ -81,6 +83,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatefulRunAsyncCompletion", test.Event.EventName);
+            Assert.Equal(SR.event_StatefulRunAsyncCompletion, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statefulService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statefulService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statefulService.ServiceTypeName);
@@ -102,6 +105,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Warning, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatefulRunAsyncSlowCancellation", test.Event.EventName);
+            Assert.Equal(SR.event_StatefulRunAsyncSlowCancellation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statefulService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statefulService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statefulService.ServiceTypeName);
@@ -124,6 +128,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Error, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatefulRunAsyncFailure", test.Event.EventName);
+            Assert.Equal(SR.event_StatefulRunAsyncFailure, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statefulService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statefulService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statefulService.ServiceTypeName);
@@ -146,6 +151,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatelessRunAsyncInvocation", test.Event.EventName);
+            Assert.Equal(SR.event_StatelessRunAsyncInvocation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statelessService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statelessService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statelessService.ServiceTypeName);
@@ -166,6 +172,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatelessRunAsyncCancellation", test.Event.EventName);
+            Assert.Equal(SR.event_StatelessRunAsyncCancellation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statelessService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statelessService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statelessService.ServiceTypeName);
@@ -187,6 +194,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatelessRunAsyncCompletion", test.Event.EventName);
+            Assert.Equal(SR.event_StatelessRunAsyncCompletion, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statelessService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statelessService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statelessService.ServiceTypeName);
@@ -208,6 +216,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Warning, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatelessRunAsyncSlowCancellation", test.Event.EventName);
+            Assert.Equal(SR.event_StatelessRunAsyncSlowCancellation, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statelessService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statelessService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statelessService.ServiceTypeName);
@@ -230,6 +239,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             Assert.Equal(EventLevel.Error, test.Event.Level);
             test.EventKeywords(EventKeywords.None);
             Assert.Equal("StatelessRunAsyncFailure", test.Event.EventName);
+            Assert.Equal(SR.event_StatelessRunAsyncFailure, test.Event.Message);
             test.EventPayload(0, "applicationTypeName", statelessService.CodePackageActivationContext.ApplicationTypeName);
             test.EventPayload(1, "applicationName", statelessService.CodePackageActivationContext.ApplicationName);
             test.EventPayload(2, "serviceTypeName", statelessService.ServiceTypeName);

--- a/test/Services/ServiceEventSourceTest.cs
+++ b/test/Services/ServiceEventSourceTest.cs
@@ -83,6 +83,7 @@ namespace Microsoft.ServiceFabric.Services
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ServiceEventSource.Keywords.Default);
             Assert.Equal("ServiceLifecycleEvent", test.Event.EventName);
+            Assert.Equal(ServiceEventSource.ServiceLifecycleEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);
@@ -118,6 +119,7 @@ namespace Microsoft.ServiceFabric.Services
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ServiceEventSource.Keywords.Default);
             Assert.Equal("CommunicationListenerUsageEvent", test.Event.EventName);
+            Assert.Equal(ServiceEventSource.CommunicationListenerUsageEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);
@@ -154,6 +156,7 @@ namespace Microsoft.ServiceFabric.Services
             Assert.Equal(EventLevel.Informational, test.Event.Level);
             test.EventKeywords(ServiceEventSource.Keywords.Default);
             Assert.Equal("ServiceRemotingUsageEvent", test.Event.EventName);
+            Assert.Equal(ServiceEventSource.ServiceRemotingUsageEventTraceFormat, test.Event.Message);
             test.EventPayload(0, "type", type);
             test.EventPayload(1, "clusterOsType", clusterOsType);
             test.EventPayload(2, "runtimePlatform", runtimePlatform);

--- a/test/TestFramework/EventSourceTest.cs
+++ b/test/TestFramework/EventSourceTest.cs
@@ -168,6 +168,7 @@ namespace Microsoft.ServiceFabric
                 Assert.Equal(level, test.Event.Level);
                 Assert.Equal(AllSessions | Default, test.Event.Keywords);
                 Assert.Equal(act.Method.Name, test.Event.EventName);
+                Assert.Equal(ServiceFabricEventSource.TextEventFormat, test.Event.Message);
                 test.EventPayload(0, "id", id);
                 test.EventPayload(1, "type", type);
                 test.EventPayload(2, "message", message);


### PR DESCRIPTION
They were verifying only payload before. For `EventSource` classes using string resources, test the message using string resources. For regular `EventSource` classes, use their existing message constants. Change message constants from private to internal where needed.